### PR TITLE
Fixes #203 - Tests seem brittle about DB usage

### DIFF
--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
@@ -23,6 +23,7 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.SourceDocumen
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.SubmittorDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.TrailerDocumentRepositoryMongo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 /**
  * @author Dick Schoeller
@@ -56,6 +57,10 @@ public final class RepositoryFixture {
     /** */
     @Autowired
     private transient TrailerDocumentRepositoryMongo trailerDocumentRepository;
+
+    /** */
+    @Autowired
+    private transient MongoTemplate mongoTemplate;
 
     /**
      * This is private because this is a singleton.
@@ -118,5 +123,6 @@ public final class RepositoryFixture {
         headDocumentRepository.deleteAll();
         submittorDocumentRepository.deleteAll();
         trailerDocumentRepository.deleteAll();
+        mongoTemplate.getDb().dropDatabase();
     }
 }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/HeadRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/HeadRepositoryTest.java
@@ -22,10 +22,10 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.domain.HeadDocumentMongo
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.PersonDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.RootDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.SourceDocumentMongo;
+import org.schoellerfamily.gedbrowser.persistence.mongo.fixture.RepositoryFixture;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.FamilyDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.HeadDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.PersonDocumentRepositoryMongo;
-import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RootDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.SourceDocumentRepositoryMongo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.ContextConfiguration;
@@ -42,8 +42,8 @@ public final class HeadRepositoryTest {
     private static final String HEADER_STRING = "Header";
 
     /** */
-    @Autowired
-    private transient RootDocumentRepositoryMongo rootDocumentRepository;
+//    @Autowired
+//    private transient RootDocumentRepositoryMongo rootDocumentRepository;
 
     /** */
     @Autowired
