### PR TITLE
Fixes #161 - Deprecate 2 argument insert in Root

### DIFF
--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractSource.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractSource.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public abstract class AbstractSource extends GedObject {
     /**
-     * @param parent parent object of this attribute
+     * Default constructor.
      */
-    public AbstractSource(final GedObject parent) {
-        super(parent);
+    public AbstractSource() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractSpecialObject.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractSpecialObject.java
@@ -5,6 +5,13 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public abstract class AbstractSpecialObject extends GedObject {
     /**
+     * Default constructor.
+     */
+    public AbstractSpecialObject() {
+        super();
+    }
+
+    /**
      * @param parent parent object of this attribute
      */
     public AbstractSpecialObject(final GedObject parent) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/FamC.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/FamC.java
@@ -5,30 +5,24 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class FamC extends AbstractLink {
     /**
-     * @param parent
-     *            parent object of this link
+     * Default constructor.
      */
-    public FamC(final GedObject parent) {
-        super(parent);
+    public FamC() {
+        super();
     }
 
     /**
-     * @param parent
-     *            parent object of this link
-     * @param string
-     *            long version of type string
+     * @param parent parent object of this link
+     * @param string long version of type string
      */
     public FamC(final GedObject parent, final String string) {
         super(parent, string);
     }
 
     /**
-     * @param parent
-     *            person that is a child in the referred family
-     * @param string
-     *            long version of type string
-     * @param xref
-     *            the reference to a family object
+     * @param parent person that is a child in the referred family
+     * @param string long version of type string
+     * @param xref the reference to a family object
      */
     public FamC(final GedObject parent, final String string,
             final ObjectId xref) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/FamS.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/FamS.java
@@ -7,10 +7,10 @@ import java.util.List;
  */
 public final class FamS extends AbstractLink implements FamilyLinkage {
     /**
-     * @param parent parent object of this link
+     * Default constructor.
      */
-    public FamS(final GedObject parent) {
-        super(parent);
+    public FamS() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Family.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Family.java
@@ -16,13 +16,6 @@ public final class Family extends GedObject implements FamilyLinkage {
 
     /**
      * @param parent parent object of this family
-     */
-    public Family(final GedObject parent) {
-        super(parent);
-    }
-
-    /**
-     * @param parent parent object of this family
      * @param xref cross reference to this family
      */
     public Family(final GedObject parent, final ObjectId xref) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
@@ -348,24 +348,36 @@ public class GedObject {
     }
 
     /**
-     * @return the filename associated with this data set.
+     * @return the filename associated with this data set
      */
     public final String getFilename() {
         return finder.getFilename(this);
     }
 
     /**
-     * @return the filename associated with this data set.
+     * @return the filename associated with this data set
      */
     public final String getDbName() {
         return finder.getDbName(this);
     }
 
     /**
-     * @param gob object to insert.
+     * @param gob object to insert
      */
     public final void insert(final GedObject gob) {
+        if (gob == null) {
+            return;
+        }
+        extraInsert(gob);
         finder.insert(this, gob);
+    }
+
+    /**
+     * @param gob object to insert
+     */
+    public void extraInsert(final GedObject gob) {
+        // The default implementation is empty. Some derived
+        // classes implement this.
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Head.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Head.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class Head extends AbstractSpecialObject {
     /**
-     * @param parent parent object of this object
+     * Default constructor.
      */
-    public Head(final GedObject parent) {
-        super(parent);
+    public Head() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Husband.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Husband.java
@@ -13,13 +13,6 @@ public final class Husband extends AbstractLink implements Spouse {
 
     /**
      * @param parent parent object of this husband
-     */
-    public Husband(final GedObject parent) {
-        super(parent);
-    }
-
-    /**
-     * @param parent parent object of this husband
      * @param string long version of type string
      */
     public Husband(final GedObject parent, final String string) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Multimedia.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Multimedia.java
@@ -8,20 +8,17 @@ public final class Multimedia extends AbstractAttribute {
     private String tail;
 
     /**
-     * @param parent
-     *            parent object of this attribute
+     * Default constructor.
      */
-    public Multimedia(final GedObject parent) {
-        super(parent);
+    public Multimedia() {
+        super();
         this.tail = "";
         this.setAppender(new MultimediaAppender(this));
     }
 
     /**
-     * @param parent
-     *            parent object of this attribute
-     * @param string
-     *            long version of type string
+     * @param parent parent object of this attribute
+     * @param string long version of type string
      */
     public Multimedia(final GedObject parent, final String string) {
         super(parent, string);

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Person.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Person.java
@@ -17,13 +17,6 @@ public final class Person extends GedObject implements Nameable, FamilyLinkage {
 
     /**
      * @param parent parent object of this person
-     */
-    public Person(final GedObject parent) {
-        super(parent);
-    }
-
-    /**
-     * @param parent parent object of this person
      * @param xref cross reference to this person
      */
     public Person(final GedObject parent, final ObjectId xref) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Place.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Place.java
@@ -6,10 +6,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
 public final class Place extends AbstractAttribute
         implements Comparable<Place> {
     /**
-     * @param parent parent object of this child
+     * Default constructor.
      */
-    public Place(final GedObject parent) {
-        super(parent);
+    public Place() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Root.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Root.java
@@ -27,67 +27,43 @@ public final class Root extends AbstractSpecialObject {
     private final transient Index surnameIndex;
 
     /**
-     * @param parent
-     *            parent object of this child
+     * Default constructor.
      */
-    public Root(final GedObject parent) {
-        super(parent);
-        surnameIndex = new Index(this);
-        setFinder(new RootFinder());
+    public Root() {
+        this(new RootFinder());
     }
 
     /**
-     * @param parent parent object of this child
      * @param string long version of type string
      * @param finder the engine for find objects in this data set
      */
-    public Root(final GedObject parent, final String string,
-            final FinderStrategy finder) {
-        super(parent, string);
-        surnameIndex = new Index(this);
-        setFinder(finder);
+    public Root(final String string, final FinderStrategy finder) {
+        this(finder);
+        setString(string);
     }
 
     /**
-     * @param parent parent object of this child
      * @param finder the engine for finding objects in the data set
      */
-    public Root(final GedObject parent, final FinderStrategy finder) {
-        super(parent);
+    public Root(final FinderStrategy finder) {
+        super();
         surnameIndex = new Index(this);
         setFinder(finder);
     }
 
     /**
-     * @param parent
-     *            parent object of this child
-     * @param string
-     *            long version of type string
+     * @param string long version of type string
      */
-    public Root(final GedObject parent, final String string) {
-        super(parent, string);
-        surnameIndex = new Index(this);
-        setFinder(new RootFinder());
+    public Root(final String string) {
+        this(string, new RootFinder());
     }
 
     /**
-     * @param str ID string of object to insert
      * @param gob object to insert
      */
-    public void insert(final String str, final GedObject gob) {
-        if (gob == null) {
-            // I don't think this should happen. We would only get
-            // here is the factory for a level 0 tag didn't return
-            // anything. Even then, I think that that insert would
-            // have been cut off by gob being NULL.
-            return;
-        }
-
-        if (str == null || str.isEmpty()) {
-            objects.put(gob.getString(), gob);
-        } else {
-            objects.put(str, gob);
-        }
+    @Override
+    public void extraInsert(final GedObject gob) {
+        objects.put(gob.getString(), gob);
         addAttribute(gob);
     }
 

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/RootFinder.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/RootFinder.java
@@ -36,7 +36,7 @@ public final class RootFinder implements FinderStrategy {
     @Override
     public void insert(final GedObject owner, final GedObject gob) {
         final Root root = (Root) owner;
-        root.insert(gob.getString(), gob);
+        root.extraInsert(gob);
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Source.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Source.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class Source extends AbstractSource {
     /**
-     * @param parent parent object of this source
+     * Default constructor.
      */
-    public Source(final GedObject parent) {
-        super(parent);
+    public Source() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/SourceLink.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/SourceLink.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class SourceLink extends AbstractLink {
     /**
-     * @param parent parent object of this link
+     * Default constructor.
      */
-    public SourceLink(final GedObject parent) {
-        super(parent);
+    public SourceLink() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Submittor.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Submittor.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class Submittor extends AbstractSource implements Nameable {
     /**
-     * @param parent parent object of this submittor
+     * Default constructor.
      */
-    public Submittor(final GedObject parent) {
-        super(parent);
+    public Submittor() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/SubmittorLink.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/SubmittorLink.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class SubmittorLink extends AbstractLink {
     /**
-     * @param parent parent object of this link
+     * Default constructor.
      */
-    public SubmittorLink(final GedObject parent) {
-        super(parent);
+    public SubmittorLink() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Trailer.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Trailer.java
@@ -5,10 +5,10 @@ package org.schoellerfamily.gedbrowser.datamodel;
  */
 public final class Trailer extends AbstractSpecialObject {
     /**
-     * @param parent parent object of this object
+     * Default constructor.
      */
-    public Trailer(final GedObject parent) {
-        super(parent);
+    public Trailer() {
+        super();
     }
 
     /**

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Wife.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Wife.java
@@ -13,13 +13,6 @@ public final class Wife extends AbstractLink implements Spouse {
 
     /**
      * @param parent parent object of this wife
-     */
-    public Wife(final GedObject parent) {
-        super(parent);
-    }
-
-    /**
-     * @param parent parent object of this wife
      * @param string long version of type string
      */
     public Wife(final GedObject parent, final String string) {

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
@@ -34,7 +34,7 @@ public final class GedObjectBuilder {
      * Constructor.
      */
     public GedObjectBuilder() {
-        this(new Root(null));
+        this(new Root());
     }
 
     /**
@@ -295,7 +295,7 @@ public final class GedObjectBuilder {
      */
     public Submittor createSubmittor(final String idString, final String name) {
         if (idString == null || name == null) {
-            return new Submittor(root);
+            return new Submittor(root, null);
         }
         final Submittor submittor = new Submittor(root, idString);
         submittor.insert(new Name(submittor, name));
@@ -312,7 +312,7 @@ public final class GedObjectBuilder {
      */
     public Submittor createSubmittor(final String idString) {
         if (idString == null) {
-            return new Submittor(root);
+            return new Submittor(root, null);
         }
         final Submittor submittor = new Submittor(root, idString);
         root.insert(submittor);
@@ -326,7 +326,7 @@ public final class GedObjectBuilder {
      */
     public Trailer createTrailer() {
         final Trailer trailer = new Trailer(root, "Trailer");
-        root.insert("Trailer", trailer);
+        root.insert(trailer);
         return trailer;
     }
 
@@ -337,7 +337,7 @@ public final class GedObjectBuilder {
      */
     public Head createHead() {
         final Head head = new Head(root, "Head");
-        root.insert("Head", head);
+        root.insert(head);
         return head;
     }
 
@@ -377,7 +377,7 @@ public final class GedObjectBuilder {
     public Multimedia addMultimediaToPerson(final Person person,
             final String string) {
         if (person == null || string == null) {
-            return new Multimedia(null);
+            return new Multimedia();
         }
         final Multimedia mm = new Multimedia(person, "Multimedia", string);
         person.insert(mm);
@@ -408,7 +408,7 @@ public final class GedObjectBuilder {
      */
     public Source createSource(final String string) {
         final Source source = new Source(root, new ObjectId(string));
-        root.insert(string, source);
+        root.insert(source);
         return source;
     }
 
@@ -420,7 +420,7 @@ public final class GedObjectBuilder {
     public SourceLink createSourceLink(final GedObject ged,
             final Source source) {
         if (ged == null || source == null) {
-            return new SourceLink(null);
+            return new SourceLink();
         }
         final SourceLink sourceLink = new SourceLink(ged, "Source",
                 new ObjectId(source.getString()));
@@ -436,7 +436,7 @@ public final class GedObjectBuilder {
     public SubmittorLink createSubmittorLink(final GedObject ged,
             final Submittor submittor) {
         if (ged == null || submittor == null) {
-            return new SubmittorLink(null);
+            return new SubmittorLink();
         }
         final SubmittorLink submittorLink = new SubmittorLink(ged, "Submittor",
                 new ObjectId(submittor.getString()));

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/ChildTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/ChildTest.java
@@ -212,7 +212,7 @@ public final class ChildTest {
     /** */
     @Test
     public void testChildNullString() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Child child = new Child(localRoot, null);
         assertEmpty(child);
     }
@@ -220,7 +220,7 @@ public final class ChildTest {
     /** */
     @Test
     public void testChildEmptyString() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Child child = new Child(localRoot, "");
         assertEmpty(child);
     }
@@ -239,7 +239,7 @@ public final class ChildTest {
     /** */
     @Test
     public void testChildEmptyTail() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Child child = new Child(localRoot, "I1", new ObjectId(""));
         assertPerson1(child, "I1");
     }
@@ -247,7 +247,7 @@ public final class ChildTest {
     /** */
     @Test
     public void testChildEmptyTailStrip() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Child child = new Child(localRoot, "I1", new ObjectId("@@"));
         assertPerson1(child, "I1");
     }
@@ -267,9 +267,9 @@ public final class ChildTest {
     /** */
     @Test
     public void testChildEmptyTailAfterInsert() {
-        final Root localRoot = new Root(null, "Root");
-        final Child child2 = new Child(localRoot, "I1", new ObjectId(""));
-        localRoot.insert("I1", child2);
+        final Root localRoot = new Root("Root");
+        final Child child2 = new Child(localRoot, "I1", new ObjectId("I1"));
+        localRoot.insert(child2);
         assertEquals("Mismatched child", child2, child2.find("I1"));
     }
 }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/DateTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/DateTest.java
@@ -13,7 +13,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Root;
 @SuppressWarnings({ "PMD.ExcessivePublicCount" })
 public final class DateTest {
     /** */
-    private final transient Root root = new Root(null, "Root");
+    private final transient Root root = new Root("Root");
 
     /** */
     @Test

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamCConstructorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamCConstructorTest.java
@@ -93,13 +93,6 @@ public final class FamCConstructorTest {
 
     /** */
     @Test
-    public void testOneArgumentConstructor() {
-        final FamC famc = new FamC(parent);
-        assertMatch(famc, expectedParent, "", "", expectedFromString);
-    }
-
-    /** */
-    @Test
     public void testTwoArgumentConstructor() {
         final FamC famc = new FamC(parent, string);
         assertMatch(famc, expectedParent, expectedString, "",

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamCTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamCTest.java
@@ -60,7 +60,7 @@ public final class FamCTest {
     /** */
     @Test
     public void testGetFatherNotSet() {
-        final FamC dummy = new FamC(null);
+        final FamC dummy = new FamC();
         assertFalse("Father should be unset", dummy.getFather().isSet());
     }
 
@@ -73,7 +73,7 @@ public final class FamCTest {
     /** */
     @Test
     public void testGetMotherNotSet() {
-        final FamC dummy = new FamC(null);
+        final FamC dummy = new FamC();
         assertFalse("Mother should be unset", dummy.getMother().isSet());
     }
 

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamSTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamSTest.java
@@ -114,15 +114,8 @@ public final class FamSTest {
     /** */
     @Test
     public void testFamSConstructNull() {
-        final FamS fams = new FamS(null);
+        final FamS fams = new FamS();
         assertMatch(fams, null, "", "", "", false, 0, false);
-    }
-
-    /** */
-    @Test
-    public void testFamSConstructPerson() {
-        final FamS fams = new FamS(person1);
-        assertMatch(fams, person1, "", "", "I1", false, 0, false);
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamilyTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/FamilyTest.java
@@ -118,13 +118,13 @@ public final class FamilyTest {
     /** */
     @Test
     public void testFamilyUsualSetup() {
-        final Root localRoot = new Root(null, ROOT_NAME);
+        final Root localRoot = new Root(ROOT_NAME);
         final Family localFamily1 = new Family(localRoot, new ObjectId("F1"));
-        localRoot.insert("F1", localFamily1);
+        localRoot.insert(localFamily1);
         final Person localPerson1 = new Person(localRoot, new ObjectId("I1"));
-        localRoot.insert("I1", localPerson1);
+        localRoot.insert(localPerson1);
         final Person localPerson2 = new Person(localRoot, new ObjectId("I2"));
-        localRoot.insert("I2", localPerson2);
+        localRoot.insert(localPerson2);
         final Husband localHusband = new Husband(localFamily1, "HUSB",
                 new ObjectId("@I1@"));
         localFamily1.insert(localHusband);
@@ -132,7 +132,7 @@ public final class FamilyTest {
                 new Wife(localFamily1, "WIFE", new ObjectId("@I2@"));
         localFamily1.insert(localWife);
         final Person localPerson3 = new Person(localRoot, new ObjectId("I3"));
-        localRoot.insert("I3", localPerson3);
+        localRoot.insert(localPerson3);
         final Child localChild = new Child(localFamily1, "CHIL",
                 new ObjectId("@I3@"));
         localFamily1.insert(localChild);
@@ -155,7 +155,7 @@ public final class FamilyTest {
                 new ObjectId("@S4@"));
         marriage.insert(sourceLink);
         final Source source = new Source(localRoot, new ObjectId("S4"));
-        localRoot.insert("S4", source);
+        localRoot.insert(source);
 
         final GedObject gob = localRoot.find("F1");
         assertMatchUnusual(localFamily1, gob, localChild, localHusband,
@@ -205,19 +205,10 @@ public final class FamilyTest {
 
     /** */
     @Test
-    public void testConstructorRoot() {
-        final Root localRoot = new Root(null, ROOT_NAME);
-        final Family family = new Family(localRoot);
-        localRoot.insert("F1", family);
-        assertMatch(localRoot, family, "", false, false, 0);
-    }
-
-    /** */
-    @Test
     public void testConstructorRootId() {
-        final Root localRoot = new Root(null, ROOT_NAME);
+        final Root localRoot = new Root(ROOT_NAME);
         final Family family = new Family(localRoot, new ObjectId("F1"));
-        localRoot.insert("F1", family);
+        localRoot.insert(family);
         assertMatch(localRoot, family, "F1", false, false, 0);
     }
 

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/GedObjectTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/GedObjectTest.java
@@ -66,24 +66,14 @@ public final class GedObjectTest {
     /** */
     @Before
     public void setUp() {
-        root = new Root(null, "Root");
+        root = new Root("Root");
         root.setDbName("DBNAME");
-    }
-
-    /** */
-    @Test
-    public void testGedObjectFind() {
-        gob = new GedObjectWrapper(root);
-        root.insert(GOB_TAG, gob);
-        assertEquals("Find should have matched",
-                gob, gob.find(GOB_TAG));
     }
 
     /** */
     @Test
     public void testGedObjectDefaultEmptyString() {
         gob = new GedObjectWrapper(root);
-        root.insert(GOB_TAG, gob);
         assertEquals("Expected empty string",
                 "", gob.toString());
     }
@@ -92,7 +82,7 @@ public final class GedObjectTest {
     @Test
     public void testGedObjectStringFind() {
         gob = new GedObjectWrapper(root, GOB_TAG);
-        root.insert(null, gob);
+        root.insert(gob);
         assertEquals("Find should have matched", gob, gob.find(GOB_TAG));
     }
 
@@ -100,7 +90,7 @@ public final class GedObjectTest {
     @Test
     public void testGedObjectGedObjectString() {
         gob = new GedObjectWrapper(root, GOB_TAG);
-        root.insert(null, gob);
+        root.insert(gob);
         assertEquals("String mismatch", GOB_TAG, gob.toString());
     }
 
@@ -169,8 +159,7 @@ public final class GedObjectTest {
     /** */
     @Test
     public void testInsertFamily() {
-        final Family family = new Family(root);
-        family.setString("F777");
+        final Family family = new Family(root, new ObjectId("F777"));
         root.insert(family);
         assertEquals("Should have found same family",
                 family, finder.find(family, "F777", Family.class));
@@ -414,16 +403,15 @@ public final class GedObjectTest {
     /** */
     @Test
     public void testFindUnaffectedBySetString() {
-        gob = new GedObjectWrapper(root);
-        gob.setString(GOB_TAG);
+        gob = new GedObjectWrapper(root, GOB_TAG);
         assertNull("Expected null result", gob.find(GOB_TAG));
     }
 
     /** */
     @Test
     public void testFindAfterInsert() {
-        gob = new GedObjectWrapper(root);
-        root.insert(GOB_TAG, gob);
+        gob = new GedObjectWrapper(root, GOB_TAG);
+        root.insert(gob);
         assertEquals("Object mismatch", gob, gob.find(GOB_TAG));
     }
 
@@ -432,7 +420,7 @@ public final class GedObjectTest {
     public void testFindPersonWithProperId() {
         gob = new GedObjectWrapper(root);
         final Person person = new Person(root, new ObjectId("I1"));
-        root.insert("I1", person);
+        root.insert(person);
         assertEquals("Person mismatch", person, gob.find("I1"));
     }
 
@@ -441,7 +429,7 @@ public final class GedObjectTest {
     public void testFindNullWithNullParent() {
         gob = new GedObjectWrapper(root);
         final Person person = new Person(root, new ObjectId("I1"));
-        root.insert("I1", person);
+        root.insert(person);
         gob = new GedObjectWrapper(null);
         assertNull("Expected null", gob.find(GOB_TAG));
     }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/HeadTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/HeadTest.java
@@ -83,24 +83,11 @@ public final class HeadTest {
 
     /** */
     @Test
-    public void testHeadGedObject() {
-        final Root root = new Root(null, "Root");
-
-        final Head head = new Head(root);
-        root.insert("Head", head);
-
-        final GedObject gob = root.find("Head");
-        assertTrue("Should have found head with empty string",
-                head.equals(gob) && head.getString().isEmpty());
-    }
-
-    /** */
-    @Test
     public void testHeadGedObjectString() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
 
         final Head head = new Head(root, "Head");
-        root.insert("Head", head);
+        root.insert(head);
 
         final GedObject gob = root.find("Head");
         assertTrue("Should have found head with head tag string",
@@ -110,10 +97,10 @@ public final class HeadTest {
     /** */
     @Test
     public void testHeadGedObjectStringEmptyString() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
 
         final Head head = new Head(root, "Head", "");
-        root.insert("Head", head);
+        root.insert(head);
 
         final GedObject gob = root.find("Head");
         assertTrue("Should have found the head with head tag string",
@@ -123,7 +110,7 @@ public final class HeadTest {
     /** */
     @Test
     public void testHeadGedObjectStringString() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         final Head head2 = new Head(root, "Head", "foo");
         assertEquals("Combined string mismatch",
                 "Head" + " foo", head2.getString());

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/HusbandTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/HusbandTest.java
@@ -102,20 +102,10 @@ public final class HusbandTest {
 
     /** */
     @Test
-    public void testHusbandGedObject() {
-        final Root localRoot = new Root(null, ROOT_TAG);
-        final Family family = new Family(localRoot, new ObjectId("F1"));
-        localRoot.insert("F1", family);
-        final Husband husband = new Husband(family);
-        assertMatch(husband, "", "", "F1", false);
-    }
-
-    /** */
-    @Test
     public void testHusbandGedObjectString() {
-        final Root localRoot = new Root(null, ROOT_TAG);
+        final Root localRoot = new Root(ROOT_TAG);
         final Family family = new Family(localRoot, new ObjectId("F1"));
-        localRoot.insert("F1", family);
+        localRoot.insert(family);
         final Husband husband = new Husband(family, HUSB_TAG);
         assertMatch(husband, HUSB_TAG, "", "F1", false);
     }
@@ -123,9 +113,9 @@ public final class HusbandTest {
     /** */
     @Test
     public void testHusbandGedObjectStringString() {
-        final Root localRoot = new Root(null, ROOT_TAG);
+        final Root localRoot = new Root(ROOT_TAG);
         final Family family = new Family(localRoot, new ObjectId("F1"));
-        localRoot.insert("F1", family);
+        localRoot.insert(family);
         final Husband husband =
                 new Husband(family, HUSB_TAG, new ObjectId("@I3@"));
         assertMatch(husband, HUSB_TAG, "I3", "F1", false);

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
@@ -61,7 +61,7 @@ public final class IndexTest {
     /** */
     @Before
     public void setUp() {
-        root = new Root(null);
+        root = new Root();
         final GedObjectBuilder builder = new GedObjectBuilder(root);
         builder.createPerson("I1", "Richard John/Schoeller/");
         builder.createPerson("I2", "Lisa Hope/Robinson/");

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/MultimediaConstructorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/MultimediaConstructorTest.java
@@ -100,8 +100,8 @@ public final class MultimediaConstructorTest {
     /** */
     @Test
     public void testOneArgumentConstructor() {
-        final Multimedia attribute = new Multimedia(parent);
-        assertMatch(attribute, expectedParent, "", "");
+        final Multimedia attribute = new Multimedia();
+        assertMatch(attribute, null, "", "");
     }
 
     /**

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/MultimediaTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/MultimediaTest.java
@@ -208,14 +208,14 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFilePathEmpty() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         assertEquals("File path mismatch", null, multimedia.getFilePath());
     }
 
     /** */
     @Test
     public void testGetFilePathGood() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -235,7 +235,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFileFormatGood() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -255,7 +255,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFileFormatEmpty() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -268,14 +268,14 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFileFormatPartiallyBuilt() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         assertEquals("File format mismatch", null, multimedia.getFileFormat());
     }
 
     /** */
     @Test
     public void testGetFileTitleGood1() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -295,7 +295,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFileTitleGood2() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -315,14 +315,14 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testGetFileTitleEmpty() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         assertEquals("File title mismatch", null, multimedia.getFileTitle());
     }
 
     /** */
     @Test
     public void testIsImageTrueJpg() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -341,7 +341,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testIsImageTrueGif() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -360,7 +360,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testIsImageTruePng() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -379,7 +379,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testIsImageTrueTif() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -398,7 +398,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testIsImageFalse() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         final Attribute note =
                 new Attribute(multimedia, "Note", "A note");
         multimedia.addAttribute(note);
@@ -417,7 +417,7 @@ public final class MultimediaTest {
     /** */
     @Test
     public void testIsImageEmpty() {
-        final Multimedia multimedia = new Multimedia(person1);
+        final Multimedia multimedia = new Multimedia();
         assertFalse("Expected is not image", multimedia.isImage());
     }
 }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/NameTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/NameTest.java
@@ -213,9 +213,9 @@ public final class NameTest {
     /** */
     @Test
     public void testNameGedObject() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Person localPerson = new Person(localRoot, new ObjectId("I1"));
-        localRoot.insert("I1", localPerson);
+        localRoot.insert(localPerson);
         final Name name = new Name(localPerson);
         localPerson.insert(name);
         assertMatch(localPerson, name, "", "", "?", "");
@@ -224,9 +224,9 @@ public final class NameTest {
     /** */
     @Test
     public void testNameGedObjectString() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Person localPerson = new Person(localRoot, new ObjectId("I1"));
-        localRoot.insert("I1", localPerson);
+        localRoot.insert(localPerson);
         final Name name = new Name(localPerson, "Karl/Schoeller/Jr.");
         localPerson.insert(name);
         assertMatch(localPerson, name, "Karl/Schoeller/Jr.", "Karl",

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/PersonTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/PersonTest.java
@@ -47,7 +47,7 @@ public final class PersonTest {
     /** */
     @Before
     public void setUp() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedObjectBuilder builder = new GedObjectBuilder(root);
         person1 = builder.createPerson("I1", "Richard John/Schoeller/");
         final Attribute attr =
@@ -345,56 +345,40 @@ public final class PersonTest {
     /** */
     @Test
     public void testPersonGedObjectMissingID() {
-        final Root localRoot = new Root(null, "Root");
-        final Person person = new Person(localRoot);
-        localRoot.insert("I1", person);
+        final Person person = new Person();
         assertTrue("Person string should be empty", person.getString()
                 .isEmpty());
     }
 
     /** */
     @Test
-    public void testPersonGedObjectMissingIDFindable() {
-        final Root localRoot = new Root(null, "Root");
-        final Person person = new Person(localRoot);
-        localRoot.insert("I1", person);
-        assertEquals("Expected to find person anyway",
-                person, localRoot.find("I1"));
-    }
-
-    /** */
-    @Test
     public void testPersonGedObjectMissingIDNoFather() {
-        final Root localRoot = new Root(null, "Root");
-        final Person person = new Person(localRoot);
-        localRoot.insert("I1", person);
+        final Person person = new Person();
         assertFalse("Expected no father", person.getFather().isSet());
     }
 
     /** */
     @Test
     public void testPersonGedObjectMissingIDNoMother() {
-        final Root localRoot = new Root(null, "Root");
-        final Person person = new Person(localRoot);
-        localRoot.insert("I1", person);
+        final Person person = new Person();
         assertFalse("Expected no mother", person.getMother().isSet());
     }
 
     /** */
     @Test
     public void testPersonGedObjectString() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Person person = new Person(localRoot, new ObjectId("I1"));
-        localRoot.insert("I1", person);
+        localRoot.insert(person);
         assertEquals("Expected ID to match", "I1", person.getString());
     }
 
     /** */
     @Test
     public void testPersonFindGedObjectString() {
-        final Root localRoot = new Root(null, "Root");
+        final Root localRoot = new Root("Root");
         final Person person = new Person(localRoot, new ObjectId("I1"));
-        localRoot.insert("I1", person);
+        localRoot.insert(person);
         assertEquals("Expected to find person by ID",
                 person, localRoot.find("I1"));
     }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/PlaceTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/PlaceTest.java
@@ -64,8 +64,8 @@ public final class PlaceTest {
     /** */
     @Test
     public void testOneArgumentConstructor() {
-        final Place place1 = new Place(parent);
-        assertMatch(place1, expectedParent, "");
+        final Place place1 = new Place();
+        assertMatch(place1, null, "");
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/RootConstructorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/RootConstructorTest.java
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
-import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
 
 /**
@@ -19,25 +18,17 @@ import org.schoellerfamily.gedbrowser.datamodel.Root;
 @RunWith(Parameterized.class)
 public final class RootConstructorTest {
     /** */
-    private final GedObject parent;
-    /** */
     private final String string;
-    /** */
-    private final GedObject expectedParent;
     /** */
     private final String expectedString;
 
     /**
-     * @param parent the input parent
      * @param string the input string
-     * @param expectedParent the expected result of getParent
      * @param expectedString the expected result of getString
      */
-    public RootConstructorTest(final GedObject parent, final String string,
-            final GedObject expectedParent, final String expectedString) {
-        this.parent = parent;
+    public RootConstructorTest(final String string,
+            final String expectedString) {
         this.string = string;
-        this.expectedParent = expectedParent;
         this.expectedString = expectedString;
     }
 
@@ -46,29 +37,26 @@ public final class RootConstructorTest {
      */
     @Parameters
     public static Collection<Object[]> params() {
-        final GedObject gob = new Person();
         return Arrays.asList(new Object[][] {
-            {null, null, null, ""},
-            {gob, null, gob, ""},
-            {null, "", null, ""},
-            {gob, "", gob, ""},
-            {null, "Root", null, "Root"},
-            {gob, "ROOT", gob, "ROOT"},
+            {null, ""},
+            {"", ""},
+            {"Root", "Root"},
+            {"ROOT", "ROOT"},
         });
     }
 
     /** */
     @Test
     public void testRootGedObject() {
-        final Root root = new Root(parent);
-        assertMatch(root, expectedParent, "");
+        final Root root = new Root();
+        assertMatch(root, null, "");
     }
 
     /** */
     @Test
     public void testTwoArgumentConstructor() {
-        final Root root = new Root(parent, string);
-        assertMatch(root, expectedParent, expectedString);
+        final Root root = new Root(string);
+        assertMatch(root, null, expectedString);
     }
 
     /**

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/RootTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/RootTest.java
@@ -39,7 +39,7 @@ public final class RootTest {
     /** */
     @Before
     public void setUp() {
-        root = new Root(null, "Root");
+        root = new Root("Root");
         final GedObjectBuilder builder = new GedObjectBuilder(root);
         person1 = builder.createPerson("I1", "Richard/Schoeller/");
         person2 = builder.createPerson("I2", "John/Schoeller/");
@@ -53,7 +53,7 @@ public final class RootTest {
     /** */
     @Test
     public void testOneArgInsertAndFind() {
-        final Root rt = new Root(null, "Root");
+        final Root rt = new Root("Root");
         final Person person = new Person(rt, new ObjectId("I2"));
         rt.insert(person);
         final Name name2 = new Name(person, "John/Schoeller/");
@@ -61,58 +61,6 @@ public final class RootTest {
         final Person personx = new Person(root, new ObjectId("I3"));
         personx.insert(new Name(personx, "Patricia/Hayes/"));
         assertEquals("Person mismatch", person, root.find("I2"));
-    }
-
-    /** */
-    @Test
-    public void testTwoArgInsertBlankAndFind() {
-        final Root rt = new Root(null, "Root");
-        final Person person = new Person(rt, new ObjectId("I2"));
-        rt.insert("", person);
-        final Name name2 = new Name(person, "John/Schoeller/");
-        person.insert(name2);
-        final Person personx = new Person(root, new ObjectId("I3"));
-        personx.insert(new Name(personx, "Patricia/Hayes/"));
-        assertEquals("Person mismatch", person, rt.find("I2"));
-    }
-
-    /** */
-    @Test
-    public void testTwoArgInsertNullAndFind() {
-        final Root rt = new Root(null, "Root");
-        final Person person = new Person(rt, new ObjectId("I2"));
-        rt.insert(null, person);
-        final Name name2 = new Name(person, "John/Schoeller/");
-        person.insert(name2);
-        final Person personx = new Person(root, new ObjectId("I3"));
-        personx.insert(new Name(personx, "Patricia/Hayes/"));
-        assertEquals("Person mismatch", person, rt.find("I2"));
-    }
-
-    /** */
-    @Test
-    public void testTwoArgInsertAndFind() {
-        final Root rt = new Root(null, "Root");
-        final Person person = new Person(rt, new ObjectId("I2"));
-        rt.insert("I4", person);
-        final Name name2 = new Name(person, "John/Schoeller/");
-        person.insert(name2);
-        final Person personx = new Person(root, new ObjectId("I3"));
-        personx.insert(new Name(personx, "Patricia/Hayes/"));
-        assertEquals("Person mismatch", person, rt.find("I4"));
-    }
-
-    /** */
-    @Test
-    public void testTwoArgInsertAndGetObjects() {
-        final Root rt = new Root(null, "Root");
-        final Person person = new Person(rt, new ObjectId("I2"));
-        rt.insert("I4", person);
-        final Name name2 = new Name(person, "John/Schoeller/");
-        person.insert(name2);
-        final Person personx = new Person(root, new ObjectId("I3"));
-        personx.insert(new Name(personx, "Patricia/Hayes/"));
-        assertEquals("Person mismatch", person, rt.getObjects().get("I4"));
     }
 
     /** */
@@ -143,9 +91,9 @@ public final class RootTest {
     @Test
     public void testGetObjects() {
         final Person person4 = new Person(root, new ObjectId("I4"));
-        root.insert(null, person4);
-        final Person person5 = new Person(root, new ObjectId("I4"));
-        root.insert("SQUIRT", person5);
+        root.insert(person4);
+        final Person person5 = new Person(root, new ObjectId("SQUIRT"));
+        root.insert(person5);
         final Map<String, GedObject> objects = root.getObjects();
         assertTrue("Content mismatch",
                 OBJECT_COUNT == objects.size()
@@ -160,10 +108,11 @@ public final class RootTest {
     /** */
     @Test
     public void testGetObjectsNull() {
-        root.insert("nullTest", null);
+        final Root localRoot = new Root();
+        localRoot.insert(null);
         final Map<String, GedObject> objects = root.getObjects();
         assertFalse("Null object should not be inserted",
-                objects.keySet().contains("nullTest"));
+                objects.isEmpty());
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SourceLinkTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SourceLinkTest.java
@@ -84,8 +84,8 @@ public final class SourceLinkTest {
     /** */
     @Test
     public void testOneArgumentConstructor() {
-        final SourceLink sourceLink = new SourceLink(parent);
-        assertMatch(sourceLink, parent, "", expectedFromString, "");
+        final SourceLink sourceLink = new SourceLink();
+        assertMatch(sourceLink, null, "", "", "");
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SourceTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SourceTest.java
@@ -16,18 +16,17 @@ public final class SourceTest {
     /** */
     @Test
     public void testSourceGedObjectCompare() {
-        final Root root = new Root(null, "Root");
-        final Source source = new Source(root);
-        root.insert("S1", source);
+        final Root root = new Root("Root");
+        final Source source = new Source(root, new ObjectId("S1"));
+        root.insert(source);
         final GedObject gob = root.find("S1");
         assertEquals("Found wrong source", source, gob);
     }
+
     /** */
     @Test
     public void testSourceGedObjectGetString() {
-        final Root root = new Root(null, "Root");
-        final Source source = new Source(root);
-        root.insert("S1", source);
+        final Source source = new Source();
         assertTrue("Source string should be empty", source.getString()
                 .isEmpty());
     }
@@ -35,9 +34,9 @@ public final class SourceTest {
     /** */
     @Test
     public void testSourceGedObjectStringCompare() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         final Source source = new Source(root, new ObjectId("S1"));
-        root.insert("S1", source);
+        root.insert(source);
         final GedObject gob = root.find("S1");
         assertEquals("Found wrong source", source, gob);
     }
@@ -45,9 +44,9 @@ public final class SourceTest {
     /** */
     @Test
     public void testSourceGedObjectStringGetString() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         final Source source = new Source(root, new ObjectId("S1"));
-        root.insert("S1", source);
+        root.insert(source);
         assertEquals("Expected source 1", "S1", source.getString());
     }
 }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SubmittorLinkTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SubmittorLinkTest.java
@@ -84,8 +84,8 @@ public final class SubmittorLinkTest {
     /** */
     @Test
     public void testOneArgumentConstructor() {
-        final SubmittorLink sourceLink = new SubmittorLink(parent);
-        assertMatch(sourceLink, parent, "", expectedFromString, "");
+        final SubmittorLink sourceLink = new SubmittorLink();
+        assertMatch(sourceLink, null, "", "", "");
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SubmittorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/SubmittorTest.java
@@ -18,7 +18,7 @@ public final class SubmittorTest {
     /** */
     private static final String TEST_STRING = "string";
     /** */
-    private final transient Root root = new Root(null, "Root");
+    private final transient Root root = new Root("Root");
 
     /** */
     @Test
@@ -80,33 +80,22 @@ public final class SubmittorTest {
     /** */
     @Test
     public void testSubmittorNullParent() {
-        Submittor submittor;
-        submittor = new Submittor(null);
+        final Submittor submittor = new Submittor();
         assertNull("Expected null parent", submittor.getParent());
     }
 
     /** */
     @Test
     public void testSubmittorNullString() {
-        Submittor submittor;
-        submittor = new Submittor(null);
+        final Submittor submittor = new Submittor();
         assertEquals("Expected empty string", "", submittor.getString());
     }
 
     /** */
     @Test
     public void testSubmittorRootParent() {
-        Submittor submittor;
-        submittor = new Submittor(root);
+        final Submittor submittor = new Submittor(root, "SUB1");
         assertEquals("Mismatched parent", root, submittor.getParent());
-    }
-
-    /** */
-    @Test
-    public void testSubmittorGedObject() {
-        Submittor submittor;
-        submittor = new Submittor(root);
-        assertEquals("Expected empty string", "", submittor.getString());
     }
 
     /** */

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/TrailerTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/TrailerTest.java
@@ -1,7 +1,6 @@
 package org.schoellerfamily.gedbrowser.datamodel.test;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 import org.junit.Test;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
@@ -14,40 +13,25 @@ import org.schoellerfamily.gedbrowser.datamodel.util.GedObjectBuilder;
  */
 public final class TrailerTest {
     /** */
-    private static final String TRAILER_TAG = "Trailer";
-
-    /** */
     @Test
     public void testTrailerGedObject() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
 
-        final Trailer trailer = new Trailer(root);
-        root.insert(TRAILER_TAG, trailer);
+        final Trailer trailer = new Trailer(root, "Trailer");
+        root.insert(trailer);
 
-        final GedObject gob = root.find(TRAILER_TAG);
+        final GedObject gob = root.find("Trailer");
         assertEquals("expected trailer", trailer, gob);
     }
 
     /** */
     @Test
-    public void testTrailerEmpty() {
-        final Root root = new Root(null, "Root");
-
-        final Trailer trailer = new Trailer(root);
-        root.insert(TRAILER_TAG, trailer);
-
-        assertTrue("Trailer string should be empty", trailer.getString()
-                .isEmpty());
-    }
-
-    /** */
-    @Test
     public void testTrailerGedFoundObjectString() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         final GedObjectBuilder builder = new GedObjectBuilder(root);
         final Trailer trailer = builder.createTrailer();
 
-        final GedObject gob = root.find(TRAILER_TAG);
+        final GedObject gob = root.find("Trailer");
         assertEquals("expected trailer", trailer, gob);
     }
     /** */
@@ -55,6 +39,6 @@ public final class TrailerTest {
     public void testTrailerGedObjectString() {
         final GedObjectBuilder builder = new GedObjectBuilder();
         final Trailer trailer = builder.createTrailer();
-        assertEquals("expected trailer tag", TRAILER_TAG, trailer.getString());
+        assertEquals("expected trailer tag", "Trailer", trailer.getString());
     }
 }

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/WifeTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/WifeTest.java
@@ -107,19 +107,10 @@ public final class WifeTest {
 
     /** */
     @Test
-    public void testWifeGedObjectEmptyString() {
-        final GedObjectBuilder builder = new GedObjectBuilder();
-        final Family family = builder.createFamily1();
-        final Wife wife = new Wife(family);
-        assertTrue("Wife string should be empty", wife.getString().isEmpty());
-    }
-
-    /** */
-    @Test
     public void testWifeGedObjectEmptyToString() {
         final GedObjectBuilder builder = new GedObjectBuilder();
         final Family family = builder.createFamily1();
-        final Wife wife = new Wife(family);
+        final Wife wife = new Wife(family, "Wife");
         assertTrue("Wife getToString should be empty",
                 wife.getToString().isEmpty());
     }
@@ -129,7 +120,7 @@ public final class WifeTest {
     public void testWifeGedObjectFromString() {
         final GedObjectBuilder builder = new GedObjectBuilder();
         final Family family = builder.createFamily1();
-        final Wife wife = new Wife(family);
+        final Wife wife = new Wife(family, "Wife");
         assertEquals("Wife fromString doesn't match",
                 "F1", wife.getFromString());
     }
@@ -139,7 +130,7 @@ public final class WifeTest {
     public void testWifeGedObjectMotherNotSet() {
         final GedObjectBuilder builder = new GedObjectBuilder();
         final Family family = builder.createFamily1();
-        final Wife wife = new Wife(family);
+        final Wife wife = new Wife(family, "Wife");
         assertFalse("Mother should not be set", wife.getMother().isSet());
     }
 

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GedObjectBuilderTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GedObjectBuilderTest.java
@@ -236,7 +236,7 @@ public final class GedObjectBuilderTest {
     /** */
     @Test
     public void testFamilyWithIdFind() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedObjectBuilder builder = new GedObjectBuilder(root);
         final Family family = builder.createFamily("F1");
         assertEquals("Should have found matching family",

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/GedDocumentMongoFactory.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/GedDocumentMongoFactory.java
@@ -15,6 +15,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Head;
 import org.schoellerfamily.gedbrowser.datamodel.Husband;
 import org.schoellerfamily.gedbrowser.datamodel.Multimedia;
 import org.schoellerfamily.gedbrowser.datamodel.Name;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Place;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
@@ -146,73 +147,60 @@ public final class GedDocumentMongoFactory {
         } else if (document instanceof MultimediaDocumentMongo) {
             final MultimediaDocumentMongo multimediaDocument =
                     (MultimediaDocumentMongo) document;
-            final Multimedia attribute = new Multimedia(parent);
-            attribute.setString(multimediaDocument.getString());
+            final Multimedia attribute = new Multimedia(parent,
+                    multimediaDocument.getString());
             attribute.setTail(multimediaDocument.getTail());
             retval = attribute;
         } else if (document instanceof NameDocumentMongo) {
             retval = new Name(parent, document.getString());
         } else if (document instanceof FamilyDocumentMongo) {
-            retval = new Family(parent);
-            retval.setString(document.getString());
+            retval = new Family(parent, new ObjectId(document.getString()));
         } else if (document instanceof FamCDocumentMongo) {
             final FamCDocumentMongo famcDocument = (FamCDocumentMongo) document;
-            final FamC famc = new FamC(parent);
+            final FamC famc = new FamC(parent, "Child of Family");
             famc.setFromString(parent.getString());
             famc.setToString(famcDocument.getString());
-            famc.setString("Child of Family");
             retval = famc;
         } else if (document instanceof FamSDocumentMongo) {
             final FamSDocumentMongo famsDocument = (FamSDocumentMongo) document;
-            final FamS fams = new FamS(parent);
+            final FamS fams = new FamS(parent, "Spouse of Family");
             fams.setFromString(parent.getString());
             fams.setToString(famsDocument.getString());
-            fams.setString("Spouse of Family");
             retval = fams;
         } else if (document instanceof HeadDocumentMongo) {
-            retval = new Head(parent);
-            retval.setString("Header");
+            retval = new Head(parent, "Header");
         } else if (document instanceof HusbandDocumentMongo) {
             final HusbandDocumentMongo husbandDocument =
                     (HusbandDocumentMongo) document;
-            final Husband husband = new Husband(parent);
-            husband.setString("Husband");
+            final Husband husband = new Husband(parent, "Husband");
             husband.setFromString(parent.getString());
             husband.setToString(husbandDocument.getString());
             retval = husband;
         } else if (document instanceof PersonDocumentMongo) {
-            retval = new Person(parent);
-            retval.setString(document.getString());
+            retval = new Person(parent, new ObjectId(document.getString()));
         } else if (document instanceof PlaceDocumentMongo) {
-            retval = new Place(parent);
-            retval.setString(document.getString());
+            retval = new Place(parent, document.getString());
         } else if (document instanceof SourceDocumentMongo) {
-            retval = new Source(parent);
-            retval.setString(document.getString());
+            retval = new Source(parent, new ObjectId(document.getString()));
         } else if (document instanceof SourceLinkDocumentMongo) {
-            final SourceLink slink = new SourceLink(parent);
-            slink.setString("Source");
+            final SourceLink slink = new SourceLink(parent, "Source");
             slink.setToString(document.getString());
             retval = slink;
         } else if (document instanceof SubmittorDocumentMongo) {
-            retval = new Submittor(parent);
-            retval.setString(document.getString());
+            retval = new Submittor(parent, document.getString());
         } else if (document instanceof SubmittorLinkDocumentMongo) {
-            retval = new SubmittorLink(parent);
-            retval.setString(document.getString());
+            retval = new SubmittorLink(parent, document.getString());
         } else if (document instanceof TrailerDocumentMongo) {
-            retval = new Trailer(parent);
-            retval.setString(document.getString());
+            retval = new Trailer(parent, document.getString());
         } else if (document instanceof WifeDocumentMongo) {
             final WifeDocumentMongo wifeDocument = (WifeDocumentMongo) document;
-            final Wife wife = new Wife(parent);
-            wife.setString("Wife");
+            final Wife wife = new Wife(parent, "Wife");
             wife.setFromString(parent.getString());
             wife.setToString(wifeDocument.getString());
             retval = wife;
         } else if (document instanceof RootDocumentMongo) {
             final RootDocumentMongo rootDocument = (RootDocumentMongo) document;
-            final Root root = new Root(null, "Root");
+            final Root root = new Root("Root");
             root.setFilename(rootDocument.getFilename());
             root.setDbName(rootDocument.getDbName());
             retval = root;
@@ -237,7 +225,7 @@ public final class GedDocumentMongoFactory {
      */
     public Root createRoot(final RootDocument document,
             final FinderStrategy finder) {
-        final Root root = new Root(null, "Root", finder);
+        final Root root = new Root("Root", finder);
         root.setFilename(document.getFilename());
         root.setDbName(document.getDbName());
         return root;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
@@ -33,7 +33,7 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.domain.WifeDocumentMongo
  */
 public final class BadLoadTest {
     /** */
-    private final GedObject root = new Root(null);
+    private final GedObject root = new Root();
     /** */
     private final GedObject attr = new Attribute(root);
 

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentFactoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentFactoryTest.java
@@ -17,6 +17,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Head;
 import org.schoellerfamily.gedbrowser.datamodel.Husband;
 import org.schoellerfamily.gedbrowser.datamodel.Multimedia;
 import org.schoellerfamily.gedbrowser.datamodel.Name;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Place;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
@@ -96,7 +97,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateMultimediaDocument() {
-        final GedObject ged = new Multimedia(null);
+        final GedObject ged = new Multimedia();
         final String typeString = "multimedia";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -122,7 +123,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateFamilyDocument() {
-        final GedObject ged = new Family(null);
+        final GedObject ged = new Family();
         final String typeString = "family";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -135,7 +136,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateFamCDocument() {
-        final GedObject ged = new FamC(null);
+        final GedObject ged = new FamC();
         final String typeString = "famc";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -148,7 +149,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateFamSDocument() {
-        final GedObject ged = new FamS(null);
+        final GedObject ged = new FamS();
         final String typeString = "fams";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -161,7 +162,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateHeadDocument() {
-        final GedObject ged = new Head(null);
+        final GedObject ged = new Head();
         final String typeString = "head";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -174,7 +175,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateHusbandDocument() {
-        final GedObject ged = new Husband(null);
+        final GedObject ged = new Husband();
         final String typeString = "husband";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -187,7 +188,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreatePersonDocument() {
-        final GedObject ged = new Person(null);
+        final GedObject ged = new Person(null, new ObjectId("I1"));
         final String typeString = "person";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -200,7 +201,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreatePlaceDocument() {
-        final GedObject ged = new Place(null);
+        final GedObject ged = new Place();
         final String typeString = "place";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -213,7 +214,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateSourceDocument() {
-        final GedObject ged = new Source(null);
+        final GedObject ged = new Source(null, new ObjectId("S1"));
         final String typeString = "source";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -226,7 +227,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateSourceLinkDocument() {
-        final GedObject ged = new SourceLink(null);
+        final GedObject ged = new SourceLink();
         final String typeString = "sourcelink";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -239,7 +240,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateSubmittorDocument() {
-        final GedObject ged = new Submittor(null);
+        final GedObject ged = new Submittor();
         final String typeString = "submittor";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -252,7 +253,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateSubmittorLinkDocument() {
-        final GedObject ged = new SubmittorLink(null);
+        final GedObject ged = new SubmittorLink();
         final String typeString = "submittorlink";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -265,7 +266,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateTrailerDocument() {
-        final GedObject ged = new Trailer(null);
+        final GedObject ged = new Trailer();
         final String typeString = "trailer";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -278,7 +279,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testCreateWifeDocument() {
-        final GedObject ged = new Wife(null);
+        final GedObject ged = new Wife();
         final String typeString = "wife";
         final GedDocument<?> gmd = GedDocumentMongoFactory.getInstance()
                 .createGedDocument(ged);
@@ -304,7 +305,7 @@ public final class GedDocumentFactoryTest {
     /** */
     @Test
     public void testUnexpectedCreateDocument() {
-        final GedObject ged = new GedObject(null) {
+        final GedObject ged = new GedObject() {
         };
         GedDocument<?> gmd = null;
         try {
@@ -339,7 +340,7 @@ public final class GedDocumentFactoryTest {
         final AttributeDocumentMongo gmd = new AttributeDocumentMongo();
         gmd.setString("Attribute");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Attribute.class, ged.getClass());
     }
 
@@ -349,7 +350,7 @@ public final class GedDocumentFactoryTest {
         final ChildDocumentMongo gmd = new ChildDocumentMongo();
         gmd.setString("Child");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Child.class, ged.getClass());
     }
 
@@ -359,7 +360,7 @@ public final class GedDocumentFactoryTest {
         final DateDocumentMongo gmd = new DateDocumentMongo();
         gmd.setString("Date");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Date.class, ged.getClass());
     }
 
@@ -369,7 +370,7 @@ public final class GedDocumentFactoryTest {
         final FamilyDocumentMongo gmd = new FamilyDocumentMongo();
         gmd.setString("Family");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Family.class, ged.getClass());
     }
 
@@ -379,7 +380,7 @@ public final class GedDocumentFactoryTest {
         final FamCDocumentMongo gmd = new FamCDocumentMongo();
         gmd.setString("FamC");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", FamC.class, ged.getClass());
     }
 
@@ -389,7 +390,7 @@ public final class GedDocumentFactoryTest {
         final FamSDocumentMongo gmd = new FamSDocumentMongo();
         gmd.setString("FamS");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", FamS.class, ged.getClass());
     }
 
@@ -399,7 +400,7 @@ public final class GedDocumentFactoryTest {
         final HeadDocumentMongo gmd = new HeadDocumentMongo();
         gmd.setString("Head");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Head.class, ged.getClass());
     }
 
@@ -409,7 +410,7 @@ public final class GedDocumentFactoryTest {
         final HusbandDocumentMongo gmd = new HusbandDocumentMongo();
         gmd.setString("Husband");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Husband.class, ged.getClass());
     }
 
@@ -419,7 +420,7 @@ public final class GedDocumentFactoryTest {
         final PersonDocumentMongo gmd = new PersonDocumentMongo();
         gmd.setString("Person");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Person.class, ged.getClass());
     }
 
@@ -429,7 +430,7 @@ public final class GedDocumentFactoryTest {
         final PlaceDocumentMongo gmd = new PlaceDocumentMongo();
         gmd.setString("Place");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Place.class, ged.getClass());
     }
 
@@ -439,7 +440,7 @@ public final class GedDocumentFactoryTest {
         final SourceDocumentMongo gmd = new SourceDocumentMongo();
         gmd.setString("Source");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Source.class, ged.getClass());
     }
 
@@ -449,7 +450,7 @@ public final class GedDocumentFactoryTest {
         final SourceLinkDocumentMongo gmd = new SourceLinkDocumentMongo();
         gmd.setString("SourceLink");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", SourceLink.class, ged.getClass());
     }
 
@@ -459,7 +460,7 @@ public final class GedDocumentFactoryTest {
         final SubmittorDocumentMongo gmd = new SubmittorDocumentMongo();
         gmd.setString("Submittor");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Submittor.class, ged.getClass());
     }
 
@@ -469,7 +470,7 @@ public final class GedDocumentFactoryTest {
         final SubmittorLinkDocumentMongo gmd = new SubmittorLinkDocumentMongo();
         gmd.setString("SubmittorLink");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", SubmittorLink.class, ged.getClass());
     }
 
@@ -479,7 +480,7 @@ public final class GedDocumentFactoryTest {
         final TrailerDocumentMongo gmd = new TrailerDocumentMongo();
         gmd.setString("Trailer");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Trailer.class, ged.getClass());
     }
 
@@ -489,7 +490,7 @@ public final class GedDocumentFactoryTest {
         final WifeDocumentMongo gmd = new WifeDocumentMongo();
         gmd.setString("Wife");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Wife.class, ged.getClass());
     }
 
@@ -499,7 +500,7 @@ public final class GedDocumentFactoryTest {
         final MultimediaDocumentMongo gmd = new MultimediaDocumentMongo();
         gmd.setString("Multimedia");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Multimedia.class, ged.getClass());
     }
 
@@ -509,7 +510,7 @@ public final class GedDocumentFactoryTest {
         final NameDocumentMongo gmd = new NameDocumentMongo();
         gmd.setString("Name");
         final GedObject ged = GedDocumentMongoFactory.getInstance().
-                createGedObject(new Root(null), gmd);
+                createGedObject(new Root(), gmd);
         assertEquals("Wrong class", Name.class, ged.getClass());
     }
 
@@ -533,7 +534,7 @@ public final class GedDocumentFactoryTest {
         GedObject ged = null;
         try {
             ged = GedDocumentMongoFactory.getInstance().
-                    createGedObject(new Root(null), gmd);
+                    createGedObject(new Root(), gmd);
             fail("Should not get here");
         } catch (PersistenceException e) {
             assertNull("Result should be null", ged);

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
@@ -15,6 +15,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Family;
 import org.schoellerfamily.gedbrowser.datamodel.FinderStrategy;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Head;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
@@ -237,8 +238,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertPerson() {
-        final Person person = new Person(root);
-        person.setString(BOGUS_ID);
+        final Person person = new Person(root, new ObjectId(BOGUS_ID));
         finder.insert(root, person);
         assertEquals("Person mismatch",
                 person, finder.find(root, BOGUS_ID, Person.class));
@@ -247,8 +247,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertFamily() {
-        final Family family = new Family(root);
-        family.setString(BOGUS_ID);
+        final Family family = new Family(root, new ObjectId(BOGUS_ID));
         finder.insert(root, family);
         assertEquals("Family mismatch",
                 family, finder.find(root, BOGUS_ID, Family.class));
@@ -257,8 +256,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertSource() {
-        final Source source = new Source(root);
-        source.setString(BOGUS_ID);
+        final Source source = new Source(root, new ObjectId(BOGUS_ID));
         finder.insert(root, source);
         assertEquals("Source mismatch",
                 source, finder.find(root, BOGUS_ID, Source.class));
@@ -267,8 +265,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertSubmittor() {
-        final Submittor submittor = new Submittor(root);
-        submittor.setString(BOGUS_ID);
+        final Submittor submittor = new Submittor(root, BOGUS_ID);
         finder.insert(root, submittor);
         assertEquals("Submittor mismatch",
                 submittor, finder.find(root, BOGUS_ID, Submittor.class));
@@ -278,8 +275,7 @@ public final class RepositoryFinderTest {
     @Test
     public void testInsertHead() {
         // TODO this test describes the current, probably wrong behavior.
-        final Head head = new Head(root);
-        head.setString(BOGUS_ID);
+        final Head head = new Head(root, BOGUS_ID);
         finder.insert(root, head);
         final Head newHead = finder.find(root, BOGUS_ID, Head.class);
         assertNotEquals(head, newHead);
@@ -288,9 +284,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertHeadTag() {
-        // TODO this test describes the current, probably wrong behavior.
-        final Head head = new Head(root);
-        head.setString(BOGUS_ID);
+        final Head head = new Head(root, BOGUS_ID);
         finder.insert(root, head);
         final Head newHead = finder.find(root, BOGUS_ID, Head.class);
         assertEquals("Tag string mismatch", "Header", newHead.getString());
@@ -299,8 +293,7 @@ public final class RepositoryFinderTest {
     /** */
     @Test
     public void testInsertTrailer() {
-        final Trailer trailer = new Trailer(root);
-        trailer.setString(BOGUS_ID);
+        final Trailer trailer = new Trailer(root, BOGUS_ID);
         finder.insert(root, trailer);
         assertEquals("Should have found trailer",
                 trailer, finder.find(root, BOGUS_ID, Trailer.class));

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedObjectFactory.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedObjectFactory.java
@@ -532,7 +532,8 @@ public abstract class AbstractGedObjectFactory {
         @Override
         public final GedObject create(final GedObject parent,
                 final ObjectId xref, final String tag, final String tail) {
-            return new Root(parent, tag);
+            // Root is a special case. Always has null parent.
+            return new Root(tag);
         }
     }
 

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/GedFile.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/GedFile.java
@@ -46,9 +46,9 @@ public final class GedFile extends AbstractGedLine {
     protected GedObject createGedObject(final GedObject parent) {
         Root gob;
         if (finder == null) {
-            gob = new Root(null);
+            gob = new Root();
         } else {
-            gob = new Root(null, finder);
+            gob = new Root(finder);
         }
         gob.setFilename(filename);
         gob.setDbName(dbName);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousModePersonNameHtmlRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousModePersonNameHtmlRendererTest.java
@@ -40,7 +40,7 @@ public final class AnonymousModePersonNameHtmlRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonNameIndexRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonNameIndexRendererTest.java
@@ -32,7 +32,7 @@ public final class AnonymousPersonNameIndexRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonRendererTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProvider;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProviderStub;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.renderer.ApplicationInfo;
 import org.schoellerfamily.gedbrowser.renderer.CellRenderer;
@@ -318,8 +319,7 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof PersonAttributeListOpenRenderer);
@@ -331,8 +331,7 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getListItemRenderer()
                 instanceof NullListItemRenderer);
@@ -344,8 +343,7 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof PersonNameHtmlRenderer);
@@ -357,8 +355,7 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof PersonNameIndexRenderer);
@@ -370,8 +367,7 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getPhraseRenderer()
                 instanceof NullPhraseRenderer);
@@ -383,11 +379,20 @@ public final class AnonymousPersonRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Mismatched renderer type",
                 renderer.getSectionRenderer()
                 instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private PersonRenderer createRenderer() {
+        final PersonRenderer renderer = new PersonRenderer(
+                new Person(null, new ObjectId("I1")), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 
     /**

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamCRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamCRendererTest.java
@@ -42,7 +42,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -55,7 +55,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -68,7 +68,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -81,7 +81,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -94,7 +94,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -107,7 +107,7 @@ public final class FamCRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final FamCRenderer renderer = new FamCRenderer(new FamC(null),
+        final FamCRenderer renderer = new FamCRenderer(new FamC(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamSRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamSRendererTest.java
@@ -42,7 +42,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -55,7 +55,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -68,7 +68,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -81,7 +81,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -94,7 +94,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -107,7 +107,7 @@ public final class FamSRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final FamSRenderer renderer = new FamSRenderer(new FamS(null),
+        final FamSRenderer renderer = new FamSRenderer(new FamS(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamilyRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamilyRendererTest.java
@@ -85,7 +85,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -98,7 +98,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -111,7 +111,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -124,7 +124,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -137,7 +137,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -150,7 +150,7 @@ public final class FamilyRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final FamilyRenderer renderer = new FamilyRenderer(new Family(null),
+        final FamilyRenderer renderer = new FamilyRenderer(new Family(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
@@ -306,7 +306,7 @@ public final class FamilyRendererTest {
     /** */
     @Test
     public void testMinimalFamilySpouses() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final Family fam = new Family(root, new ObjectId("F1"));
         root.insert(fam);
         final Person person = new Person(root, new ObjectId("I1"));
@@ -335,7 +335,7 @@ public final class FamilyRendererTest {
     /** */
     @Test
     public void testMinimalFamilySpousesAnonymous() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final Family fam = new Family(root, new ObjectId("F1"));
         root.insert(fam);
         final Person person = new Person(root, new ObjectId("I1"));
@@ -366,7 +366,7 @@ public final class FamilyRendererTest {
     /** */
     @Test
     public void testMinimalFamilySpouses2() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final Family fam = new Family(root, new ObjectId("F1"));
         root.insert(fam);
         final Person person = new Person(root, new ObjectId("I1"));
@@ -394,7 +394,7 @@ public final class FamilyRendererTest {
     /** */
     @Test
     public void testMinimalFamilySpouses2Anonymous() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final Family fam = new Family(root, new ObjectId("F1"));
         root.insert(fam);
         final Person person = new Person(root, new ObjectId("I1"));

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamilySectionRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/FamilySectionRendererTest.java
@@ -44,7 +44,7 @@ public final class FamilySectionRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         final Family family = new Family(root, new ObjectId("F1"));
         root.insert(family);
         final User user = new User();
@@ -275,7 +275,7 @@ public final class FamilySectionRendererTest {
     /** */
     @Test
     public void testMinimalFamilyAsSectionUser() {
-        final Root root1 = new Root(null);
+        final Root root1 = new Root();
         final Family fam = new Family(root1, new ObjectId("F1"));
         root1.insert(fam);
         final Person person = new Person(root1, new ObjectId("I1"));
@@ -314,7 +314,7 @@ public final class FamilySectionRendererTest {
     /** */
     @Test
     public void testMinimalFamilyAsSectionAnonymous() {
-        final Root root1 = new Root(null);
+        final Root root1 = new Root();
         final Family fam = new Family(root1, new ObjectId("F1"));
         root1.insert(fam);
         final Person person = new Person(root1, new ObjectId("I1"));

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GedRendererFactoryTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GedRendererFactoryTest.java
@@ -17,6 +17,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Head;
 import org.schoellerfamily.gedbrowser.datamodel.Husband;
 import org.schoellerfamily.gedbrowser.datamodel.Link;
 import org.schoellerfamily.gedbrowser.datamodel.Name;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Place;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
@@ -103,7 +104,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetPlaceRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new Place(null), provider, appInfo);
+                grf.create(new Place(), provider, appInfo);
         assertTrue("Expected PlaceRenderer",
                 gedRenderer instanceof PlaceRenderer);
     }
@@ -148,7 +149,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetFamCRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new FamC(null), provider, appInfo);
+                grf.create(new FamC(), provider, appInfo);
         assertTrue("Expected FamCRenderer",
                 gedRenderer instanceof FamCRenderer);
     }
@@ -166,7 +167,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetFamSRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new FamS(null), provider, appInfo);
+                grf.create(new FamS(), provider, appInfo);
         assertTrue("Expected FamSRenderer",
                 gedRenderer instanceof FamSRenderer);
     }
@@ -175,7 +176,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetHeadRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new Head(null), provider, appInfo);
+                grf.create(new Head(null, "Header"), provider, appInfo);
         assertTrue("Expected HeadRenderer",
                 gedRenderer instanceof HeadRenderer);
     }
@@ -184,7 +185,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetRootRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new Root(null), provider, appInfo);
+                grf.create(new Root(), provider, appInfo);
         assertTrue("Expected RootRenderer",
                 gedRenderer instanceof RootRenderer);
     }
@@ -192,8 +193,8 @@ public final class GedRendererFactoryTest {
     /** */
     @Test
     public void testGetSourceRenderer() {
-        final GedRenderer<?> gedRenderer =
-                grf.create(new Source(null), provider, appInfo);
+        final GedRenderer<?> gedRenderer = grf.create(
+                new Source(null, new ObjectId("S1")), provider, appInfo);
         assertTrue("Expected SourceRenderer",
                 gedRenderer instanceof SourceRenderer);
     }
@@ -202,7 +203,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetSourceLinkRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new SourceLink(null), provider, appInfo);
+                grf.create(new SourceLink(), provider, appInfo);
         assertTrue("Expected SourceLinkRenderer",
                 gedRenderer instanceof SourceLinkRenderer);
     }
@@ -211,7 +212,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetSubmittorRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new Submittor(null), provider, appInfo);
+                grf.create(new Submittor(null, "SUB1"), provider, appInfo);
         assertTrue("Expected SubmittorRenderer",
                 gedRenderer instanceof SubmittorRenderer);
     }
@@ -220,7 +221,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetSubmittorLinkRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new SubmittorLink(null), provider, appInfo);
+                grf.create(new SubmittorLink(), provider, appInfo);
         assertTrue("Expected SubmittorLinkRenderer",
                 gedRenderer instanceof SubmittorLinkRenderer);
     }
@@ -229,7 +230,7 @@ public final class GedRendererFactoryTest {
     @Test
     public void testGetTrailerRenderer() {
         final GedRenderer<?> gedRenderer =
-                grf.create(new Trailer(null), provider, appInfo);
+                grf.create(new Trailer(null, "Trailer"), provider, appInfo);
         assertTrue("Expected TrailerRenderer",
                 gedRenderer instanceof TrailerRenderer);
     }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GedRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GedRendererTest.java
@@ -139,7 +139,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlEmpty() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new GedRenderer<GedObject>(root,
                 new GedRendererFactory(), anonymousContext, provider) {
         };
@@ -180,7 +180,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetHeaderHtml() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new DefaultRenderer(root,
                 new GedRendererFactory(),
                 anonymousContext, provider);
@@ -214,7 +214,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetTrailerHtml() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new DefaultRenderer(root,
                 new GedRendererFactory(),
                 anonymousContext, provider);
@@ -255,7 +255,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlHeader() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new DefaultRenderer(root,
                 new GedRendererFactory(),
                 anonymousContext, provider);
@@ -297,7 +297,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlSurnames() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new DefaultRenderer(root,
                 new GedRendererFactory(),
                 anonymousContext, provider);
@@ -340,7 +340,7 @@ public final class GedRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlIndex() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final GedRenderer<GedObject> renderer = new DefaultRenderer(root,
                 new GedRendererFactory(),
                 anonymousContext, provider);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HeadRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HeadRendererTest.java
@@ -42,7 +42,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -55,7 +55,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -68,7 +68,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -81,7 +81,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testNameIndeRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -94,7 +94,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -107,7 +107,7 @@ public final class HeadRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final HeadRenderer renderer = new HeadRenderer(new Head(null),
+        final HeadRenderer renderer = new HeadRenderer(new Head(null, "Header"),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HeadSectionRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HeadSectionRendererTest.java
@@ -41,8 +41,8 @@ public final class HeadSectionRendererTest {
     /** */
     @Before
     public void init() {
-        root = new Root(null, "root");
-        head = new Head(root);
+        root = new Root("Root");
+        head = new Head(root, "Header");
         root.insert(head);
         root.setFilename("thefile.ged");
         root.setDbName("thefile");

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HusbandRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/HusbandRendererTest.java
@@ -42,8 +42,7 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -55,8 +54,7 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof NullListItemRenderer);
@@ -68,8 +66,7 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof NullNameHtmlRenderer);
@@ -81,8 +78,7 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -94,8 +90,7 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof NullPhraseRenderer);
@@ -107,10 +102,19 @@ public final class HusbandRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final HusbandRenderer renderer = new HusbandRenderer(new Husband(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final HusbandRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private HusbandRenderer createRenderer() {
+        final HusbandRenderer renderer = new HusbandRenderer(
+                new Husband(null, "Husband"), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/MultimediaRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/MultimediaRendererTest.java
@@ -41,9 +41,7 @@ public final class MultimediaRendererTest {
      */
     @Test
     public void testMultimediaListItemRenderer() {
-        final MultimediaRenderer renderer = new MultimediaRenderer(
-                new Multimedia(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final MultimediaRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof MultimediaListItemRenderer);
@@ -55,9 +53,7 @@ public final class MultimediaRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final MultimediaRenderer renderer = new MultimediaRenderer(
-                new Multimedia(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final MultimediaRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof NullNameHtmlRenderer);
@@ -69,9 +65,7 @@ public final class MultimediaRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final MultimediaRenderer renderer = new MultimediaRenderer(
-                new Multimedia(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final MultimediaRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -83,9 +77,7 @@ public final class MultimediaRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final MultimediaRenderer renderer = new MultimediaRenderer(
-                new Multimedia(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final MultimediaRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof MultimediaPhraseRenderer);
@@ -97,12 +89,21 @@ public final class MultimediaRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final MultimediaRenderer renderer = new MultimediaRenderer(
-                new Multimedia(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final MultimediaRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof MultimediaSectionRenderer);
     }
+
+    /**
+     * @return the renderer
+     */
+    private MultimediaRenderer createRenderer() {
+        final MultimediaRenderer renderer = new MultimediaRenderer(
+                new Multimedia(), new GedRendererFactory(), anonymousContext,
+                provider);
+        return renderer;
+    }
+
     // TODO test render as page and renderAsListItem
 }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/NameNameHtmlRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/NameNameHtmlRendererTest.java
@@ -33,7 +33,7 @@ public final class NameNameHtmlRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/NullRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/NullRendererTest.java
@@ -124,7 +124,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlEmpty() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);
@@ -155,7 +155,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetHeaderHtml() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);
@@ -183,7 +183,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetTrailerHtml() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);
@@ -214,7 +214,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlHeader() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);
@@ -246,7 +246,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlSurnames() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);
@@ -279,7 +279,7 @@ public final class NullRendererTest {
     /** */
     @Test
     public void testGetTrailerHtmlIndex() {
-        final Root root = new Root(null);
+        final Root root = new Root();
         final NullRenderer renderer = new NullRenderer(root,
                 new GedRendererFactory(), anonymousContext,
                 provider);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonAttributeListOpenRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonAttributeListOpenRendererTest.java
@@ -44,7 +44,7 @@ public final class PersonAttributeListOpenRendererTest {
     @Before
     public void init() {
         Root root;
-        root = new Root(null, "root");
+        root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonNameIndexRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonNameIndexRendererTest.java
@@ -32,7 +32,7 @@ public final class PersonNameIndexRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonRendererTest.java
@@ -11,6 +11,7 @@ import org.junit.Test;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProvider;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProviderStub;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.renderer.ApplicationInfo;
 import org.schoellerfamily.gedbrowser.renderer.CellRenderer;
@@ -522,8 +523,7 @@ public final class PersonRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof PersonAttributeListOpenRenderer);
@@ -535,8 +535,7 @@ public final class PersonRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof NullListItemRenderer);
@@ -548,8 +547,7 @@ public final class PersonRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof PersonNameHtmlRenderer);
@@ -561,8 +559,7 @@ public final class PersonRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof PersonNameIndexRenderer);
@@ -574,8 +571,7 @@ public final class PersonRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof NullPhraseRenderer);
@@ -587,11 +583,20 @@ public final class PersonRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final PersonRenderer renderer = new PersonRenderer(new Person(null),
-                new GedRendererFactory(), userContext, provider);
+        final PersonRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private PersonRenderer createRenderer() {
+        final PersonRenderer renderer = new PersonRenderer(
+                new Person(null, new ObjectId("I1")), new GedRendererFactory(),
+                userContext, provider);
+        return renderer;
     }
 
     /**

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PlaceRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PlaceRendererTest.java
@@ -42,7 +42,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -55,7 +55,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -68,7 +68,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -81,7 +81,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -94,7 +94,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -107,7 +107,7 @@ public final class PlaceRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final PlaceRenderer renderer = new PlaceRenderer(new Place(null),
+        final PlaceRenderer renderer = new PlaceRenderer(new Place(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/RootRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/RootRendererTest.java
@@ -42,7 +42,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -55,7 +55,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -68,7 +68,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -81,7 +81,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -94,7 +94,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -107,7 +107,7 @@ public final class RootRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final RootRenderer renderer = new RootRenderer(new Root(null),
+        final RootRenderer renderer = new RootRenderer(new Root(),
                 new GedRendererFactory(), anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceLinkListItemRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceLinkListItemRendererTest.java
@@ -33,7 +33,7 @@ public final class SourceLinkListItemRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         final Source source = new Source(root, new ObjectId("S1"));

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceLinkRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceLinkRendererTest.java
@@ -42,9 +42,7 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -56,9 +54,7 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof SourceLinkListItemRenderer);
@@ -70,9 +66,7 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof NullNameHtmlRenderer);
@@ -84,9 +78,7 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -98,9 +90,7 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof SourceLinkPhraseRenderer);
@@ -112,11 +102,19 @@ public final class SourceLinkRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final SourceLinkRenderer renderer = new SourceLinkRenderer(
-                new SourceLink(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceLinkRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private SourceLinkRenderer createRenderer() {
+        final SourceLinkRenderer renderer = new SourceLinkRenderer(
+                new SourceLink(), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceRendererTest.java
@@ -9,6 +9,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProvider;
 import org.schoellerfamily.gedbrowser.analytics.CalendarProviderStub;
+import org.schoellerfamily.gedbrowser.datamodel.ObjectId;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
 import org.schoellerfamily.gedbrowser.renderer.ApplicationInfo;
@@ -47,9 +48,7 @@ public final class SourceRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -61,9 +60,7 @@ public final class SourceRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof NullListItemRenderer);
@@ -75,9 +72,7 @@ public final class SourceRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof NullNameHtmlRenderer);
@@ -89,9 +84,7 @@ public final class SourceRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -103,9 +96,7 @@ public final class SourceRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof NullPhraseRenderer);
@@ -117,12 +108,20 @@ public final class SourceRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final SourceRenderer renderer = new SourceRenderer(new Source(null),
-                new GedRendererFactory(),
-                anonymousContext, provider);
+        final SourceRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof SourceSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private SourceRenderer createRenderer() {
+        final SourceRenderer renderer = new SourceRenderer(
+                new Source(null, new ObjectId("S1")), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 
     /**

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceSectionRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SourceSectionRendererTest.java
@@ -34,7 +34,7 @@ public final class SourceSectionRendererTest {
     /** */
     @Before
     public void init() {
-        root = new Root(null, "root");
+        root = new Root("Root");
         provider = new CalendarProviderStub();
         final ApplicationInfo appInfo = new ApplicationInfoStub();
         anonymousContext = RenderingContext.anonymous(appInfo);
@@ -54,8 +54,9 @@ public final class SourceSectionRendererTest {
         final SourceSectionRenderer ssRenderer =
                 (SourceSectionRenderer) sRenderer.getSectionRenderer();
         final StringBuilder builder = new StringBuilder();
-        ssRenderer.renderAsSection(builder, new PersonRenderer(new Person(root),
-                new GedRendererFactory(), anonymousContext, provider),
+        ssRenderer.renderAsSection(builder,
+                new PersonRenderer(new Person(root, new ObjectId("I1")),
+                        new GedRendererFactory(), anonymousContext, provider),
                 false, 0, 1);
         assertEquals("Rendered html doesn't match expectation",
                 "\n" + "<ul>\n"

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkListItemRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkListItemRendererTest.java
@@ -34,7 +34,7 @@ public final class SubmittorLinkListItemRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         /** */
         final Head head = new Head(root, "Head");
         root.insert(head);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkPhraseRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkPhraseRendererTest.java
@@ -35,7 +35,7 @@ public final class SubmittorLinkPhraseRendererTest {
     @Before
     public void init() {
         /** */
-        final Root root = new Root(null, "Root");
+        final Root root = new Root("Root");
         /** */
         final Head head = new Head(root, "Head");
         root.insert(head);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkRendererTest.java
@@ -43,7 +43,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testAttributeListOpenRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
@@ -57,7 +57,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testListItemRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
@@ -71,7 +71,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testNameHtmlRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
@@ -85,7 +85,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testNameIndeRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
@@ -99,7 +99,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testPhraseRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
@@ -113,7 +113,7 @@ public final class SubmittorLinkRendererTest {
     @Test
     public void testSectionRenderer() {
         final SubmittorLinkRenderer renderer = new SubmittorLinkRenderer(
-                new SubmittorLink(null), new GedRendererFactory(),
+                new SubmittorLink(), new GedRendererFactory(),
                 anonymousContext, provider);
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkSectionRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorLinkSectionRendererTest.java
@@ -38,7 +38,7 @@ public final class SubmittorLinkSectionRendererTest {
     /** */
     @Before
     public void init() {
-        root = new Root(null, "Root");
+        root = new Root("Root");
         final Head head = new Head(root, "Head");
         root.insert(head);
         final Submittor submittor = new Submittor(root, "SUBM", "S1");

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorRendererTest.java
@@ -42,9 +42,7 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -56,9 +54,7 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer()
                 instanceof NullListItemRenderer);
@@ -70,9 +66,7 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer()
                 instanceof NullNameHtmlRenderer);
@@ -84,9 +78,7 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -98,9 +90,7 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer()
                 instanceof NullPhraseRenderer);
@@ -112,11 +102,19 @@ public final class SubmittorRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final SubmittorRenderer renderer = new SubmittorRenderer(
-                new Submittor(null), new GedRendererFactory(),
-                anonymousContext, provider);
+        final SubmittorRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer()
                 instanceof SubmittorSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private SubmittorRenderer createRenderer() {
+        final SubmittorRenderer renderer = new SubmittorRenderer(
+                new Submittor(null, "SUB1"), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorSectionRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmittorSectionRendererTest.java
@@ -35,8 +35,8 @@ public final class SubmittorSectionRendererTest {
     /** */
     @Before
     public void init() {
-        root = new Root(null);
-        submittor = new Submittor(root);
+        root = new Root();
+        submittor = new Submittor(root, "SUB1");
         final Name name = new Name(submittor, "Richard/Schoeller/");
         root.insert(submittor);
         submittor.insert(name);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/TrailerRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/TrailerRendererTest.java
@@ -42,8 +42,7 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -55,8 +54,7 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer() instanceof NullListItemRenderer);
     }
@@ -67,8 +65,7 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer() instanceof NullNameHtmlRenderer);
     }
@@ -79,8 +76,7 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type", renderer
                 .getNameIndexRenderer() instanceof NullNameIndexRenderer);
     }
@@ -91,8 +87,7 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer() instanceof NullPhraseRenderer);
     }
@@ -103,9 +98,18 @@ public final class TrailerRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final TrailerRenderer renderer = new TrailerRenderer(new Trailer(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final TrailerRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer() instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private TrailerRenderer createRenderer() {
+        final TrailerRenderer renderer = new TrailerRenderer(
+                new Trailer(null, "Trailer"), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 }

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/UserModePersonNameHtmlRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/UserModePersonNameHtmlRendererTest.java
@@ -32,7 +32,7 @@ public final class UserModePersonNameHtmlRendererTest {
     /** */
     @Before
     public void init() {
-        final Root root = new Root(null, "root");
+        final Root root = new Root("Root");
         person = new Person(root, new ObjectId("I1"));
         root.insert(person);
         provider = new CalendarProviderStub();

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/WifeRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/WifeRendererTest.java
@@ -42,8 +42,7 @@ public final class WifeRendererTest {
      */
     @Test
     public void testAttributeListOpenRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getAttributeListOpenRenderer()
                 instanceof SimpleAttributeListOpenRenderer);
@@ -55,8 +54,7 @@ public final class WifeRendererTest {
      */
     @Test
     public void testListItemRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getListItemRenderer() instanceof NullListItemRenderer);
     }
@@ -67,8 +65,7 @@ public final class WifeRendererTest {
      */
     @Test
     public void testNameHtmlRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameHtmlRenderer() instanceof NullNameHtmlRenderer);
     }
@@ -79,8 +76,7 @@ public final class WifeRendererTest {
      */
     @Test
     public void testNameIndexRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getNameIndexRenderer()
                 instanceof NullNameIndexRenderer);
@@ -92,8 +88,7 @@ public final class WifeRendererTest {
      */
     @Test
     public void testPhraseRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getPhraseRenderer() instanceof NullPhraseRenderer);
     }
@@ -104,9 +99,18 @@ public final class WifeRendererTest {
      */
     @Test
     public void testSectionRenderer() {
-        final WifeRenderer renderer = new WifeRenderer(new Wife(null),
-                new GedRendererFactory(), anonymousContext, provider);
+        final WifeRenderer renderer = createRenderer();
         assertTrue("Wrong renderer type",
                 renderer.getSectionRenderer() instanceof NullSectionRenderer);
+    }
+
+    /**
+     * @return the renderer
+     */
+    private WifeRenderer createRenderer() {
+        final WifeRenderer renderer = new WifeRenderer(
+                new Wife(null, "Wife"), new GedRendererFactory(),
+                anonymousContext, provider);
+        return renderer;
     }
 }


### PR DESCRIPTION
The title aspect of change unifies the interface so that Root is
the same as all GedObjects as far as insert is concerned.

Together with this I eliminated the constructors in the data
model that only take a parent. Most of these were being used either:

* in places where a string was being added after construction
* or in being passed a null

Switched the null versions to using a default constructor. Switched
the instance where a string was being set immediately after to use
the version with a parent and a string.