### PR TITLE
Fixes #281 - selenium tests try to talk to sauce

### DIFF
--- a/gedbrowser/pom.xml
+++ b/gedbrowser/pom.xml
@@ -44,7 +44,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.3.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/GedBrowserBasicIT.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/GedBrowserBasicIT.java
@@ -12,6 +12,7 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
+import org.junit.rules.TestWatcher;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 import org.openqa.selenium.remote.RemoteWebDriver;
@@ -21,9 +22,7 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
-import com.saucelabs.common.SauceOnDemandAuthentication;
 import com.saucelabs.common.SauceOnDemandSessionIdProvider;
-import com.saucelabs.junit.SauceOnDemandTestWatcher;
 
 /**
  * @author Dick Schoeller
@@ -55,33 +54,31 @@ public final class GedBrowserBasicIT implements SauceOnDemandSessionIdProvider {
     private PageWaiter waiter;
 
     /** */
+    private RemoteWebDriver driver;
+
+    /** */
     private SessionId sessionId;
 
     /**
-     * Constructs a {@link SauceOnDemandAuthentication} instance using the
-     * supplied user name/access key. To use the authentication supplied by
-     * environment variables or from an external file, use the no-arg
-     * {@link SauceOnDemandAuthentication} constructor.
+     * The factory that creates the appropriate test watcher based on current
+     * environment.
      */
-    private final SauceOnDemandAuthentication authentication =
-            new SauceOnDemandAuthentication(
-                    System.getenv("SAUCE_USERNAME"),
-                    System.getenv("SAUCE_ACCESS_KEY"));
+    private final TestWatcherFactory watcherFactory =
+            new SauceOnDemandWatcherFactory(this);
 
     /**
-     * JUnit Rule which will mark the Sauce Job as passed/failed when the test
-     * succeeds or fails.
+     * JUnit Rule which will watch test results. Depending on the environment,
+     * this could be watcher that marks the Sauce Job as passed/failed when the
+     * test completes.
      */
     @Rule
-    public SauceOnDemandTestWatcher resultReportingTestWatcher =
-        new SauceOnDemandTestWatcher(this, authentication);
+    public TestWatcher testWatcher = watcherFactory.createTestWatcher();
 
-    /** */
+    /**
+     * This rule makes the current test name available to various consumers.
+     */
     @Rule
     public TestName testName = new TestName();
-
-    /** */
-    private RemoteWebDriver driver;
 
     /**
      * {@inheritDoc}
@@ -89,7 +86,9 @@ public final class GedBrowserBasicIT implements SauceOnDemandSessionIdProvider {
     @Override
     public String getSessionId() {
         if (sessionId == null) {
-            logger.warn("SessionId is null");
+            logger.warn("********************** "
+                    + "SESSION ID IS NULL"
+                    + " *********************");
             return "";
         }
         return sessionId.toString();

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/SauceOnDemandWatcherFactory.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/SauceOnDemandWatcherFactory.java
@@ -1,0 +1,59 @@
+package org.schoellerfamily.gedbrowser.selenium.test;
+
+import org.junit.rules.TestWatcher;
+
+import com.saucelabs.common.SauceOnDemandAuthentication;
+import com.saucelabs.common.SauceOnDemandSessionIdProvider;
+import com.saucelabs.junit.SauceOnDemandTestWatcher;
+
+/**
+ * @author Dick Schoeller
+ */
+public final class SauceOnDemandWatcherFactory implements TestWatcherFactory {
+    /**
+     * The session ID provider. As a rule, this is the current instance of the
+     * test class.
+     */
+    private final SauceOnDemandSessionIdProvider provider;
+
+    /**
+     * @param provider the provider for the session ID.
+     */
+    public SauceOnDemandWatcherFactory(
+            final SauceOnDemandSessionIdProvider provider) {
+        this.provider = provider;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public TestWatcher createTestWatcher() {
+        if (useSauceLabs()) {
+            return new SauceOnDemandTestWatcher(provider, authentication());
+        }
+        // Null watcher as a fallback
+        return new TestWatcher() {
+        };
+    }
+
+    /**
+     * @return true if SAUCE_USERNAME is defined in the environment
+     */
+    private boolean useSauceLabs() {
+        return System.getenv("SAUCE_USERNAME") != null;
+    }
+
+    /**
+     * Constructs a {@link SauceOnDemandAuthentication} instance using the
+     * supplied user name/access key. To use the authentication supplied by
+     * environment variables or from an external file, use the no-arg
+     * {@link SauceOnDemandAuthentication} constructor.
+     *
+     * @return the created authentication
+     */
+    private SauceOnDemandAuthentication authentication() {
+        return new SauceOnDemandAuthentication(System.getenv("SAUCE_USERNAME"),
+                System.getenv("SAUCE_ACCESS_KEY"));
+    }
+}

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/TestWatcherFactory.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/TestWatcherFactory.java
@@ -1,0 +1,13 @@
+package org.schoellerfamily.gedbrowser.selenium.test;
+
+import org.junit.rules.TestWatcher;
+
+/**
+ * @author Dick Schoeller
+ */
+public interface TestWatcherFactory {
+    /**
+     * @return a test watcher to report on test status.
+     */
+    TestWatcher createTestWatcher();
+}

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/WebDriverFactory.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/WebDriverFactory.java
@@ -102,7 +102,6 @@ public class WebDriverFactory {
         return capabilities;
     }
 
-
     /**
      * @return true if SAUCE_USERNAME is defined in the environment
      */

--- a/geoservice/pom.xml
+++ b/geoservice/pom.xml
@@ -44,7 +44,7 @@
         <!-- Import dependency management from Spring Boot -->
         <groupId>org.springframework.boot</groupId>
         <artifactId>spring-boot-dependencies</artifactId>
-        <version>${spring-boot.version}</version>
+        <version>1.5.3.RELEASE</version>
         <type>pom</type>
         <scope>import</scope>
       </dependency>


### PR DESCRIPTION
The selenium tests were configured to talk to sauce even when it
was not enabled. Fixed this by tweaking the test watcher creation.