@@ -62,6 +62,10 @@ public final class HeadRepositoryTest {
     private transient HeadDocumentRepositoryMongo headDocumentRepository;
 
     /** */
+    @Autowired
+    private transient RepositoryFixture repositoryFixture;
+
+    /** */
     private transient Root root;
 
     /** */
@@ -72,11 +76,7 @@ public final class HeadRepositoryTest {
      */
     @Before
     public void setUp() throws IOException {
-        rootDocumentRepository.deleteAll();
-        personDocumentRepository.deleteAll();
-        familyDocumentRepository.deleteAll();
-        sourceDocumentRepository.deleteAll();
-        sourceDocumentRepository.deleteAll();
+        repositoryFixture.clearRepository();
 
         root = (Root) TestDataReader.getInstance().readBigTestSource();
         root.setFilename("bigtest");
@@ -104,11 +104,7 @@ public final class HeadRepositoryTest {
     /** */
     @After
     public void tearDown() {
-        rootDocumentRepository.deleteAll();
-        personDocumentRepository.deleteAll();
-        familyDocumentRepository.deleteAll();
-        sourceDocumentRepository.deleteAll();
-        headDocumentRepository.deleteAll();
+        repositoryFixture.clearRepository();
     }
 
     /** */

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
@@ -1,6 +1,7 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
 import java.net.UnknownHostException;
+import java.util.UUID;
 
 import org.schoellerfamily.gedbrowser.datamodel.FinderStrategy;
 import org.schoellerfamily.gedbrowser.persistence.mongo.fixture.RepositoryFixture;
@@ -60,8 +61,10 @@ public class MongoTestConfiguration {
      */
     @Bean
     public MongoDbFactory mongoDbFactory() throws UnknownHostException {
+        final String databaseName =
+                "gebrowserTest_" + UUID.randomUUID().toString();
         return new SimpleMongoDbFactory(
-                new MongoClient(host, port), "gedbrowserTest");
+                new MongoClient(host, port), databaseName);
     }
 
     /**
@@ -72,10 +75,7 @@ public class MongoTestConfiguration {
      */
     @Bean
     public MongoTemplate mongoTemplate() throws UnknownHostException {
-        final MongoTemplate mongoTemplate = new MongoTemplate(mongoDbFactory());
-
-        return mongoTemplate;
-
+        return new MongoTemplate(mongoDbFactory());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
@@ -8,6 +8,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.util.Collection;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -61,6 +62,12 @@ public final class RepositoryFinderTest {
     @Before
     public void setUp() throws IOException {
         root = repositoryFixture.loadRepository();
+    }
+
+    /** */
+    @After
+    public void tearDown() {
+        repositoryFixture.clearRepository();
     }
 
     /** */

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
@@ -7,6 +7,7 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Collection;
@@ -15,6 +16,8 @@ import java.util.List;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.junit.After;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -71,11 +74,24 @@ public final class GeoCodeMongoTest {
     }
 
     /**
+     * @throws IOException if there is a problem loading data
+     */
+    @Before
+    public void init() throws IOException {
+        testFixture.loadRepository();
+    }
+
+    /** */
+    @After
+    public void tearDown() {
+        testFixture.clearRepository();
+    }
+
+    /**
      */
     @Test
     public void testStupidNotFound() {
         logger.info("Entering testStupidNotFound");
-        testFixture.clearRepository();
         final GeoCodeItem entry = gcc.find("XYZZY");
         assertNull("Should not have found XYZZY",
                 entry.getGeocodingResult());
@@ -86,7 +102,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testModernStupidNotFound() {
         logger.info("Entering testModernStupidNotFound");
-        testFixture.clearRepository();
         final GeoCodeItem entry = gcc.find("PLUGH", "XYZZY");
         assertNull("Should not have found modern XYZZY",
                 entry.getGeocodingResult());
@@ -97,7 +112,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testOldHomeFound() {
         logger.info("Entering testOldHomeFound");
-        testFixture.clearRepository();
         final GeoCodeItem entry = gcc
                 .find("3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeocodingResult geocodingResult = entry.getGeocodingResult();
@@ -110,7 +124,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheStupid() {
         logger.info("Entering testCacheStupid");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("XYZZY");
         final GeoCodeItem entry2 = gcc.find("XYZZY");
         assertEquals("Should be equal", entry1, entry2);
@@ -121,7 +134,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testModernEmpty() {
         logger.info("Entering testModernEmpty");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("XYZZY");
         final GeoCodeItem entry2 = gcc.find("XYZZY", "");
         assertEquals("Should be equal", entry1, entry2);
@@ -132,7 +144,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testModernNull() {
         logger.info("Entering testModernNull");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("XYZZY");
         final GeoCodeItem entry2 = gcc.find("XYZZY", null);
         assertEquals("Should be equal", entry1, entry2);
@@ -143,7 +154,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheFound() {
         logger.info("Entering testCacheFound");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc
                 .find("3341 Chaucer Lane, Bethlehem, Pennsylvania, USA");
         final GeoCodeItem entry2 = gcc
@@ -156,7 +166,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheRefind() {
         logger.info("Entering testCacheReplace");
-        testFixture.clearRepository();
         gcc.find("XYZZY");
         final GeoCodeItem entry2 = gcc.find("XYZZY",
                 "3341 Chaucer Lane, Bethlehem, Pennsylvania, USA");
@@ -169,7 +178,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHome() {
         logger.info("Entering testCacheOldHome");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc
                 .find("3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeoCodeItem entry2 = gcc
@@ -182,7 +190,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeModern() {
         logger.info("Entering testCacheOldHomeModern");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeoCodeItem entry2 = gcc.find("Old Home");
@@ -194,7 +201,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeModernBoth() {
         logger.info("Entering testCacheOldHomeModernBoth");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeoCodeItem entry2 = gcc.find("Old Home",
@@ -207,7 +213,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeModernChange() {
         logger.info("Entering testCacheOldHomeModernChange");
-        testFixture.clearRepository();
         final GeoCodeItem entry1 = gcc.find("Old Home");
         final GeoCodeItem entry2 = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
@@ -219,7 +224,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheReplaceCheckEquals() {
         logger.info("Entering testCacheReplace");
-        testFixture.clearRepository();
         gcc.find("XYZZY");
         final GeoCodeItem entry2 = gcc.find("XYZZY", "XYZZY");
         final GeoCodeItem entry3 = gcc.find("XYZZY", "XYZZY");
@@ -231,7 +235,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheReplaceCheckNullGeocodingResult() {
         logger.info("Entering testCacheReplace");
-        testFixture.clearRepository();
         gcc.find("XYZZY");
         gcc.find("XYZZY", "XYZZY");
         final GeoCodeItem entry3 = gcc.find("XYZZY", "XYZZY");
@@ -244,7 +247,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeModernSet() {
         logger.info("Entering testCacheOldHomeModernSet");
-        testFixture.clearRepository();
         gcc.find("Old Home");
         final GeoCodeItem entry2 = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
@@ -257,7 +259,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeLocationResultNotNull() {
         logger.info("Entering testCacheOldHomeLocation");
-        testFixture.clearRepository();
         final GeoCodeItem entry = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeocodingResult geocodingResult = entry.getGeocodingResult();
@@ -270,7 +271,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCacheOldHomeLocationLatLngMatch() {
         logger.info("Entering testCacheOldHomeLocation");
-        testFixture.clearRepository();
         final GeoCodeItem entry = gcc.find("Old Home",
                 "3341 Chaucer Lane, Bethlehem, PA, USA");
         final LatLng expected = new LatLng(40.65800200, -75.40644300);
@@ -285,7 +285,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testNotFounds() {
         logger.info("Entering testNotFounds");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final List<String> expectList = Arrays
                 .asList(testFixture.expectedNotFound());
@@ -300,7 +299,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testNotFoundsFromFile() {
         logger.info("Entering testNotFounds");
-        testFixture.clearRepository();
         final InputStream fis = getTestFileAsStream();
         loader.load(fis);
         final List<String> expectList = Arrays
@@ -316,7 +314,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCountNotFoundsLowBound() {
         logger.info("Entering testCountNotFounds");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final int count = gcc.countNotFound();
         // Count does not seem to be deterministic with Google's APIs.
@@ -329,7 +326,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCountNotFoundsHighBound() {
         logger.info("Entering testCountNotFounds");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final int count = gcc.countNotFound();
         // Count does not seem to be deterministic with Google's APIs.
@@ -342,7 +338,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCountNotFoundsFromFileLowBound() {
         logger.info("Entering testCountNotFounds");
-        testFixture.clearRepository();
         final InputStream fis = getTestFileAsStream();
         loader.load(fis);
         final int count = gcc.countNotFound();
@@ -356,7 +351,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testCountNotFoundsFromFileHighBound() {
         logger.info("Entering testCountNotFounds");
-        testFixture.clearRepository();
         final InputStream fis = getTestFileAsStream();
         loader.load(fis);
         final int count = gcc.countNotFound();
@@ -391,7 +385,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testSize() {
         logger.info("Entering testSize");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final int expected = 19;
         assertEquals("Should match known table size of 19",
@@ -403,7 +396,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testSizeFromResource() {
         logger.info("Entering testSizeFromFile");
-        testFixture.clearRepository();
         final InputStream fis = getTestFileAsStream();
         loader.load(fis);
         final int expected = 19;
@@ -416,7 +408,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testSizeLoadFileError() {
         logger.info("Entering testSizeFromFile");
-        testFixture.clearRepository();
         loader.load(dummyFileName);
         final int expected = 0;
         assertEquals(
@@ -429,7 +420,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testDump() {
         logger.info("Entering testDump");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         gcc.dump();
         final int expected = 19;
@@ -442,7 +432,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testDumpFromFile() {
         logger.info("Entering testDumpFile");
-        testFixture.clearRepository();
         final InputStream fis = getTestFileAsStream();
         loader.load(fis);
         gcc.dump();
@@ -456,7 +445,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testAllKeysSize() {
         logger.info("Entering testAllKeysSize");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final int expected = 19;
         assertEquals("Should match known table size of 19",
@@ -468,7 +456,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testAllKeys() {
         logger.info("Entering testAllKeys");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         assertTrue("Should contain search string",
                 gcc.allKeys().contains("America"));
@@ -479,7 +466,6 @@ public final class GeoCodeMongoTest {
     @Test
     public void testDelete() {
         logger.info("Entering testDelete");
-        testFixture.clearRepository();
         testFixture.loadTestAddresses();
         final GeoCodeItem gci = gcc.find("America");
         gcc.delete(gci);
@@ -490,7 +476,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddGet() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("America");
         gcc.add(input);
         final GeoCodeItem output = gcc.get("America");
@@ -500,7 +485,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFind() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("America");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("America");
@@ -510,7 +494,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFindWithModern() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("America", "America");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("America", "America");
@@ -520,7 +503,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFindChangeModernResultsPresent() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "America");
@@ -532,7 +514,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFindChangeModernNamesMatch() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "America");
@@ -543,7 +524,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFindChangeModernToBogusResultsPresent() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "PLUGH");
@@ -555,7 +535,6 @@ public final class GeoCodeMongoTest {
     /** */
     @Test
     public void testAddFindChangeModernToBogusNamesMatch() {
-        testFixture.clearRepository();
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "PLUGH");

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
@@ -37,7 +37,7 @@ import com.google.maps.model.LatLng;
  *
  * @author Dick Schoeller
  */
-@SuppressWarnings({ "PMD.CommentSize", "PMD.TooManyStaticImports" })
+@SuppressWarnings({ "PMD.CommentSize", "PMD.GodClass", "PMD.TooManyStaticImports" })
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = MongoTestConfiguration.class)
 public final class GeoCodeMongoTest {

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoTest.java
@@ -37,7 +37,8 @@ import com.google.maps.model.LatLng;
  *
  * @author Dick Schoeller
  */
-@SuppressWarnings({ "PMD.CommentSize", "PMD.GodClass", "PMD.TooManyStaticImports" })
+@SuppressWarnings({ "PMD.CommentSize", "PMD.GodClass",
+    "PMD.TooManyStaticImports" })
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = MongoTestConfiguration.class)
 public final class GeoCodeMongoTest {

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoRepositoryFixture.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoRepositoryFixture.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import org.schoellerfamily.geoservice.persistence.fixture.GeoCodeTestFixture;
 import org.schoellerfamily.geoservice.persistence.mongo.repository.GeoDocumentRepositoryMongo;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.mongodb.core.MongoTemplate;
 
 /**
  * Test fixture for the MongoDB tests. Extends the standard fixture a little.
@@ -15,6 +16,10 @@ public final class GeoRepositoryFixture extends GeoCodeTestFixture {
     /** */
     @Autowired
     private transient GeoDocumentRepositoryMongo geoDocumentRepository;
+
+    /** */
+    @Autowired
+    private transient MongoTemplate mongoTemplate;
 
     /**
      * This is private because this is a singleton.
@@ -29,7 +34,7 @@ public final class GeoRepositoryFixture extends GeoCodeTestFixture {
      * @throws IOException if there is a problem reading the file
      */
     public void loadRepository() throws IOException {
-        clearRepository();
+        geoDocumentRepository.deleteAll();
         // TODO put in a loader
     }
 
@@ -38,5 +43,6 @@ public final class GeoRepositoryFixture extends GeoCodeTestFixture {
      */
     public void clearRepository() {
         geoDocumentRepository.deleteAll();
+        mongoTemplate.getDb().dropDatabase();
     }
 }

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/MongoTestConfiguration.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/MongoTestConfiguration.java
@@ -1,6 +1,7 @@
 package org.schoellerfamily.geoservice.persistence.mongo.test;
 
 import java.net.UnknownHostException;
+import java.util.UUID;
 
 import org.schoellerfamily.geoservice.geocoder.GeoCoder;
 import org.schoellerfamily.geoservice.geocoder.StubGeoCoder;
@@ -68,8 +69,10 @@ public class MongoTestConfiguration {
      */
     @Bean
     public MongoDbFactory mongoDbFactory() throws UnknownHostException {
+        final String databaseName =
+                "geoserviceTest_" + UUID.randomUUID().toString();
         return new SimpleMongoDbFactory(
-                new MongoClient(host, port), "geoserviceTest");
+                new MongoClient(host, port), databaseName);
     }
 
     /**


### PR DESCRIPTION
There were 2 problems with test databases:
1. All tests executions were using the same database name
2. No one was cleaning up the database on exit

I have fixed both of those behaviors. The test database names
now always contain a UUID string. And clean up happens much
more consistently.