### PR TITLE
Resolves #199 - Scan reports want jxr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
   <reporting>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jxr-plugin</artifactId>
+        <version>2.5</version>
+      </plugin>
+      <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
         <version>3.0.4</version>


### PR DESCRIPTION
Warnings were being generated in the build because of missing
cross-references. This change fixes that.