### PR TITLE
Fixes #232 - add bean annotation to checkstyle

### DIFF
--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -72,7 +72,7 @@ Allow field shadowing with constructor and setter arguments
     <module name="SimplifyBooleanReturn"/>
     <module name="DesignForExtension">
       <!-- disable until codeclimate gets 7.2 or better -->
-      <!-- property name="ignoredAnnotations" value="Test, Before, After, BeforeClass, AfterClass, Bean"/ -->
+      <property name="ignoredAnnotations" value="Test, Before, After, BeforeClass, AfterClass, Bean"/>
     </module>
     <module name="FinalClass"/>
     <module name="HideUtilityClassConstructor"/>

--- a/gedbrowser-dao/pom.xml
+++ b/gedbrowser-dao/pom.xml
@@ -56,7 +56,7 @@
   </reporting>
   <build>
     <plugins>
-      <plugin> 
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>

--- a/gedbrowser-mongo-dao/pom.xml
+++ b/gedbrowser-mongo-dao/pom.xml
@@ -56,7 +56,7 @@
   </reporting>
   <build>
     <plugins>
-      <plugin> 
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>

--- a/geoservice-persistence/pom.xml
+++ b/geoservice-persistence/pom.xml
@@ -56,7 +56,7 @@
   </reporting>
   <build>
     <plugins>
-      <plugin> 
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-compiler-plugin</artifactId>
       </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -70,7 +70,7 @@
 
     <pmd-version>5.5.4</pmd-version>
     <checkstyle-version>7.6</checkstyle-version>
-    
+
     <config-dir>${project.basedir}/config</config-dir>
   </properties>
 


### PR DESCRIPTION
Bean methods may not be final nor may their class. The new version
of checkstyle allows you to add them to the methods that are omitted
from design for extension check.