### PR TITLE
Fixes #251 - divide up person renderer

### DIFF
--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ParentsRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ParentsRenderer.java
@@ -1,0 +1,165 @@
+package org.schoellerfamily.gedbrowser.renderer;
+
+import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.datamodel.Person;
+import org.schoellerfamily.gedbrowser.datamodel.navigator.PersonNavigator;
+
+/**
+ * @author Dick Schoeller
+ */
+public class ParentsRenderer {
+    /** */
+    private final PersonRenderer personRenderer;
+
+    /** */
+    private final PersonNavigator navigator;
+
+    /**
+     * Constructor.
+     *
+     * @param personRenderer the containing renderer
+     */
+    public ParentsRenderer(final PersonRenderer personRenderer) {
+        this.personRenderer = personRenderer;
+        navigator = new PersonNavigator(personRenderer.getGedObject());
+    }
+
+    /**
+     * This method is public for testing purposes only. Do not try to call it
+     * outside of the context of the rendering engine.
+     *
+     * @param builder Buffer for holding the rendition
+     * @param pad Minimum number spaces for padding each line of the output
+     * @param father Father
+     */
+    public void renderFather(final StringBuilder builder,
+            final int pad, final Person father) {
+        renderParent(builder, pad, father, "Father");
+    }
+
+    /**
+     * This method is public for testing purposes only. Do not try to call it
+     * outside of the context of the rendering engine.
+     *
+     * @param builder Buffer for holding the rendition
+     * @param pad Minimum number spaces for padding each line of the output
+     * @param mother Mother
+     */
+    public void renderMother(final StringBuilder builder,
+            final int pad, final Person mother) {
+        renderParent(builder, pad, mother, "Mother");
+    }
+
+    /**
+     * @param builder Buffer for holding the rendition
+     * @param pad Minimum number spaces for padding each line of the output
+     * @param parent The parent being rendered
+     * @param parentLabel The string containing the parent type
+     */
+    private void renderParent(final StringBuilder builder,
+            final int pad, final Person parent, final String parentLabel) {
+        if (parent != null) {
+            final String parentHtml = createGedRenderer(parent).getNameHtml();
+            renderParent(builder, pad, parentHtml, parentLabel);
+        }
+    }
+
+    /**
+     * @param builder Buffer for holding the rendition
+     * @param pad Minimum number spaces for padding each line of the output
+     * @param parentHtml The parent being rendered
+     * @param parentLabel The string containing the parent type
+     */
+    private void renderParent(final StringBuilder builder,
+            final int pad, final String parentHtml, final String parentLabel) {
+        if (!parentHtml.isEmpty() && (isConfidential() || isHiddenLiving())) {
+            return;
+        }
+        GedRenderer.renderPad(builder, pad, true);
+        builder.append("<p class=\"parent\">");
+
+        GedRenderer.renderPad(builder, pad, true);
+        builder.append(
+                " <span class=\"parent label\">" + parentLabel
+                + ":</span> ").append(
+                        parentHtml);
+
+        GedRenderer.renderPad(builder, pad, true);
+        builder.append("</p>");
+    }
+
+    /**
+     * @return the father string.
+     */
+    public String getFatherRendition() {
+        final StringBuilder builder = new StringBuilder();
+        final Person father = navigator.getFather();
+        if (father != null) {
+            renderParent(builder, 0,
+                    createGedRenderer(father).getNameHtml(), "Father");
+        }
+        return builder.toString();
+    }
+
+    /**
+     * @return the mother string
+     */
+    public String getMotherRendition() {
+        final StringBuilder builder = new StringBuilder();
+        final Person mother = navigator.getMother();
+        if (mother != null) {
+            renderParent(builder, 0,
+                    createGedRenderer(mother).getNameHtml(), "Mother");
+        }
+        return builder.toString();
+    }
+
+    /**
+     * @return the HTML string format of the father's name.
+     */
+    public String getFatherNameHtml() {
+        if (isConfidential()) {
+            return "";
+        }
+        if (isHiddenLiving()) {
+            return "";
+        }
+        return createGedRenderer(navigator.getFather()).getNameHtml();
+    }
+
+    /**
+     * @return the HTML string format of the mother's name.
+     */
+    public String getMotherNameHtml() {
+        if (isConfidential()) {
+            return "";
+        }
+        if (isHiddenLiving()) {
+            return "";
+        }
+        return createGedRenderer(navigator.getMother()).getNameHtml();
+    }
+
+    /**
+     * @param parent the parent that we are creating a renderer for
+     * @return the renderer
+     */
+    private GedRenderer<? extends GedObject> createGedRenderer(
+            final Person parent) {
+        return personRenderer.createGedRenderer(parent);
+    }
+
+    /**
+     * @return true if the person is hidden because confidential
+     */
+    private boolean isConfidential() {
+        return personRenderer.isConfidential();
+    }
+
+    /**
+     * @return true if the person is hidden because living
+     */
+    private boolean isHiddenLiving() {
+        return personRenderer.isHiddenLiving();
+    }
+}

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
@@ -19,7 +19,6 @@ import org.schoellerfamily.gedbrowser.datamodel.visitor.PersonVisitor;
  *
  * @author Dick Schoeller
  */
