### PR TITLE
Issue #125 - Docker configuration to make gedbrowser and geoserver talk

### DIFF
--- a/gedbrowser/src/main/docker/Dockerfile
+++ b/gedbrowser/src/main/docker/Dockerfile
@@ -4,5 +4,7 @@ ADD gedbrowser-1.1.0-SNAPSHOT.jar gedbrowser.jar
 EXPOSE 8080
 EXPOSE 8081
 ENV spring.data.mongodb.host=mongo
+ENV geoservice.host=geoservice
+ENV geoservice.port=8080
 RUN bash -c 'touch /gedbrowser.jar'
 ENTRYPOINT ["java", "-Djava.security.egd=file:/dev/./urandom","-jar","/gedbrowser.jar"]


### PR DESCRIPTION
Change the gedbrower Docker configuration to include the necessary port
information to connect to geoservice.