-@SuppressWarnings({ "PMD.GodClass" })
 public final class PersonRenderer extends GedRenderer<Person> {
     /**
      * Number of generations, including the root when rendering the tree.
@@ -33,6 +32,9 @@ public final class PersonRenderer extends GedRenderer<Person> {
 
     /** */
     private final PersonNavigator navigator;
+
+    /** */
+    private final ParentsRenderer parentsRenderer;
 
     /**
      * @param gedObject the Person that we are going to render
@@ -51,70 +53,16 @@ public final class PersonRenderer extends GedRenderer<Person> {
         setAttributeListOpenRenderer(new PersonAttributeListOpenRenderer());
         le = new LivingEstimator(gedObject, provider);
         navigator = new PersonNavigator(gedObject);
+        parentsRenderer = new ParentsRenderer(this);
     }
 
     /**
-     * This method is public for testing purposes only. Do not try to call it
-     * outside of the context of the rendering engine.
+     * Get the renderer responsible for rendering the parents of this person.
      *
-     * @param builder Buffer for holding the rendition
-     * @param pad Minimum number spaces for padding each line of the output
-     * @param father Father
+     * @return the parents renderer
      */
-    public void renderFather(final StringBuilder builder,
-            final int pad, final Person father) {
-        renderParent(builder, pad, father, "Father");
-    }
-
-    /**
-     * This method is public for testing purposes only. Do not try to call it
-     * outside of the context of the rendering engine.
-     *
-     * @param builder Buffer for holding the rendition
-     * @param pad Minimum number spaces for padding each line of the output
-     * @param mother Mother
-     */
-    public void renderMother(final StringBuilder builder,
-            final int pad, final Person mother) {
-        renderParent(builder, pad, mother, "Mother");
-    }
-
-    /**
-     * @param builder Buffer for holding the rendition
-     * @param pad Minimum number spaces for padding each line of the output
-     * @param parent The parent being rendered
-     * @param parentLabel The string containing the parent type
-     */
-    private void renderParent(final StringBuilder builder,
-            final int pad, final Person parent, final String parentLabel) {
-        if (parent != null) {
-            final String parentHtml = createGedRenderer(parent).getNameHtml();
-            renderParent(builder, pad, parentHtml, parentLabel);
-        }
-    }
-
-    /**
-     * @param builder Buffer for holding the rendition
-     * @param pad Minimum number spaces for padding each line of the output
-     * @param parentHtml The parent being rendered
-     * @param parentLabel The string containing the parent type
-     */
-    private void renderParent(final StringBuilder builder,
-            final int pad, final String parentHtml, final String parentLabel) {
-        if (!parentHtml.isEmpty() && (isConfidential() || isHiddenLiving())) {
-            return;
-        }
-        renderPad(builder, pad, true);
-        builder.append("<p class=\"parent\">");
-
-        renderPad(builder, pad, true);
-        builder.append(
-                " <span class=\"parent label\">" + parentLabel
-                + ":</span> ").append(
-                        parentHtml);
-
-        renderPad(builder, pad, true);
-        builder.append("</p>");
+    public ParentsRenderer getParents() {
+        return parentsRenderer;
     }
 
     /**
@@ -180,58 +128,6 @@ public final class PersonRenderer extends GedRenderer<Person> {
         }
 
         return builder.toString();
-    }
-
-    /**
-     * @return the father string.
-     */
-    public String getFatherRendition() {
-        final StringBuilder builder = new StringBuilder();
-        final Person father = navigator.getFather();
-        if (father != null) {
-            renderParent(builder, 0, createGedRenderer(father).getNameHtml(),
-                    "Father");
-        }
-        return builder.toString();
-    }
-
-    /**
-     * @return the mother string
-     */
-    public String getMotherRendition() {
-        final StringBuilder builder = new StringBuilder();
-        final Person mother = navigator.getMother();
-        if (mother != null) {
-            renderParent(builder, 0, createGedRenderer(mother).getNameHtml(),
-                    "Mother");
-        }
-        return builder.toString();
-    }
-
-    /**
-     * @return the HTML string format of the father's name.
-     */
-    public String getFatherNameHtml() {
-        if (isConfidential()) {
-            return "";
-        }
-        if (isHiddenLiving()) {
-            return "";
-        }
-        return createGedRenderer(navigator.getFather()).getNameHtml();
-    }
-
-    /**
-     * @return the HTML string format of the mother's name.
-     */
-    public String getMotherNameHtml() {
-        if (isConfidential()) {
-            return "";
-        }
-        if (isHiddenLiving()) {
-            return "";
-        }
-        return createGedRenderer(navigator.getMother()).getNameHtml();
     }
 
     /**

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/AnonymousPersonRendererTest.java
@@ -474,7 +474,7 @@ public final class AnonymousPersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
-        personRenderer.renderFather(builder, 2, null);
+        personRenderer.getParents().renderFather(builder, 2, null);
         final String actual = builder.toString();
         assertTrue("Expected empty string", actual.isEmpty());
     }
@@ -491,7 +491,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderFather(builder, 2, navigator.getFather());
+        personRenderer.getParents().renderFather(
+                builder, 2, navigator.getFather());
         final String expected = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Father:</span> \n"
@@ -511,7 +512,7 @@ public final class AnonymousPersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
-        personRenderer.renderMother(builder, 2, null);
+        personRenderer.getParents().renderMother(builder, 2, null);
         final String actual = builder.toString();
         assertTrue("Expected empty string", actual.isEmpty());
     }
@@ -527,7 +528,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderFather(builder, 2, navigator.getFather());
+        personRenderer.getParents().renderFather(
+                builder, 2, navigator.getFather());
         final String actual = builder.toString();
         assertTrue("Expected empty string", actual.isEmpty());
     }
@@ -544,7 +546,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(
+                builder, 2, navigator.getMother());
         final String expected = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Mother:</span> \n"
@@ -565,7 +568,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(sabino);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(
+                builder, 2, navigator.getMother());
         final String expected = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Mother:</span> \n"
@@ -585,7 +589,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(
+                builder, 2, navigator.getMother());
         final String actual = builder.toString();
         assertTrue("Expected empty string", actual.isEmpty());
     }
@@ -664,7 +669,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I1");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getFatherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getFatherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -677,7 +683,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I5266");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getFatherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getFatherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -690,7 +697,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I5");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getFatherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getFatherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -703,7 +711,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I9");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getFatherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getFatherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -716,7 +725,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I1");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getMotherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getMotherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -729,7 +739,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I5266");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getMotherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getMotherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -742,7 +753,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I5");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getMotherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getMotherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -755,7 +767,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I9");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getMotherNameHtml();
+        final String actual = personRenderer.getParents()
+                .getMotherNameHtml();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -768,7 +781,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I1");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getFatherRendition();
+        final String actual = personRenderer.getParents()
+                .getFatherRendition();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -783,7 +797,8 @@ public final class AnonymousPersonRendererTest {
                 new GedRendererFactory(), anonymousContext, provider);
         final String expected = "\n<p class=\"parent\">\n <span class=\"par"
                 + "ent label\">Father:</span> \n</p>";
-        final String actual = personRenderer.getFatherRendition();
+        final String actual = personRenderer.getParents()
+                .getFatherRendition();
         assertEquals("Mismatched rendered string",
                 expected,
                 actual);
@@ -798,7 +813,8 @@ public final class AnonymousPersonRendererTest {
         final Person melissa = (Person) root.find("I1");
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), anonymousContext, provider);
-        final String actual = personRenderer.getMotherRendition();
+        final String actual = personRenderer.getParents()
+                .getMotherRendition();
         assertTrue("Expected empty string", actual.isEmpty());
     }
 
@@ -814,7 +830,8 @@ public final class AnonymousPersonRendererTest {
         final String expected = "\n<p class=\"parent\">\n"
                 + " <span class=\"parent label\">Mother:"
                 + "</span> \n</p>";
-        final String actual = personRenderer.getMotherRendition();
+        final String actual = personRenderer.getParents()
+                .getMotherRendition();
         assertEquals("Mismatched rendered string", expected, actual);
     }
 

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/PersonRendererTest.java
@@ -655,7 +655,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
-        personRenderer.renderFather(builder, 2, null);
+        personRenderer.getParents().renderFather(builder, 2, null);
         assertEquals("Expected empty string", "", builder.toString());
     }
 
@@ -671,7 +671,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderFather(builder, 2, navigator.getFather());
+        personRenderer.getParents().renderFather(builder, 2,
+                navigator.getFather());
         final String ts1 = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Father:</span> \n"
@@ -691,7 +692,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
-        personRenderer.renderMother(builder, 2, null);
+        personRenderer.getParents().renderMother(builder, 2, null);
         assertEquals("Expected empty string", "", builder.toString());
     }
 
@@ -706,7 +707,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderFather(builder, 2, navigator.getFather());
+        personRenderer.getParents().renderFather(builder, 2,
+                navigator.getFather());
         final String ts1 = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Father:</span> "
@@ -731,7 +733,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(builder, 2,
+                navigator.getMother());
         final String ts1 = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Mother:</span> \n"
@@ -752,7 +755,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), adminContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(sabino);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(builder, 2,
+                navigator.getMother());
         final String ts1 = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Mother:</span> \n"
@@ -773,7 +777,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(sabino);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(builder, 2,
+                navigator.getMother());
         final String expected = "\n"
                 + "  <p class=\"parent\">\n"
                 + "   <span class=\"parent label\">Mother:</span> \n"
@@ -794,7 +799,8 @@ public final class PersonRendererTest {
                 new GedRendererFactory(), userContext, provider);
         final StringBuilder builder = new StringBuilder();
         final PersonNavigator navigator = new PersonNavigator(melissa);
-        personRenderer.renderMother(builder, 2, navigator.getMother());
+        personRenderer.getParents().renderMother(builder, 2,
+                navigator.getMother());
         final String ts1 = "\n"
                 + START_PARENT
                 + "   <span class=\"parent label\">Mother:</span> "
@@ -916,7 +922,7 @@ public final class PersonRendererTest {
                 + "Richard John"
                 + " <span class=\"surname\">Schoeller</span>"
                 + " (1958-) [I2]</a>",
-                personRenderer.getFatherNameHtml());
+                personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -933,7 +939,7 @@ public final class PersonRendererTest {
                 "<a href=\"person?db=null&amp;id=I4248\" class=\"name\">"
                 + "Sabino"
                 + " <span class=\"surname\">Figliuolo</span> [I4248]</a>",
-                personRenderer.getFatherNameHtml());
+                personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -946,7 +952,8 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Rendered html doesn't match expectation",
-                "Confidential", personRenderer.getFatherNameHtml());
+                "Confidential",
+                personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -964,7 +971,7 @@ public final class PersonRendererTest {
                 + "John Vincent"
                 + " <span class=\"surname\">Schoeller</span>"
                 + " (1934-) [I4]</a>",
-                personRenderer.getFatherNameHtml());
+                personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -977,7 +984,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Expected empty string",
-                "", personRenderer.getFatherNameHtml());
+                "", personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -990,7 +997,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Expected empty string",
-                "", personRenderer.getFatherNameHtml());
+                "", personRenderer.getParents().getFatherNameHtml());
     }
 
     /**
@@ -1007,7 +1014,7 @@ public final class PersonRendererTest {
                 + "Lisa Hope"
                 + " <span class=\"surname\">Robinson</span>"
                 + " (1960-) [I3]</a>",
-                personRenderer.getMotherNameHtml());
+                personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1025,7 +1032,7 @@ public final class PersonRendererTest {
                 + "Vivian Grace"
                 + " <span class=\"surname\">Schoeller</span>"
                 + " (1960-) [I5]</a>",
-                personRenderer.getMotherNameHtml());
+                personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1038,7 +1045,8 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Rendered html doesn't match expectation",
-                "Confidential", personRenderer.getMotherNameHtml());
+                "Confidential",
+                personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1056,7 +1064,7 @@ public final class PersonRendererTest {
                 + "Patricia Ruth"
                 + " <span class=\"surname\">Hayes</span>"
                 + " (1937-) [I6]</a>",
-                personRenderer.getMotherNameHtml());
+                personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1069,7 +1077,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Expected empty string",
-                "", personRenderer.getMotherNameHtml());
+                "", personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1082,7 +1090,7 @@ public final class PersonRendererTest {
         final PersonRenderer personRenderer = new PersonRenderer(melissa,
                 new GedRendererFactory(), userContext, provider);
         assertEquals("Expected empty string",
-                "", personRenderer.getMotherNameHtml());
+                "", personRenderer.getParents().getMotherNameHtml());
     }
 
     /**
@@ -1099,7 +1107,7 @@ public final class PersonRendererTest {
                 + "</span> <a href=\"person?db=null&amp;id=I2\" class=\"name\">"
                 + "Richard John <span class=\"surname\">Schoeller</span>"
                 + " (1958-) [I2]</a>\n</p>",
-                personRenderer.getFatherRendition());
+                personRenderer.getParents().getFatherRendition());
     }
 
     /**
@@ -1114,7 +1122,7 @@ public final class PersonRendererTest {
         assertEquals("Rendered html doesn't match expectation",
                 "\n<p class=\"parent\">\n <span class=\"parent label\">Father:"
                 + "</span> \n</p>",
-                personRenderer.getFatherRendition());
+                personRenderer.getParents().getFatherRendition());
     }
 
     /**
@@ -1131,7 +1139,7 @@ public final class PersonRendererTest {
                 + "</span> <a href=\"person?db=null&amp;id=I3\" class=\"name\">"
                 + "Lisa Hope <span class=\"surname\">Robinson</span>"
                 + " (1960-) [I3]</a>\n</p>",
-                personRenderer.getMotherRendition());
+                personRenderer.getParents().getMotherRendition());
     }
 
     /**
@@ -1146,7 +1154,7 @@ public final class PersonRendererTest {
         assertEquals("Rendered html doesn't match expectation",
                 "\n<p class=\"parent\">\n <span class=\"parent label\">Mother:"
                 + "</span> \n</p>",
-                personRenderer.getMotherRendition());
+                personRenderer.getParents().getMotherRendition());
     }
 
     /**

--- a/gedbrowser/src/main/resources/templates/person.html
+++ b/gedbrowser/src/main/resources/templates/person.html
@@ -63,15 +63,15 @@
 
     <div id="map_container" th:if="${showMap}"></div>
 
-    <p class="parent" th:if="${not person.fatherNameHtml.isEmpty()}">
+    <p class="parent" th:if="${not person.parents.fatherNameHtml.isEmpty()}">
         <span class="parent label">Father:</span>
         <!-- FIXME utext is necessary because all nameHtml variants contain HTML formatting -->
-        <span id="father" th:utext="${person.fatherNameHtml}">Joe Doe</span>
+        <span id="father" th:utext="${person.parents.fatherNameHtml}">Joe Doe</span>
     </p>
-    <p class="parent" th:if="${not person.motherNameHtml.isEmpty()}">
+    <p class="parent" th:if="${not person.parents.motherNameHtml.isEmpty()}">
         <span class="parent label">Mother:</span>
         <!-- FIXME utext is necessary because all nameHtml variants contain HTML formatting -->
-        <span id="mother" th:utext="${person.motherNameHtml}">Rhonda Roe</span>
+        <span id="mother" th:utext="${person.parents.motherNameHtml}">Rhonda Roe</span>
     </p>
 
     <div th:each="family,iterStat : ${person.families}" class="family">


### PR DESCRIPTION
Moved functions for rendering parent information into a helper
class. This divides up the functionality and should reduce some
quality warnings.