### PR TITLE
Fixes #162 - PMD rules in Maven don't match Eclipse

### DIFF
--- a/.eclipse-pmd
+++ b/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -1,149 +1,4240 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ruleset xmlns="http://pmd.sourceforge.net/ruleset/2.0.0"
-         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-         name="pmd"
-         xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
-    <description>PMD rule set for gedbrowser</description>
-    <!-- basic -->
-    <rule ref="rulesets/java/basic.xml/JumbledIncrementer"/>
-    <rule ref="rulesets/java/basic.xml/ForLoopShouldBeWhileLoop"/>
-    <rule ref="rulesets/java/basic.xml/OverrideBothEqualsAndHashcode"/>
-    <rule ref="rulesets/java/basic.xml/DoubleCheckedLocking"/>
-    <rule ref="rulesets/java/basic.xml/ReturnFromFinallyBlock"/>
-    <rule ref="rulesets/java/basic.xml/UnconditionalIfStatement"/>
-    <rule ref="rulesets/java/basic.xml/BooleanInstantiation"/>
-    <rule ref="rulesets/java/basic.xml/CollapsibleIfStatements"/>
-    <rule ref="rulesets/java/basic.xml/ClassCastExceptionWithToArray"/>
-    <rule ref="rulesets/java/basic.xml/AvoidDecimalLiteralsInBigDecimalConstructor"/>
-    <rule ref="rulesets/java/basic.xml/MisplacedNullCheck"/>
-    <rule ref="rulesets/java/basic.xml/AvoidThreadGroup"/>
-    <rule ref="rulesets/java/basic.xml/BrokenNullCheck"/>
-    <rule ref="rulesets/java/basic.xml/BigIntegerInstantiation"/>
-    <rule ref="rulesets/java/basic.xml/AvoidUsingOctalValues"/>
-    <rule ref="rulesets/java/basic.xml/AvoidUsingHardCodedIP"/>
-    <rule ref="rulesets/java/basic.xml/CheckResultSet"/>
-    <rule ref="rulesets/java/basic.xml/AvoidMultipleUnaryOperators"/>
-    <rule ref="rulesets/java/basic.xml/ExtendsObject"/>
-    <rule ref="rulesets/java/basic.xml/CheckSkipResult"/>
-    <rule ref="rulesets/java/basic.xml/AvoidBranchingStatementAsLastInLoop"/>
-    <rule ref="rulesets/java/basic.xml/DontCallThreadRun"/>
-    <rule ref="rulesets/java/basic.xml/DontUseFloatTypeForLoopIndices"/>
-    <!-- unusedcode -->
-    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateField"/>
-    <rule ref="rulesets/java/unusedcode.xml/UnusedLocalVariable"/>
-    <rule ref="rulesets/java/unusedcode.xml/UnusedPrivateMethod"/>
-    <rule ref="rulesets/java/unusedcode.xml/UnusedFormalParameter"/>
-    <rule ref="rulesets/java/unusedcode.xml/UnusedModifier"/>
-    <!-- imports -->
-    <rule ref="rulesets/java/imports.xml/DuplicateImports"/>
-    <rule ref="rulesets/java/imports.xml/DontImportJavaLang"/>
-    <rule ref="rulesets/java/imports.xml/UnusedImports"/>
-    <rule ref="rulesets/java/imports.xml/ImportFromSamePackage"/>
-    <!-- coupling -->
-    <rule ref="rulesets/java/coupling.xml/CouplingBetweenObjects"/>
-    <rule ref="rulesets/java/coupling.xml/ExcessiveImports"/>
-    <rule ref="rulesets/java/coupling.xml/LooseCoupling"/>
-    <!-- Apparently this next one is broken -->
-    <!-- rule ref="rulesets/java/coupling.xml/LoosePackageCoupling"/ -->
-    <!-- I hate the Law of Demeter check!!! -->
-    <!-- rule ref="rulesets/java/coupling.xml/LawOfDemeter"/ -->
-    <!-- design -->
-    <rule ref="rulesets/java/design.xml/UseUtilityClass"/>
-    <rule ref="rulesets/java/design.xml/SimplifyBooleanReturns"/>
-    <rule ref="rulesets/java/design.xml/SimplifyBooleanExpressions"/>
-    <rule ref="rulesets/java/design.xml/SwitchStmtsShouldHaveDefault"/>
-    <rule ref="rulesets/java/design.xml/AvoidDeeplyNestedIfStmts"/>
-    <rule ref="rulesets/java/design.xml/AvoidReassigningParameters"/>
-    <rule ref="rulesets/java/design.xml/SwitchDensity"/>
-    <rule ref="rulesets/java/design.xml/ConstructorCallsOverridableMethod"/>
-    <rule ref="rulesets/java/design.xml/AccessorClassGeneration"/>
-    <rule ref="rulesets/java/design.xml/FinalFieldCouldBeStatic"/>
-    <rule ref="rulesets/java/design.xml/CloseResource"/>
-    <rule ref="rulesets/java/design.xml/NonStaticInitializer"/>
-    <rule ref="rulesets/java/design.xml/DefaultLabelNotLastInSwitchStmt"/>
-    <rule ref="rulesets/java/design.xml/NonCaseLabelInSwitchStatement"/>
-    <rule ref="rulesets/java/design.xml/OptimizableToArrayCall"/>
-    <rule ref="rulesets/java/design.xml/BadComparison"/>
-    <rule ref="rulesets/java/design.xml/EqualsNull"/>
-    <rule ref="rulesets/java/design.xml/ConfusingTernary"/>
-    <rule ref="rulesets/java/design.xml/InstantiationToGetClass"/>
-    <rule ref="rulesets/java/design.xml/IdempotentOperations"/>
-    <rule ref="rulesets/java/design.xml/ImmutableField"/>
-    <rule ref="rulesets/java/design.xml/UseLocaleWithCaseConversions"/>
-    <rule ref="rulesets/java/design.xml/AvoidProtectedFieldInFinalClass"/>
-    <rule ref="rulesets/java/design.xml/AssignmentToNonFinalStatic"/>
-    <rule ref="rulesets/java/design.xml/MissingStaticMethodInNonInstantiatableClass"/>
-    <rule ref="rulesets/java/design.xml/AvoidSynchronizedAtMethodLevel"/>
-    <rule ref="rulesets/java/design.xml/MissingBreakInSwitch"/>
-    <rule ref="rulesets/java/design.xml/UseNotifyAllInsteadOfNotify"/>
-    <rule ref="rulesets/java/design.xml/AvoidInstanceofChecksInCatchClause"/>
-    <rule ref="rulesets/java/design.xml/AbstractClassWithoutAbstractMethod"/>
-    <rule ref="rulesets/java/design.xml/SimplifyConditional"/>
-    <rule ref="rulesets/java/design.xml/CompareObjectsWithEquals"/>
-    <rule ref="rulesets/java/design.xml/PositionLiteralsFirstInComparisons"/>
-    <rule ref="rulesets/java/design.xml/PositionLiteralsFirstInCaseInsensitiveComparisons"/>
-    <rule ref="rulesets/java/design.xml/UnnecessaryLocalBeforeReturn"/>
-    <rule ref="rulesets/java/design.xml/NonThreadSafeSingleton"/>
-    <rule ref="rulesets/java/design.xml/UncommentedEmptyMethodBody"/>
-    <rule ref="rulesets/java/design.xml/UncommentedEmptyConstructor"/>
-    <rule ref="rulesets/java/design.xml/AvoidConstantsInterface"/>
-    <rule ref="rulesets/java/design.xml/UnsynchronizedStaticDateFormatter"/>
-    <rule ref="rulesets/java/design.xml/PreserveStackTrace"/>
-    <rule ref="rulesets/java/design.xml/UseCollectionIsEmpty"/>
-    <rule ref="rulesets/java/design.xml/ClassWithOnlyPrivateConstructorsShouldBeFinal"/>
-    <rule ref="rulesets/java/design.xml/EmptyMethodInAbstractClassShouldBeAbstract"/>
-    <rule ref="rulesets/java/design.xml/SingularField"/>
-    <rule ref="rulesets/java/design.xml/TooFewBranchesForASwitchStatement"/>
-    <rule ref="rulesets/java/design.xml/LogicInversion"/>
-    <rule ref="rulesets/java/design.xml/UseVarargs"/>
-    <rule ref="rulesets/java/design.xml/FieldDeclarationsShouldBeAtStartOfClass"/>
-    <rule ref="rulesets/java/design.xml/GodClass"/>
-    <rule ref="rulesets/java/design.xml/AvoidProtectedMethodInFinalClassNotExtending"/>
-    <rule ref="rulesets/java/design.xml/ConstantsInInterface"/>
-    <!-- codesize.xml -->
-    <rule ref="rulesets/java/codesize.xml/NPathComplexity"/>
-    <rule ref="rulesets/java/codesize.xml/ExcessiveMethodLength"/>
-    <rule ref="rulesets/java/codesize.xml/ExcessiveParameterList"/>
-    <rule ref="rulesets/java/codesize.xml/ExcessiveClassLength"/>
-    <rule ref="rulesets/java/codesize.xml/CyclomaticComplexity"/>
-    <rule ref="rulesets/java/codesize.xml/StdCyclomaticComplexity"/>
-    <rule ref="rulesets/java/codesize.xml/ModifiedCyclomaticComplexity"/>
-    <rule ref="rulesets/java/codesize.xml/ExcessivePublicCount"/>
-    <rule ref="rulesets/java/codesize.xml/TooManyFields"/>
-    <rule ref="rulesets/java/codesize.xml/NcssMethodCount"/>
-    <rule ref="rulesets/java/codesize.xml/NcssTypeCount"/>
-    <rule ref="rulesets/java/codesize.xml/NcssConstructorCount"/>
-    <!-- comments -->
-    <rule ref="rulesets/java/comments.xml/CommentRequired"/>
-    <rule ref="rulesets/java/comments.xml/CommentSize"/>
-    <rule ref="rulesets/java/comments.xml/CommentContent"/>
-    <!-- junit -->
-    <rule ref="rulesets/java/junit.xml/JUnitStaticSuite"/>
-    <rule ref="rulesets/java/junit.xml/JUnitSpelling"/>
-    <rule ref="rulesets/java/junit.xml/JUnitAssertionsShouldIncludeMessage"/>
-    <rule ref="rulesets/java/junit.xml/JUnitTestsShouldIncludeAssert"/>
-    <rule ref="rulesets/java/junit.xml/TestClassWithoutTestCases"/>
-    <rule ref="rulesets/java/junit.xml/UnnecessaryBooleanAssertion"/>
-    <rule ref="rulesets/java/junit.xml/UseAssertEqualsInsteadOfAssertTrue"/>
-    <rule ref="rulesets/java/junit.xml/UseAssertSameInsteadOfAssertTrue"/>
-    <rule ref="rulesets/java/junit.xml/UseAssertNullInsteadOfAssertTrue"/>
-    <rule ref="rulesets/java/junit.xml/SimplifyBooleanAssertion"/>
-    <rule ref="rulesets/java/junit.xml/JUnitTestContainsTooManyAsserts"/>
-    <rule ref="rulesets/java/junit.xml/UseAssertTrueInsteadOfAssertEquals"/>
-    <!-- optimizations -->
-    <rule ref="rulesets/java/optimizations.xml/LocalVariableCouldBeFinal"/>
-    <rule ref="rulesets/java/optimizations.xml/MethodArgumentCouldBeFinal"/>
-    <rule ref="rulesets/java/optimizations.xml/AvoidInstantiatingObjectsInLoops"/>
-    <rule ref="rulesets/java/optimizations.xml/UseArrayListInsteadOfVector"/>
-    <rule ref="rulesets/java/optimizations.xml/SimplifyStartsWith"/>
-    <rule ref="rulesets/java/optimizations.xml/UseStringBufferForStringAppends"/>
-    <rule ref="rulesets/java/optimizations.xml/UseArraysAsList"/>
-    <rule ref="rulesets/java/optimizations.xml/AvoidArrayLoops"/>
-    <rule ref="rulesets/java/optimizations.xml/UnnecessaryWrapperObjectCreation"/>
-    <rule ref="rulesets/java/optimizations.xml/AddEmptyString"/>
-    <rule ref="rulesets/java/optimizations.xml/RedundantFieldInitializer"/>
-    <rule ref="rulesets/java/optimizations.xml/PrematureDeclaration"/>
-    <!-- sunsecure -->
-    <rule ref="rulesets/java/sunsecure.xml/MethodReturnsInternalArray"/>
-    <rule ref="rulesets/java/sunsecure.xml/ArrayIsStoredDirectly"/>
+	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" name="pmd"
+	xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
+	<description>PMD rule set for gedbrowser</description>
+	<!-- basic -->
+	<rule name="JumbledIncrementer" language="java" since="1.0"
+		message="Avoid modifying an outer loop incrementer in an inner loop for update expression"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#JumbledIncrementer">
+		<description>
+Avoid jumbled loop incrementers - its usually a mistake, and is confusing even if intentional.
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                    <![CDATA[
+//ForStatement
+ [
+  ForUpdate/StatementExpressionList/StatementExpression/PostfixExpression/PrimaryExpression/PrimaryPrefix/Name/@Image
+  =
+  ancestor::ForStatement/ForInit//VariableDeclaratorId/@Image
+ ]
+                    ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+            <![CDATA[
+public class JumbledIncrementerRule1 {
+	public void foo() {
+		for (int i = 0; i < 10; i++) {			// only references 'i'
+			for (int k = 0; k < 20; i++) {		// references both 'i' and 'k'
+				System.out.println("Hello");
+			}
+		}
+	}
+}
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="ForLoopShouldBeWhileLoop" language="java" since="1.02"
+		message="This for loop could be simplified to a while loop" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#ForLoopShouldBeWhileLoop">
+		<description>
+Some for loops can be simplified to while loops, this makes them more concise.
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                    <![CDATA[
+//ForStatement
+ [count(*) > 1]
+ [not(LocalVariableDeclaration)]
+ [not(ForInit)]
+ [not(ForUpdate)]
+ [not(Type and Expression and Statement)]
+                    ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+            <![CDATA[
+public class Foo {
+	void bar() {
+		for (;true;) true; // No Init or Update part, may as well be: while (true)
+	}
+}
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="OverrideBothEqualsAndHashcode" language="java" since="0.4"
+		message="Ensure you override both equals() and hashCode()"
+		class="net.sourceforge.pmd.lang.java.rule.basic.OverrideBothEqualsAndHashcodeRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#OverrideBothEqualsAndHashcode">
+		<description>
+Override both public boolean Object.equals(Object other), and public int Object.hashCode(), or override neither.  Even if you are inheriting a hashCode() from a parent class, consider implementing hashCode and explicitly delegating to your superclass.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Bar {		// poor, missing a hashcode() method
+	public boolean equals(Object o) {
+      // do some comparison
+	}
+}
+
+public class Baz {		// poor, missing an equals() method
+	public int hashCode() {
+      // return some hash value
+	}
+}
+
+public class Foo {		// perfect, both methods provided
+	public boolean equals(Object other) {
+      // do some comparison
+	}
+	public int hashCode() {
+      // return some hash value
+	}
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="DoubleCheckedLocking" language="java" since="1.04"
+		message="Double checked locking is not thread safe in Java."
+		class="net.sourceforge.pmd.lang.java.rule.basic.DoubleCheckedLockingRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#DoubleCheckedLocking">
+		<description>
+Partially created objects can be returned by the Double Checked Locking pattern when used in Java.
+An optimizing JRE may assign a reference to the baz variable before it calls the constructor of the object the
+reference points to.
+
+Note: With Java 5, you can make Double checked locking work, if you declare the variable to be `volatile`.
+
+For more details refer to: http://www.javaworld.com/javaworld/jw-02-2001/jw-0209-double.html
+or http://www.cs.umd.edu/~pugh/java/memoryModel/DoubleCheckedLocking.html
+      </description>
+		<priority>1</priority>
+		<example>
+  <![CDATA[
+public class Foo {
+	/*volatile */ Object baz = null; // fix for Java5 and later: volatile
+	Object bar() {
+		if (baz == null) { // baz may be non-null yet not fully created
+			synchronized(this) {
+				if (baz == null) {
+					baz = new Object();
+        		}
+      		}
+    	}
+		return baz;
+	}
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="ReturnFromFinallyBlock" language="java" since="1.05"
+		message="Avoid returning from a finally block" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#ReturnFromFinallyBlock">
+		<description>
+Avoid returning from a finally block, this can discard exceptions.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//FinallyStatement//ReturnStatement
+]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public class Bar {
+	public String foo() {
+		try {
+			throw new Exception( "My Exception" );
+		} catch (Exception e) {
+			throw e;
+		} finally {
+			return "A. O. K."; // return not recommended here
+		}
+	}
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="UnconditionalIfStatement" language="java" since="1.5"
+		message="Do not use 'if' statements that are always true or always false"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#UnconditionalIfStatement">
+		<description>
+Do not use "if" statements whose conditionals are always true or always false.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+ <![CDATA[
+//IfStatement/Expression
+ [count(PrimaryExpression)=1]
+ /PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
+]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public class Foo {
+	public void close() {
+		if (true) {		// fixed conditional, not recommended
+			// ...
+		}
+	}
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="BooleanInstantiation" since="1.2"
+		message="Avoid instantiating Boolean objects; reference Boolean.TRUE or Boolean.FALSE or call Boolean.valueOf() instead."
+		class="net.sourceforge.pmd.lang.java.rule.basic.BooleanInstantiationRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BooleanInstantiation">
+		<description>
+Avoid instantiating Boolean objects; you can reference Boolean.TRUE, Boolean.FALSE, or call Boolean.valueOf() instead.
+   </description>
+		<priority>2</priority>
+		<example>
+   <![CDATA[
+Boolean bar = new Boolean("true");		// unnecessary creation, just reference Boolean.TRUE;
+Boolean buz = Boolean.valueOf(false);	// ...., just reference Boolean.FALSE;
+   ]]>
+   </example>
+	</rule>
+
+	<rule name="CollapsibleIfStatements" language="java" since="3.1"
+		message="These nested if statements could be combined" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#CollapsibleIfStatements">
+		<description>
+Sometimes two consecutive 'if' statements can be consolidated by separating their conditions with a boolean short-circuit operator.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//IfStatement[@Else='false']/Statement
+ /IfStatement[@Else='false']
+ |
+//IfStatement[@Else='false']/Statement
+ /Block[count(BlockStatement)=1]/BlockStatement
+  /Statement/IfStatement[@Else='false']]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+void bar() {
+	if (x) {			// original implementation
+		if (y) {
+			// do stuff
+		}
+	}
+}
+
+void bar() {
+	if (x && y) {		// optimized implementation
+		// do stuff
+	}
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="ClassCastExceptionWithToArray" language="java" since="3.4"
+		message="This usage of the Collection.toArray() method will throw a ClassCastException."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#ClassCastExceptionWithToArray">
+		<description>
+When deriving an array of a specific class from your Collection, one should provide an array of
+the same class as the parameter of the toArray() method. Doing otherwise you will will result
+in a ClassCastException.
+  </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//CastExpression[Type/ReferenceType/ClassOrInterfaceType[@Image !=
+"Object"]]/PrimaryExpression
+[
+ PrimaryPrefix/Name[ends-with(@Image, '.toArray')]
+ and
+ PrimarySuffix/Arguments[count(*) = 0]
+and
+count(PrimarySuffix) = 1
+]
+]]>
+    </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+Collection c = new ArrayList();
+Integer obj = new Integer(1);
+c.add(obj);
+
+    // this would trigger the rule (and throw a ClassCastException if executed)
+Integer[] a = (Integer [])c.toArray();
+
+   // this is fine and will not trigger the rule
+Integer[] b = (Integer [])c.toArray(new Integer[c.size()]);
+]]>
+  </example>
+	</rule>
+
+
+	<rule name="AvoidDecimalLiteralsInBigDecimalConstructor" language="java"
+		since="3.4"
+		message="Avoid creating BigDecimal with a decimal (float/double) literal. Use a String literal"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidDecimalLiteralsInBigDecimalConstructor">
+		<description>
+One might assume that the result of "new BigDecimal(0.1)" is exactly equal to 0.1, but it is actually
+equal to .1000000000000000055511151231257827021181583404541015625.
+This is because 0.1 cannot be represented exactly as a double (or as a binary fraction of any finite
+length). Thus, the long value that is being passed in to the constructor is not exactly equal to 0.1,
+appearances notwithstanding.
+
+The (String) constructor, on the other hand, is perfectly predictable: 'new BigDecimal("0.1")' is
+exactly equal to 0.1, as one would expect.  Therefore, it is generally recommended that the
+(String) constructor be used in preference to this one.
+  </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//AllocationExpression
+[ClassOrInterfaceType[@Image="BigDecimal"]]
+[Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix
+    [
+        Literal[(not(ends-with(@Image,'"'))) and contains(@Image,".")]
+        or
+        Name[ancestor::Block/BlockStatement/LocalVariableDeclaration
+                [Type[PrimitiveType[@Image='double' or @Image='float']
+                      or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
+                /VariableDeclarator/VariableDeclaratorId/@Image = @Image
+            ]
+        or
+        Name[ancestor::MethodDeclaration/MethodDeclarator/FormalParameters/FormalParameter
+                [Type[PrimitiveType[@Image='double' or @Image='float']
+                      or ReferenceType/ClassOrInterfaceType[@Image='Double' or @Image='Float']]]
+                /VariableDeclaratorId/@Image = @Image
+            ]
+    ]
+]
+ ]]>
+    </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+BigDecimal bd = new BigDecimal(1.123);		// loss of precision, this would trigger the rule
+
+BigDecimal bd = new BigDecimal("1.123");   	// preferred approach
+
+BigDecimal bd = new BigDecimal(12);     	// preferred approach, ok for integer values
+]]>
+  </example>
+	</rule>
+
+
+	<rule name="MisplacedNullCheck" language="java" since="3.5"
+		message="The null check here is misplaced; if the variable is null there will be a NullPointerException"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#MisplacedNullCheck">
+		<description>
+The null check here is misplaced. If the variable is null a NullPointerException will be thrown.
+Either the check is useless (the variable will never be "null") or it is incorrect.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//Expression
+    /*[self::ConditionalOrExpression or self::ConditionalAndExpression]
+    /descendant::PrimaryExpression/PrimaryPrefix
+    /Name[starts-with(@Image,
+        concat(ancestor::PrimaryExpression/following-sibling::EqualityExpression
+            [./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+            /PrimaryExpression/PrimaryPrefix
+            /Name[count(../../PrimarySuffix)=0]/@Image,".")
+        )
+     ]
+     [count(ancestor::ConditionalAndExpression/EqualityExpression
+            [@Image='!=']
+            [./PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+            [starts-with(following-sibling::*/PrimaryExpression/PrimaryPrefix/Name/@Image,
+                concat(./PrimaryExpression/PrimaryPrefix/Name/@Image, '.'))]
+      ) = 0
+     ]
+    ]]>
+        </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public class Foo {
+	void bar() {
+		if (a.equals(baz) && a != null) {}
+		}
+}
+    ]]>
+      </example>
+		<example><![CDATA[
+public class Foo {
+	void bar() {
+		if (a.equals(baz) || a == null) {}
+	}
+}
+   ]]></example>
+	</rule>
+
+
+	<rule name="AvoidThreadGroup" language="java" since="3.6"
+		message="Avoid using java.lang.ThreadGroup; it is not thread safe"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidThreadGroup"
+		typeResolution="true">
+		<description>
+Avoid using java.lang.ThreadGroup; although it is intended to be used in a threaded environment
+it contains methods that are not thread-safe.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//AllocationExpression/ClassOrInterfaceType[pmd-java:typeof(@Image, 'java.lang.ThreadGroup')]|
+//PrimarySuffix[contains(@Image, 'getThreadGroup')]
+]]>
+        </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public class Bar {
+	void buz() {
+		ThreadGroup tg = new ThreadGroup("My threadgroup") ;
+		tg = new ThreadGroup(tg, "my thread group");
+		tg = Thread.currentThread().getThreadGroup();
+		tg = System.getSecurityManager().getThreadGroup();
+	}
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="BrokenNullCheck" since="3.8"
+		message="Method call on object which may be null" class="net.sourceforge.pmd.lang.java.rule.basic.BrokenNullCheckRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BrokenNullCheck">
+		<description>
+The null check is broken since it will throw a NullPointerException itself.
+It is likely that you used || instead of &amp;&amp; or vice versa.
+     </description>
+		<priority>2</priority>
+		<example>
+<![CDATA[
+public String bar(String string) {
+  // should be &&
+	if (string!=null || !string.equals(""))
+		return string;
+  // should be ||
+	if (string==null && string.equals(""))
+		return string;
+}
+        ]]>
+        </example>
+	</rule>
+
+	<rule name="BigIntegerInstantiation" since="3.9"
+		message="Don't create instances of already existing BigInteger and BigDecimal (ZERO, ONE, TEN)"
+		class="net.sourceforge.pmd.lang.java.rule.basic.BigIntegerInstantiationRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#BigIntegerInstantiation">
+		<description>
+Don't create instances of already existing BigInteger (BigInteger.ZERO, BigInteger.ONE) and
+for Java 1.5 onwards, BigInteger.TEN and BigDecimal (BigDecimal.ZERO, BigDecimal.ONE, BigDecimal.TEN)
+  </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+BigInteger bi = new BigInteger(1);		// reference BigInteger.ONE instead
+BigInteger bi2 = new BigInteger("0");	// reference BigInteger.ZERO instead
+BigInteger bi3 = new BigInteger(0.0);	// reference BigInteger.ZERO instead
+BigInteger bi4;
+bi4 = new BigInteger(0);				// reference BigInteger.ZERO instead
+]]>
+  </example>
+	</rule>
+
+	<rule name="AvoidUsingOctalValues" since="3.9"
+		message="Do not start a literal by 0 unless it's an octal value"
+		class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingOctalValuesRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidUsingOctalValues">
+		<description>
+    	<![CDATA[
+Integer literals should not start with zero since this denotes that the rest of literal will be
+interpreted as an octal value.
+    	]]>
+    </description>
+		<priority>3</priority>
+		<example>
+		    <![CDATA[
+int i = 012;	// set i with 10 not 12
+int j = 010;	// set j with 8 not 10
+k = i * j;		// set k with 80 not 120
+		    ]]>
+    </example>
+	</rule>
+
+	<rule name="AvoidUsingHardCodedIP" since="4.1"
+		message="Do not hard code the IP address ${variableName}"
+		class="net.sourceforge.pmd.lang.java.rule.basic.AvoidUsingHardCodedIPRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidUsingHardCodedIP">
+		<description>
+	    	<![CDATA[
+Application with hard-coded IP addresses can become impossible to deploy in some cases.
+Externalizing IP adresses is preferable.
+	    	]]>
+	    </description>
+		<priority>3</priority>
+		<properties>
+			<property name="pattern" type="String" description="Regular Expression"
+				value='^"[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}"$' />
+		</properties>
+		<example>
+	    <![CDATA[
+public class Foo {
+	private String ip = "127.0.0.1"; 	// not recommended
+}
+	    ]]>
+	    </example>
+	</rule>
+
+	<rule name="CheckResultSet" language="java" since="4.1"
+		class="net.sourceforge.pmd.lang.java.rule.basic.CheckResultSetRule"
+		message="Always check the return of one of the navigation method (next,previous,first,last) of a ResultSet."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#CheckResultSet">
+		<description>
+            <![CDATA[
+Always check the return values of navigation methods (next, previous, first, last) of a ResultSet.
+If the value return is 'false', it should be handled properly.
+            ]]>
+        </description>
+		<priority>3</priority>
+		<example>
+            <![CDATA[
+Statement stat = conn.createStatement();
+ResultSet rst = stat.executeQuery("SELECT name FROM person");
+rst.next(); 	// what if it returns false? bad form
+String firstName = rst.getString(1);
+
+Statement stat = conn.createStatement();
+ResultSet rst = stat.executeQuery("SELECT name FROM person");
+if (rst.next()) {	// result is properly examined and used
+    String firstName = rst.getString(1);
+	} else  {
+		// handle missing data
+}
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="AvoidMultipleUnaryOperators" since="4.2"
+		class="net.sourceforge.pmd.lang.java.rule.basic.AvoidMultipleUnaryOperatorsRule"
+		message="Using multiple unary operators may be a bug, and/or is confusing."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidMultipleUnaryOperators">
+		<description>
+            <![CDATA[
+The use of multiple unary operators may be problematic, and/or confusing.
+Ensure that the intended usage is not a bug, or consider simplifying the expression.
+            ]]>
+        </description>
+		<priority>2</priority>
+		<example>
+            <![CDATA[
+// These are typo bugs, or at best needlessly complex and confusing:
+int i = - -1;
+int j = + - +1;
+int z = ~~2;
+boolean b = !!true;
+boolean c = !!!true;
+
+// These are better:
+int i = 1;
+int j = -1;
+int z = 2;
+boolean b = true;
+boolean c = false;
+
+// And these just make your brain hurt:
+int i = ~-2;
+int j = -~7;
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="ExtendsObject" language="java" since="5.0"
+		message="No need to explicitly extend Object." class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#ExtendsObject">
+		<description>No need to explicitly extend Object.</description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+          <![CDATA[
+//ExtendsList/ClassOrInterfaceType[@Image='Object' or @Image='java.lang.Object']
+          ]]>
+          </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public class Foo extends Object { 	// not required
+}
+    ]]>
+    </example>
+	</rule>
+
+	<rule name="CheckSkipResult" language="java" since="5.0"
+		message="Check the value returned by the skip() method of an InputStream to see if the requested number of bytes has been skipped."
+		class="net.sourceforge.pmd.lang.java.rule.basic.CheckSkipResultRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#CheckSkipResult">
+		<description>The skip() method may skip a smaller number of bytes than requested. Check the returned value to find out if it was the case or not.</description>
+		<priority>3</priority>
+		<example>
+        <![CDATA[
+public class Foo {
+
+   private FileInputStream _s = new FileInputStream("file");
+
+   public void skip(int n) throws IOException {
+      _s.skip(n); // You are not sure that exactly n bytes are skipped
+   }
+
+   public void skipExactly(int n) throws IOException {
+      while (n != 0) {
+         long skipped = _s.skip(n);
+         if (skipped == 0)
+            throw new EOFException();
+         n -= skipped;
+      }
+   }
+        ]]>
+        </example>
+	</rule>
+
+	<rule name="AvoidBranchingStatementAsLastInLoop" since="5.0"
+		class="net.sourceforge.pmd.lang.java.rule.basic.AvoidBranchingStatementAsLastInLoopRule"
+		message="Avoid using a branching statement as the last in a loop."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#AvoidBranchingStatementAsLastInLoop">
+		<description>
+            <![CDATA[
+Using a branching statement as the last part of a loop may be a bug, and/or is confusing.
+Ensure that the usage is not a bug, or consider using another approach.
+            ]]>
+        </description>
+		<priority>2</priority>
+		<example>
+            <![CDATA[
+  // unusual use of branching statement in a loop
+for (int i = 0; i < 10; i++) {
+	if (i*i <= 25) {
+		continue;
+	}
+	break;
+}
+
+  // this makes more sense...
+for (int i = 0; i < 10; i++) {
+	if (i*i > 25) {
+		break;
+	}
+}
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="DontCallThreadRun" language="java" since="4.3"
+		message="Don't call Thread.run() explicitly, use Thread.start()"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#DontCallThreadRun">
+		<description>
+Explicitly calling Thread.run() method will execute in the caller's thread of control.  Instead, call Thread.start() for the intended behavior.
+      </description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//StatementExpression/PrimaryExpression
+[
+    PrimaryPrefix
+    [
+        ./Name[ends-with(@Image, '.run') or @Image = 'run']
+        and substring-before(Name/@Image, '.') =//VariableDeclarator/VariableDeclaratorId/@Image
+        [../../../Type/ReferenceType[ClassOrInterfaceType/@Image = 'Thread']]
+        or (
+        ./AllocationExpression/ClassOrInterfaceType[@Image = 'Thread']
+        and ../PrimarySuffix[@Image = 'run'])
+    ]
+]
+]]>
+         </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+Thread t = new Thread();
+t.run();            // use t.start() instead
+new Thread().run(); // same violation
+]]>
+      </example>
+	</rule>
+
+	<rule name="DontUseFloatTypeForLoopIndices" language="java" since="4.3"
+		message="Don't use floating point for loop indices. If you must use floating point, use double."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/basic.html#DontUseFloatTypeForLoopIndices">
+		<description>
+Don't use floating point for loop indices. If you must use floating point, use double
+unless you're certain that float provides enough precision and you have a compelling
+performance need (space or time).
+    </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//ForStatement/ForInit/LocalVariableDeclaration
+/Type/PrimitiveType[@Image="float"]
+]]>
+       </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class Count {
+  public static void main(String[] args) {
+    final int START = 2000000000;
+    int count = 0;
+    for (float f = START; f < START + 50; f++)
+      count++;
+      //Prints 0 because (float) START == (float) (START + 50).
+      System.out.println(count);
+      //The termination test misbehaves due to floating point granularity.
+    }
+}
+]]>
+    </example>
+	</rule>
+	<!-- unusedcode -->
+	<rule name="UnusedPrivateField" since="0.1" language="java"
+		message="Avoid unused private fields such as ''{0}''."
+		class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedPrivateFieldRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/unusedcode.html#UnusedPrivateField">
+		<description>
+Detects when a private field is declared and/or assigned a value, but not used.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Something {
+  private static int FOO = 2; // Unused
+  private int i = 5; // Unused
+  private int j = 6;
+  public int addOne() {
+    return j++;
+  }
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="UnusedLocalVariable" language="java" since="0.1"
+		message="Avoid unused local variables such as ''{0}''."
+		class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedLocalVariableRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/unusedcode.html#UnusedLocalVariable">
+		<description>
+Detects when a local variable is declared and/or assigned, but not used.
+    </description>
+		<priority>3</priority>
+
+		<example>
+<![CDATA[
+public class Foo {
+	public void doSomething() {
+		int i = 5; // Unused
+	}
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="UnusedPrivateMethod" language="java" since="0.7"
+		message="Avoid unused private methods such as ''{0}''."
+		class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedPrivateMethodRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/unusedcode.html#UnusedPrivateMethod">
+		<description>
+Unused Private Method detects when a private method is declared but is unused.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Something {
+	private void foo() {} // unused
+}
+]]>
+    </example>
+	</rule>
+
+
+	<rule name="UnusedFormalParameter" language="java" since="0.8"
+		message="Avoid unused {0} parameters such as ''{1}''."
+		class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedFormalParameterRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/unusedcode.html#UnusedFormalParameter">
+		<description>
+Avoid passing parameters to methods or constructors without actually referencing them in the method body.
+    </description>
+		<priority>3</priority>
+
+		<example>
+<![CDATA[
+public class Foo {
+	private void bar(String howdy) {
+	// howdy is not used
+	}
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="UnusedModifier" language="java" since="1.02"
+		message="Avoid modifiers which are implied by the context"
+		class="net.sourceforge.pmd.lang.java.rule.unusedcode.UnusedModifierRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/unusedcode.html#UnusedModifier">
+		<description>
+Fields in interfaces are automatically public static final, and methods are public abstract.
+Classes or interfaces nested in an interface are automatically public and static (all nested interfaces are automatically static).
+For historical reasons, modifiers which are implied by the context are accepted by the compiler, but are superfluous.
+     </description>
+		<priority>3</priority>
+		<example>
+ <![CDATA[
+public interface Foo {
+  public abstract void bar(); 		// both abstract and public are ignored by the compiler
+  public static final int X = 0; 	// public, static, and final all ignored
+  public static class Bar {} 		// public, static ignored
+  public static interface Baz {} 	// ditto
+}
+public class Bar {
+  public static interface Baz {} // static ignored
+}
+ ]]>
+     </example>
+	</rule>
+	<!-- imports -->
+	<rule name="DuplicateImports" since="0.5"
+		message="Avoid duplicate imports such as ''{0}''"
+		class="net.sourceforge.pmd.lang.java.rule.imports.DuplicateImportsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#DuplicateImports">
+		<description>
+Duplicate or overlapping import statements should be avoided.
+    </description>
+		<priority>4</priority>
+		<example>
+<![CDATA[
+import java.lang.String;
+import java.lang.*;
+public class Foo {}
+]]>
+    </example>
+	</rule>
+
+	<rule name="DontImportJavaLang" since="0.5"
+		message="Avoid importing anything from the package 'java.lang'"
+		class="net.sourceforge.pmd.lang.java.rule.imports.DontImportJavaLangRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#DontImportJavaLang">
+		<description>
+Avoid importing anything from the package 'java.lang'.  These classes are automatically imported (JLS 7.5.3).
+    </description>
+		<priority>4</priority>
+		<example>
+<![CDATA[
+import java.lang.String;	// this is unnecessary
+
+public class Foo {}
+
+// --- in another source code file...
+
+import java.lang.*;	// this is bad
+
+public class Foo {}
+]]>
+    </example>
+	</rule>
+
+	<rule name="UnusedImports" since="1.0"
+		message="Avoid unused imports such as ''{0}''" class="net.sourceforge.pmd.lang.java.rule.imports.UnusedImportsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#UnusedImports">
+		<description>
+Avoid the use of unused import statements to prevent unwanted dependencies.
+    </description>
+		<priority>4</priority>
+		<example>
+<![CDATA[
+// this is bad
+import java.io.File;
+public class Foo {}
+]]>
+    </example>
+	</rule>
+
+	<rule name="ImportFromSamePackage" since="1.02"
+		message="No need to import a type that lives in the same package"
+		class="net.sourceforge.pmd.lang.java.rule.imports.ImportFromSamePackageRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#ImportFromSamePackage">
+		<description>
+There is no need to import a type that lives in the same package.
+     </description>
+		<priority>3</priority>
+		<example>
+ <![CDATA[
+ package foo;
+ 
+ import foo.Buz; // no need for this
+ import foo.*; // or this
+ 
+ public class Bar{}
+ ]]>
+     </example>
+	</rule>
+	<rule name="UnnecessaryFullyQualifiedName" language="java" since="5.0"
+		class="net.sourceforge.pmd.lang.java.rule.imports.UnnecessaryFullyQualifiedNameRule"
+		message="Unnecessary use of fully qualified name ''{0}'' due to existing {2}import ''{1}''"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/imports.html#UnnecessaryFullyQualifiedName">
+		<description><![CDATA[
+Import statements allow the use of non-fully qualified names.  The use of a fully qualified name
+which is covered by an import statement is redundant.  Consider using the non-fully qualified name.
+		 ]]></description>
+		<priority>4</priority>
+		<example><![CDATA[
+import java.util.List;
+
+public class Foo {
+   private java.util.List list1; // Unnecessary FQN
+   private List list2; // More appropriate given import of 'java.util.List'
+}
+		  ]]></example>
+	</rule>
+	<!-- coupling -->
+	<rule name="CouplingBetweenObjects" since="1.04"
+		message="High amount of different objects as members denotes a high coupling"
+		class="net.sourceforge.pmd.lang.java.rule.coupling.CouplingBetweenObjectsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/coupling.html#CouplingBetweenObjects">
+		<description>
+This rule counts the number of unique attributes, local variables, and return types within an object. 
+A number higher than the specified threshold can indicate a high degree of coupling.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+import com.Blah;
+import org.Bar;
+import org.Bardo;
+
+public class Foo {
+   private Blah var1;
+   private Bar var2;
+ 
+ 	//followed by many imports of unique objects
+   void ObjectC doWork() {
+     Bardo var55;
+     ObjectA var44;
+     ObjectZ var93;
+     return something;
+   }
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="ExcessiveImports" since="1.04"
+		message="A high number of imports can indicate a high degree of coupling within an object."
+		class="net.sourceforge.pmd.lang.java.rule.coupling.ExcessiveImportsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/coupling.html#ExcessiveImports">
+		<description>
+A high number of imports can indicate a high degree of coupling within an object. This rule 
+counts the number of unique imports and reports a violation if the count is above the 
+user-specified threshold.
+  </description>
+		<priority>3</priority>
+		<example>
+      <![CDATA[
+import blah.blah.Baz;
+import blah.blah.Bif;
+// 18 others from the same package elided
+public class Foo {
+ public void doWork() {}
+}
+      ]]>
+  </example>
+	</rule>
+
+	<rule name="LooseCoupling" since="0.7"
+		message="Avoid using implementation types like ''{0}''; use the interface instead"
+		class="net.sourceforge.pmd.lang.java.rule.coupling.LooseCouplingRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/coupling.html#LooseCoupling">
+		<description>
+The use of implementation types as object references limits your ability to use alternate
+implementations in the future as requirements change. Whenever available, referencing objects 
+by their interface types provides much more flexibility.
+      </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+	// sub-optimal approach
+private ArrayList list = new ArrayList();
+
+public HashSet getFoo() {
+	return new HashSet();
+}
+
+	// preferred approach
+private List list = new ArrayList();
+
+public Set getFoo() {
+	return new HashSet();
+}
+]]>
+      </example>
+	</rule>
+
+	<!-- Apparently this next one is broken -->
+	<!-- rule ref="rulesets/java/coupling.xml/LoosePackageCoupling"/ -->
+	<!-- I hate the Law of Demeter check!!! -->
+	<!-- rule ref="rulesets/java/coupling.xml/LawOfDemeter"/ -->
+
+	<!-- design -->
+	<rule ref="rulesets/java/design.xml/UseUtilityClass" />
+	<rule ref="rulesets/java/design.xml/SimplifyBooleanReturns" />
+	<rule ref="rulesets/java/design.xml/SimplifyBooleanExpressions" />
+	<rule ref="rulesets/java/design.xml/SwitchStmtsShouldHaveDefault" />
+	<rule ref="rulesets/java/design.xml/AvoidDeeplyNestedIfStmts" />
+	<rule ref="rulesets/java/design.xml/AvoidReassigningParameters" />
+	<rule ref="rulesets/java/design.xml/SwitchDensity" />
+	<rule ref="rulesets/java/design.xml/ConstructorCallsOverridableMethod" />
+	<rule name="UseUtilityClass" since="0.3"
+		message="All methods are static.  Consider using a utility class instead. Alternatively, you could add a private constructor or make the class abstract to silence this warning."
+		class="net.sourceforge.pmd.lang.java.rule.design.UseUtilityClassRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UseUtilityClass">
+		<description>
+    	<![CDATA[
+For classes that only have static methods, consider making them utility classes.
+Note that this doesn't apply to abstract classes, since their subclasses may
+well include non-static methods.  Also, if you want this class to be a utility class,
+remember to add a private constructor to prevent instantiation.
+(Note, that this use was known before PMD 5.1.0 as UseSingleton).
+		]]>
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class MaybeAUtility {
+  public static void foo() {}
+  public static void bar() {}
+}
+]]>
+    </example>
+	</rule>
+
+
+	<rule name="SimplifyBooleanReturns" since="0.9"
+		message="Avoid unnecessary if..then..else statements when returning booleans"
+		class="net.sourceforge.pmd.lang.java.rule.design.SimplifyBooleanReturnsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SimplifyBooleanReturns">
+		<description>
+Avoid unnecessary if-then-else statements when returning a boolean. The result of
+the conditional test can be returned instead.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public boolean isBarEqualTo(int x) {
+   
+	if (bar == x) {		 // this bit of code...
+		return true;
+	} else {
+		return false;
+    }
+}
+
+public boolean isBarEqualTo(int x) {
+
+   	return bar == x;	// can be replaced with this
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="SimplifyBooleanExpressions" language="java" since="1.05"
+		message="Avoid unnecessary comparisons in boolean expressions" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SimplifyBooleanExpressions">
+		<description>
+Avoid unnecessary comparisons in boolean expressions, they serve no purpose and impacts readability.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//EqualityExpression/PrimaryExpression
+ /PrimaryPrefix/Literal/BooleanLiteral
+]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public class Bar {
+  // can be simplified to
+  // bar = isFoo();
+  private boolean bar = (isFoo() == true);
+
+  public isFoo() { return false;}
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="SwitchStmtsShouldHaveDefault" language="java" since="1.0"
+		message="Switch statements should have a default label" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SwitchStmtsShouldHaveDefault">
+		<description>
+All switch statements should include a default option to catch any unspecified values.
+    </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                  <![CDATA[
+//SwitchStatement[not(SwitchLabel[@Default='true'])]
+                  ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public void bar() {
+    int x = 2;
+    switch (x) {
+      case 1: int j = 6;
+      case 2: int j = 8;
+      				// missing default: here
+    }
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="AvoidDeeplyNestedIfStmts" since="1.0"
+		message="Deeply nested if..then statements are hard to read"
+		class="net.sourceforge.pmd.lang.java.rule.design.AvoidDeeplyNestedIfStmtsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidDeeplyNestedIfStmts">
+		<description>
+Avoid creating deeply nested if-then statements since they are harder to read and error-prone to maintain.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo {
+  public void bar(int x, int y, int z) {
+    if (x>y) {
+      if (y>z) {
+        if (z==x) {
+         // !! too deep
+        }
+      }
+    }
+  }
+}
+]]>
+    </example>
+	</rule>
+
+
+	<rule name="AvoidReassigningParameters" since="1.0"
+		message="Avoid reassigning parameters such as ''{0}''"
+		class="net.sourceforge.pmd.lang.java.rule.design.AvoidReassigningParametersRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidReassigningParameters">
+		<description>
+Reassigning values to incoming parameters is not recommended.  Use temporary local variables instead.
+    </description>
+		<priority>2</priority>
+		<example>
+<![CDATA[
+public class Foo {
+  private void foo(String bar) {
+    bar = "something else";
+  }
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="SwitchDensity" since="1.02"
+		message="A high ratio of statements to labels in a switch statement.  Consider refactoring."
+		class="net.sourceforge.pmd.lang.java.rule.design.SwitchDensityRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SwitchDensity">
+		<description>
+A high ratio of statements to labels in a switch statement implies that the switch statement 
+is overloaded.  Consider moving the statements into new methods or creating subclasses based 
+on the switch variable.
+      </description>
+		<priority>3</priority>
+		<example>
+ <![CDATA[
+public class Foo {
+  public void bar(int x) {
+    switch (x) {
+      case 1: {
+        // lots of statements
+        break;
+      } case 2: {
+        // lots of statements
+        break;
+      }
+    }
+  }
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="ConstructorCallsOverridableMethod" since="1.04"
+		message="Overridable {0} called during object construction"
+		class="net.sourceforge.pmd.lang.java.rule.design.ConstructorCallsOverridableMethodRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ConstructorCallsOverridableMethod">
+		<description>
+Calling overridable methods during construction poses a risk of invoking methods on an incompletely 
+constructed object and can be difficult to debug.
+It may leave the sub-class unable to construct its superclass or forced to replicate the construction 
+process completely within itself, losing the ability to call super().  If the default constructor 
+contains a call to an overridable method, the subclass may be completely uninstantiable.   Note that 
+this includes method calls throughout the control flow graph - i.e., if a constructor Foo() calls a 
+private method bar() that calls a public method buz(), this denotes a problem.
+      </description>
+		<priority>1</priority>
+		<example>
+  <![CDATA[
+public class SeniorClass {
+  public SeniorClass(){
+      toString(); //may throw NullPointerException if overridden
+  }
+  public String toString(){
+    return "IAmSeniorClass";
+  }
+}
+public class JuniorClass extends SeniorClass {
+  private String name;
+  public JuniorClass(){
+    super(); //Automatic call leads to NullPointerException
+    name = "JuniorClass";
+  }
+  public String toString(){
+    return name.toUpperCase();
+  }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="AccessorClassGeneration" since="1.04"
+		message="Avoid instantiation through private constructors from outside of the constructor's class."
+		class="net.sourceforge.pmd.lang.java.rule.design.AccessorClassGenerationRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AccessorClassGeneration">
+		<description>
+Instantiation by way of private constructors from outside of the constructor's class often causes the 
+generation of an accessor. A factory method, or non-privatization of the constructor can eliminate this 
+situation. The generated class file is actually an interface.  It gives the accessing class the ability 
+to invoke a new hidden package scope constructor that takes the interface as a supplementary parameter. 
+This turns a private constructor effectively into one with package scope, and is challenging to discern.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Outer {
+ void method(){
+  Inner ic = new Inner();//Causes generation of accessor class
+ }
+ public class Inner {
+  private Inner(){}
+ }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="FinalFieldCouldBeStatic" language="java" since="1.1"
+		message="This final field could be made static" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#FinalFieldCouldBeStatic">
+		<description>
+If a final field is assigned to a compile-time constant, it could be made static, thus saving overhead 
+in each object at runtime.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                    <![CDATA[
+//FieldDeclaration
+ [@Final='true' and @Static='false']
+ [not (../../../../ClassOrInterfaceDeclaration[@Interface='true'])]
+   /VariableDeclarator/VariableInitializer/Expression
+    /PrimaryExpression[not(PrimarySuffix)]/PrimaryPrefix/Literal
+                    ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public class Foo {
+  public final int BAR = 42; // this could be static and save some space
+}
+  ]]>
+      </example>
+	</rule>
+
+
+	<rule name="CloseResource" since="1.2.2"
+		message="Ensure that resources like this {0} object are closed after use"
+		class="net.sourceforge.pmd.lang.java.rule.design.CloseResourceRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#CloseResource">
+		<description>
+Ensure that resources (like Connection, Statement, and ResultSet objects) are always closed after use.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Bar {
+  public void foo() {
+    Connection c = pool.getConnection();
+    try {
+      // do stuff
+    } catch (SQLException ex) {
+     // handle exception
+    } finally {
+      // oops, should close the connection using 'close'!
+      // c.close();
+    }
+  }
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="NonStaticInitializer" language="java" since="1.5"
+		message="Non-static initializers are confusing" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#NonStaticInitializer">
+		<description>
+A non-static initializer block will be called any time a constructor is invoked (just prior to 
+invoking the constructor).  While this is a valid language construct, it is rarely used and is 
+confusing.
+       </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//Initializer[@Static='false']
+]]>
+                 </value>
+			</property>
+		</properties>
+		<example>
+   <![CDATA[
+public class MyClass {
+ // this block gets run before any call to a constructor
+  {
+   System.out.println("I am about to construct myself");
+  }
+}
+   ]]>
+       </example>
+	</rule>
+
+	<rule name="DefaultLabelNotLastInSwitchStmt" language="java"
+		since="1.5"
+		message="The default label should be the last label in a switch statement"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#DefaultLabelNotLastInSwitchStmt">
+		<description>
+By convention, the default label should be the last label in a switch statement.
+       </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//SwitchStatement
+ [not(SwitchLabel[position() = last()][@Default='true'])]
+ [SwitchLabel[@Default='true']]
+]]>
+                 </value>
+			</property>
+		</properties>
+		<example>
+   <![CDATA[
+public class Foo {
+  void bar(int a) {
+   switch (a) {
+    case 1:  // do something
+       break;
+    default:  // the default case should be last, by convention
+       break;
+    case 2:
+       break;
+   }
+  }
+}   ]]>
+       </example>
+	</rule>
+
+	<rule name="NonCaseLabelInSwitchStatement" language="java" since="1.5"
+		message="A non-case label was present in a switch statement" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#NonCaseLabelInSwitchStatement">
+		<description>
+A non-case label (e.g. a named break/continue label) was present in a switch statement.
+This legal, but confusing. It is easy to mix up the case labels and the non-case labels.
+       </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+ <![CDATA[
+//SwitchStatement//BlockStatement/Statement/LabeledStatement
+ ]]>
+                 </value>
+			</property>
+		</properties>
+		<example>
+   <![CDATA[
+public class Foo {
+  void bar(int a) {
+   switch (a) {
+     case 1:
+       // do something
+       break;
+     mylabel: // this is legal, but confusing!
+       break;
+     default:
+       break;
+    }
+  }
+}
+   ]]>
+       </example>
+	</rule>
+
+	<rule name="OptimizableToArrayCall" language="java" since="1.8"
+		message="This call to Collection.toArray() may be optimizable" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#OptimizableToArrayCall">
+		<description>
+Calls to a collection's toArray() method should specify target arrays sized to match the size of the
+collection. Initial arrays that are too small are discarded in favour of new ones that have to be created
+that are the proper size.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                  <![CDATA[
+//PrimaryExpression
+[PrimaryPrefix/Name[ends-with(@Image, 'toArray')]]
+[
+PrimarySuffix/Arguments/ArgumentList/Expression
+ /PrimaryExpression/PrimaryPrefix/AllocationExpression
+ /ArrayDimsAndInits/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image='0']
+]
+
+                  ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+List foos = getFoos();
+  
+    // inefficient, the array will be discarded
+Foo[] fooArray = foos.toArray(new Foo[0]);
+    
+    // much better; this one sizes the destination array, 
+    // avoiding of a new one via reflection
+Foo[] fooArray = foos.toArray(new Foo[foos.size()]);
+  ]]>
+      </example>
+	</rule>
+
+
+	<rule name="BadComparison" language="java" since="1.8"
+		message="Avoid equality comparisons with Double.NaN" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#BadComparison">
+		<description>
+Avoid equality comparisons with Double.NaN. Due to the implicit lack of representation
+precision when comparing floating point numbers these are likely to cause logic errors.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                  <![CDATA[
+//EqualityExpression[@Image='==']
+ /PrimaryExpression/PrimaryPrefix
+ /Name[@Image='Double.NaN' or @Image='Float.NaN']
+                  ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+boolean x = (y == Double.NaN);
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="EqualsNull" language="java" since="1.9"
+		message="Avoid using equals() to compare against null" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#EqualsNull">
+		<description>
+Tests for null should not use the equals() method. The '==' operator should be used instead.
+        </description>
+		<priority>1</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//PrimaryExpression
+  [
+    PrimaryPrefix[Name[ends-with(@Image, 'equals')]]
+      [following-sibling::node()/Arguments/ArgumentList[count(Expression)=1]
+          /Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+
+    or
+
+    PrimarySuffix[ends-with(@Image, 'equals')]
+      [following-sibling::node()/Arguments/ArgumentList[count(Expression)=1]
+          /Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral]
+
+  ]
+    ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+       <![CDATA[
+String x = "foo";
+
+if (x.equals(null)) { // bad form
+   	doSomething();
+	}
+	
+if (x == null) { 	// preferred
+   	doSomething();
+	}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="ConfusingTernary" since="1.9"
+		message="Avoid if (x != y) ..; else ..;"
+		class="net.sourceforge.pmd.lang.java.rule.design.ConfusingTernaryRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ConfusingTernary">
+		<description>
+Avoid negation within an "if" expression with an "else" clause.  For example, rephrase:
+
+  if (x != y) diff(); else same();
+as:
+  if (x == y) same(); else diff();
+
+Most "if (x != y)" cases without an "else" are often return cases, so consistent use of this 
+rule makes the code easier to read.  Also, this resolves trivial ordering problems, such
+as "does the error case go first?" or "does the common case go first?".
+        </description>
+		<priority>3</priority>
+		<example>
+          <![CDATA[
+boolean bar(int x, int y) {
+  return (x != y) ? diff : same;
+ }
+          ]]>
+        </example>
+	</rule>
+
+	<rule name="InstantiationToGetClass" language="java" since="2.0"
+		message="Avoid instantiating an object just to call getClass() on it; use the .class public member instead"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#InstantiationToGetClass">
+		<description>
+Avoid instantiating an object just to call getClass() on it; use the .class public member instead.
+      </description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//PrimarySuffix
+ [@Image='getClass']
+ [parent::PrimaryExpression
+  [PrimaryPrefix/AllocationExpression]
+  [count(PrimarySuffix) = 2]
+ ]
+     ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+  // replace this
+Class c = new String().getClass();
+
+  // with this:
+Class c = String.class;
+
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="IdempotentOperations" since="2.0"
+		message="Avoid idempotent operations (like assigning a variable to itself)."
+		class="net.sourceforge.pmd.lang.java.rule.design.IdempotentOperationsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#IdempotentOperations">
+		<description>
+Avoid idempotent operations - they have no effect.
+      </description>
+		<priority>3</priority>
+
+		<example>
+      <![CDATA[
+public class Foo {
+ public void bar() {
+  int x = 2;
+  x = x;
+ }
+}
+      ]]>
+      </example>
+	</rule>
+
+	<!-- skipped SimpleDateFormatNeedsLocale -->
+
+	<rule ref="rulesets/java/design.xml/ImmutableField" />
+	<rule ref="rulesets/java/design.xml/UseLocaleWithCaseConversions" />
+	<rule ref="rulesets/java/design.xml/AvoidProtectedFieldInFinalClass" />
+	<rule ref="rulesets/java/design.xml/AssignmentToNonFinalStatic" />
+	<rule
+		ref="rulesets/java/design.xml/MissingStaticMethodInNonInstantiatableClass" />
+	<rule ref="rulesets/java/design.xml/AvoidSynchronizedAtMethodLevel" />
+	<rule ref="rulesets/java/design.xml/MissingBreakInSwitch" />
+	<rule name="ImmutableField" since="2.0"
+		message="Private field ''{0}'' could be made final; it is only initialized in the declaration or constructor."
+		class="net.sourceforge.pmd.lang.java.rule.design.ImmutableFieldRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ImmutableField">
+		<description>
+Identifies private fields whose values never change once they are initialized either in the declaration 
+of the field or by a constructor.  This helps in converting existing classes to becoming immutable ones.
+      </description>
+		<priority>3</priority>
+
+		<example>
+  <![CDATA[
+public class Foo {
+  private int x; // could be final
+  public Foo() {
+      x = 7;
+  }
+  public void foo() {
+     int a = x + 2;
+  }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="UseLocaleWithCaseConversions" language="java" since="2.0"
+		message="When doing a String.toLowerCase()/toUpperCase() call, use a Locale"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UseLocaleWithCaseConversions">
+		<description>
+When doing String.toLowerCase()/toUpperCase() conversions, use Locales to avoids problems with languages that
+have unusual conventions, i.e. Turkish.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//PrimaryExpression
+[PrimaryPrefix/Name
+ [ends-with(@Image, 'toLowerCase') or ends-with(@Image,
+'toUpperCase')]
+ ]
+[PrimarySuffix[position() = 1]/Arguments[@ArgumentCount=0]]
+     ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+class Foo {
+ // BAD
+ if (x.toLowerCase().equals("list")) { }
+ /*
+ This will not match "LIST" when in Turkish locale
+ The above could be
+ if (x.toLowerCase(Locale.US).equals("list")) { }
+ or simply
+ if (x.equalsIgnoreCase("list")) { }
+ */
+ // GOOD
+ String z = a.toLowerCase(Locale.EN);
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="AvoidProtectedFieldInFinalClass" language="java"
+		since="2.1"
+		message="Avoid protected fields in a final class.  Change to private or package access."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidProtectedFieldInFinalClass">
+		<description>
+Do not use protected fields in final classes since they cannot be subclassed.
+Clarify your intent by using private or package access modifiers instead.
+         </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[@Final='true']
+/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+/FieldDeclaration[@Protected='true']
+ ]]>
+                 </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public final class Bar {
+  private int x;
+  protected int y;  // bar cannot be subclassed, so is y really private or package visible?
+  Bar() {}
+}
+ ]]>
+         </example>
+	</rule>
+
+	<rule name="AssignmentToNonFinalStatic" since="2.2"
+		message="Possible unsafe assignment to a non-final static field in a constructor."
+		class="net.sourceforge.pmd.lang.java.rule.design.AssignmentToNonFinalStaticRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AssignmentToNonFinalStatic">
+		<description>
+Identifies a possible unsafe usage of a static field.
+       </description>
+		<priority>3</priority>
+		<example>
+   <![CDATA[
+public class StaticField {
+   static int x;
+   public FinalFields(int y) {
+    x = y; // unsafe
+   }
+}
+   ]]>
+       </example>
+	</rule>
+
+	<rule name="MissingStaticMethodInNonInstantiatableClass" language="java"
+		since="3.0"
+		message="Class cannot be instantiated and does not provide any static methods or fields"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#MissingStaticMethodInNonInstantiatableClass">
+		<description>
+A class that has private constructors and does not have any static methods or fields cannot be used.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//ClassOrInterfaceDeclaration[@Nested='false']
+[
+  (
+    count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration)>0
+    and
+    count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration) = count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Private='true'])
+  )
+  and
+  count(.//MethodDeclaration[@Static='true'])=0
+  and
+  count(.//FieldDeclaration[@Private='false'][@Static='true'])=0
+  and
+  count(.//ClassOrInterfaceDeclaration[@Nested='true']
+           [@Public='true']
+           [@Static='true']
+           [count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Public='true']) > 0]
+           [count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/MethodDeclaration
+                    [@Public='true']
+                    [./ResultType/Type/ReferenceType/ClassOrInterfaceType
+                        [@Image = //ClassOrInterfaceDeclaration[@Nested='false']/@Image]
+                    ]
+            ) > 0]
+        ) = 0
+  and
+  count(//ClassOrInterfaceDeclaration
+            [@Nested='true']
+            [@Static='true']
+            [@Public='true']
+            [.//MethodDeclaration
+              [@Public='true']
+              [.//ReturnStatement//AllocationExpression
+                [ClassOrInterfaceType
+                    [@Image = //ClassOrInterfaceDeclaration/@Image]
+                ]
+                [./Arguments//PrimaryPrefix/@ThisModifier='true']
+              ]
+            ]
+       ) = 0
+]
+    ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+// This class is unusable, since it cannot be
+// instantiated (private constructor),
+// and no static method can be called.
+
+public class Foo {
+  private Foo() {}
+  void foo() {}
+}
+
+]]>
+      </example>
+	</rule>
+
+
+	<rule name="AvoidSynchronizedAtMethodLevel" language="java" since="3.0"
+		message="Use block level rather than method level synchronization"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidSynchronizedAtMethodLevel">
+		<description>
+Method-level synchronization can cause problems when new code is added to the method.  
+Block-level synchronization helps to ensure that only the code that needs synchronization 
+gets it.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//MethodDeclaration[@Synchronized='true']
+    ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class Foo {
+  // Try to avoid this:
+  synchronized void foo() {
+  }
+  // Prefer this:
+  void bar() {
+    synchronized(this) {
+    }
+  }
+
+  // Try to avoid this for static methods:
+  static synchronized void fooStatic() {
+  }
+  
+  // Prefer this:
+  static void barStatic() {
+    synchronized(Foo.class) {
+    }
+  }
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="MissingBreakInSwitch" language="java" since="3.0"
+		message="A switch statement does not contain a break" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#MissingBreakInSwitch">
+		<description>
+Switch statements without break or return statements for each case option
+may indicate problematic behaviour. Empty cases are ignored as these indicate an intentional fall-through.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//SwitchStatement
+[(count(.//BreakStatement)
+ + count(BlockStatement//Statement/ReturnStatement)
+ + count(BlockStatement//Statement/ThrowStatement)
+ + count(BlockStatement//Statement/IfStatement[@Else='true' and Statement[2][ReturnStatement|ThrowStatement]]/Statement[1][ReturnStatement|ThrowStatement])
+ + count(SwitchLabel[name(following-sibling::node()) = 'SwitchLabel'])
+ + count(SwitchLabel[count(following-sibling::node()) = 0])
+  < count (SwitchLabel))]
+    ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public void bar(int status) {
+    switch(status) {
+      case CANCELLED:
+        doCancelled();
+        // break; hm, should this be commented out?
+      case NEW:
+        doNew();
+        // is this really a fall-through?
+      case REMOVED:
+        doRemoved();
+        // what happens if you add another case after this one?
+      case OTHER: // empty case - this is interpreted as an intentional fall-through
+      case ERROR:
+        doErrorHandling();
+        break;
+    }
+}
+]]>
+      </example>
+	</rule>
+
+
+	<rule name="UseNotifyAllInsteadOfNotify" language="java" since="3.0"
+		message="Call Thread.notifyAll() rather than Thread.notify()" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UseNotifyAllInsteadOfNotify">
+		<description>
+Thread.notify() awakens a thread monitoring the object. If more than one thread is monitoring, then only
+one is chosen.  The thread chosen is arbitrary; thus its usually safer to call notifyAll() instead.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//StatementExpression/PrimaryExpression
+[PrimarySuffix/Arguments[@ArgumentCount = '0']]
+[
+PrimaryPrefix[./Name[@Image='notify' or ends-with(@Image,'.notify')]
+or ../PrimarySuffix/@Image='notify'
+or (./AllocationExpression and ../PrimarySuffix[@Image='notify'])
+]
+]
+    ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+  void bar() {
+    x.notify();
+    // If many threads are monitoring x, only one (and you won't know which) will be notified.
+    // use instead:
+    x.notifyAll();
+  }
+]]>
+      </example>
+	</rule>
+
+	<rule name="AvoidInstanceofChecksInCatchClause" language="java"
+		since="3.0"
+		message="An instanceof check is being performed on the caught exception.  Create a separate catch clause for this exception type."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidInstanceofChecksInCatchClause">
+		<description>
+Each caught exception type should be handled in its own catch clause.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//CatchStatement/FormalParameter
+ /following-sibling::Block//InstanceOfExpression/PrimaryExpression/PrimaryPrefix
+  /Name[
+   @Image = ./ancestor::Block/preceding-sibling::FormalParameter
+    /VariableDeclaratorId/@Image
+  ]
+    ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+try { // Avoid this
+ // do something
+} catch (Exception ee) {
+ if (ee instanceof IOException) {
+  cleanup();
+ }
+}
+try {  // Prefer this:
+ // do something
+} catch (IOException ee) {
+ cleanup();
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="AbstractClassWithoutAbstractMethod" language="java"
+		since="3.0" message="This abstract class does not have any abstract methods"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AbstractClassWithoutAbstractMethod">
+		<description>
+The abstract class does not contain any abstract methods. An abstract class suggests
+an incomplete implementation, which is to be completed by subclasses implementing the
+abstract methods. If the class is intended to be used as a base class only (not to be instantiated
+directly) a protected constructor can be provided prevent direct instantiation.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value><![CDATA[
+//ClassOrInterfaceDeclaration
+ [@Abstract='true'
+  and count( .//MethodDeclaration[@Abstract='true'] )=0 ]
+  [count(ImplementsList)=0]
+  [count(.//ExtendsList)=0]
+              ]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public abstract class Foo {
+  void int method1() { ... }
+  void int method2() { ... }
+  // consider using abstract methods or removing
+  // the abstract modifier and adding protected constructors
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="SimplifyConditional" language="java" since="3.1"
+		message="No need to check for null before an instanceof" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SimplifyConditional">
+		<description>
+No need to check for null before an instanceof; the instanceof keyword returns false when given a null argument.
+          </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                      <![CDATA[
+//Expression
+ [ConditionalOrExpression
+ [EqualityExpression[@Image='==']
+  //NullLiteral
+  and
+  UnaryExpressionNotPlusMinus
+   [@Image='!']//InstanceOfExpression[PrimaryExpression
+     //Name/@Image = ancestor::ConditionalOrExpression/EqualityExpression
+      /PrimaryExpression/PrimaryPrefix/Name/@Image]
+  and
+  (count(UnaryExpressionNotPlusMinus) + 1 = count(*))
+ ]
+or
+ConditionalAndExpression
+ [EqualityExpression[@Image='!=']//NullLiteral
+ and
+InstanceOfExpression
+ [PrimaryExpression[count(PrimarySuffix[@ArrayDereference='true'])=0]
+  //Name[not(contains(@Image,'.'))]/@Image = ancestor::ConditionalAndExpression
+   /EqualityExpression/PrimaryExpression/PrimaryPrefix/Name/@Image]
+ and
+(count(InstanceOfExpression) + 1 = count(*))
+ ]
+]
+ ]]>
+                  </value>
+			</property>
+		</properties>
+		<example>
+      <![CDATA[
+class Foo {
+  void bar(Object x) {
+    if (x != null && x instanceof Bar) {
+      // just drop the "x != null" check
+    }
+  }
+}      ]]>
+           </example>
+	</rule>
+
+	<rule name="CompareObjectsWithEquals" since="3.2"
+		message="Use equals() to compare object references."
+		class="net.sourceforge.pmd.lang.java.rule.design.CompareObjectsWithEqualsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#CompareObjectsWithEquals">
+		<description>
+Use equals() to compare object references; avoid comparing them with ==.
+  </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+class Foo {
+  boolean bar(String a, String b) {
+    return a == b;
+  }
+}
+
+]]>
+  </example>
+	</rule>
+
+
+	<rule name="PositionLiteralsFirstInComparisons" language="java"
+		since="3.3" message="Position literals first in String comparisons"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#PositionLiteralsFirstInComparisons">
+		<description>
+Position literals first in comparisons, if the second argument is null then NullPointerExceptions 
+can be avoided, they will just return false.
+  </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+              <![CDATA[
+//PrimaryExpression[
+        PrimaryPrefix[Name
+                [
+	(ends-with(@Image, '.equals'))
+                ]
+        ]
+        [
+                   (../PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal[@StringLiteral='true'])
+	and
+	( count(../PrimarySuffix/Arguments/ArgumentList/Expression) = 1 )
+        ]
+]
+[not(ancestor::Expression/ConditionalAndExpression//EqualityExpression[@Image='!=']//NullLiteral)]
+[not(ancestor::Expression/ConditionalOrExpression//EqualityExpression[@Image='==']//NullLiteral)]
+
+          ]]>
+          </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+class Foo {
+  boolean bar(String x) {
+    return x.equals("2"); // should be "2".equals(x)
+  }
+}
+
+]]>
+  </example>
+	</rule>
+
+
+	<rule name="PositionLiteralsFirstInCaseInsensitiveComparisons"
+		language="java" since="5.1"
+		message="Position literals first in String comparisons for EqualsIgnoreCase"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#PositionLiteralsFirstInCaseInsensitiveComparisons">
+		<description>
+Position literals first in comparisons, if the second argument is null then NullPointerExceptions 
+can be avoided, they will just return false.
+  </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+              <![CDATA[
+//PrimaryExpression[
+        PrimaryPrefix[Name
+                [
+    (ends-with(@Image, '.equalsIgnoreCase'))
+                ]
+        ]
+        [
+                   (../PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal)
+    and
+    ( count(../PrimarySuffix/Arguments/ArgumentList/Expression) = 1 )
+        ]
+]
+[not(ancestor::Expression/ConditionalAndExpression//EqualityExpression[@Image='!=']//NullLiteral)]
+[not(ancestor::Expression/ConditionalOrExpression//EqualityExpression[@Image='==']//NullLiteral)]
+
+          ]]>
+          </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+class Foo {
+  boolean bar(String x) {
+    return x.equalsIgnoreCase("2"); // should be "2".equalsIgnoreCase(x)
+  }
+}
+
+]]>
+  </example>
+	</rule>
+
+
+	<rule name="UnnecessaryLocalBeforeReturn" since="3.3"
+		message="Consider simply returning the value vs storing it in local variable ''{0}''"
+		class="net.sourceforge.pmd.lang.java.rule.design.UnnecessaryLocalBeforeReturnRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UnnecessaryLocalBeforeReturn">
+		<description>
+Avoid the creation of unnecessary local variables
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Foo {
+   public int foo() {
+     int x = doSomething();
+     return x;  // instead, just 'return doSomething();'
+   }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="NonThreadSafeSingleton" since="3.4"
+		message="Singleton is not thread safe"
+		class="net.sourceforge.pmd.lang.java.rule.design.NonThreadSafeSingletonRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#NonThreadSafeSingleton">
+		<description>
+Non-thread safe singletons can result in bad state changes. Eliminate
+static singletons if possible by instantiating the object directly. Static
+singletons are usually not needed as only a single instance exists anyway.
+Other possible fixes are to synchronize the entire method or to use an
+initialize-on-demand holder class (do not use the double-check idiom).
+
+See Effective Java, item 48.
+        </description>
+		<priority>3</priority>
+		<example><![CDATA[
+private static Foo foo = null;
+
+//multiple simultaneous callers may see partially initialized objects
+public static Foo getFoo() {
+    if (foo==null) {
+        foo = new Foo();
+    }
+    return foo;
+}
+        ]]></example>
+	</rule>
+
+	<!-- rule name="SingleMethodSingleton" since="5.4" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SingleMethodSingleton" 
+		message="Class contains multiple getInstance methods. Please review." class="net.sourceforge.pmd.lang.java.rule.design.SingleMethodSingletonRule"> 
+		<description> Some classes contain overloaded getInstance. The problem with 
+		overloaded getInstance methods is that the instance created using the overloaded 
+		method is not cached and so, for each call and new objects will be created 
+		for every invocation. </description> <priority>2</priority> <example><![CDATA[ 
+		public class Singleton { private static Singleton singleton = new Singleton( 
+		); private Singleton(){ } public static Singleton getInstance( ) { return 
+		singleton; } public static Singleton getInstance(Object obj){ Singleton singleton 
+		= (Singleton) obj; return singleton; //violation } } ]]> </example> </rule -->
+
+	<!-- rule name="SingletonClassReturningNewInstance" since="5.4" externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SingletonClassReturningNewInstance" 
+		message="getInstance method always creates a new object and hence does not 
+		comply to Singleton Design Pattern behaviour. Please review" class="net.sourceforge.pmd.lang.java.rule.design.SingletonClassReturningNewInstanceRule"> 
+		<description> Some classes contain overloaded getInstance. The problem with 
+		overloaded getInstance methods is that the instance created using the overloaded 
+		method is not cached and so, for each call and new objects will be created 
+		for every invocation. </description> <priority>2</priority> <example><![CDATA[ 
+		class Singleton { private static Singleton instance = null; public static 
+		Singleton getInstance() { synchronized(Singleton.class){ return new Singleton(); 
+		} } } ]]> </example> </rule -->
+
+	<rule name="UncommentedEmptyMethodBody" language="java" since="3.4"
+		message="Document empty method body" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UncommentedEmptyMethodBody">
+		<description>
+Uncommented Empty Method Body finds instances where a method body does not contain
+statements, but there is no comment. By explicitly commenting empty method bodies
+it is easier to distinguish between intentional (commented) and unintentional
+empty methods.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//MethodDeclaration/Block[count(BlockStatement) = 0 and @containsComment = 'false']
+ ]]>
+             </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public void doSomething() {
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="UncommentedEmptyConstructor" language="java" since="3.4"
+		message="Document empty constructor" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UncommentedEmptyConstructor">
+		<description>
+Uncommented Empty Constructor finds instances where a constructor does not
+contain statements, but there is no comment. By explicitly commenting empty
+constructors it is easier to distinguish between intentional (commented)
+and unintentional empty constructors.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//ConstructorDeclaration[@Private='false'][count(BlockStatement) = 0 and ($ignoreExplicitConstructorInvocation = 'true' or not(ExplicitConstructorInvocation)) and @containsComment = 'false']
+ ]]>
+             </value>
+			</property>
+			<property name="ignoreExplicitConstructorInvocation" type="Boolean"
+				description="Ignore explicit constructor invocation when deciding whether constructor is empty or not"
+				value="false" />
+		</properties>
+		<example>
+  <![CDATA[
+public Foo() {
+  // This constructor is intentionally empty. Nothing special is needed here.
+}
+ ]]>
+      </example>
+	</rule>
+
+	<rule name="AvoidConstantsInterface" language="java" since="3.5"
+		message="An Interface should be used only to model a behaviour; consider converting this to a class."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidConstantsInterface">
+		<description>
+An interface should be used only to characterize the external behaviour of an
+implementing class: using an interface as a container of constants is a poor 
+usage pattern and not recommended.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//ClassOrInterfaceDeclaration[@Interface="true"]
+    [
+     count(.//MethodDeclaration)=0
+     and
+     count(.//FieldDeclaration)>0
+    ]
+    ]]>
+        </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public interface ConstantsInterface {
+   public static final int CONSTANT1=0;
+   public static final String CONSTANT2="1";
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="UnsynchronizedStaticDateFormatter" since="3.6"
+		message="Static DateFormatter objects should be accessed in a synchronized manner"
+		class="net.sourceforge.pmd.lang.java.rule.design.UnsynchronizedStaticDateFormatterRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UnsynchronizedStaticDateFormatter">
+		<description>
+SimpleDateFormat instances are not synchronized. Sun recommends using separate format instances
+for each thread. If multiple threads must access a static formatter, the formatter must be 
+synchronized either on method or block level.
+      </description>
+		<priority>3</priority>
+		<example>
+    <![CDATA[
+public class Foo {
+    private static final SimpleDateFormat sdf = new SimpleDateFormat();
+    void bar() {
+        sdf.format(); // poor, no thread-safety
+    }
+    synchronized void foo() {
+        sdf.format(); // preferred
+    }
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="PreserveStackTrace" since="3.7"
+		message="New exception is thrown in catch block, original stack trace may be lost"
+		class="net.sourceforge.pmd.lang.java.rule.design.PreserveStackTraceRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#PreserveStackTrace">
+		<description>
+Throwing a new exception from a catch block without passing the original exception into the
+new exception will cause the original stack trace to be lost making it difficult to debug 
+effectively.
+      </description>
+		<priority>3</priority>
+		<example>
+    <![CDATA[
+public class Foo {
+    void good() {
+        try{
+            Integer.parseInt("a");
+        } catch (Exception e) {
+            throw new Exception(e); // first possibility to create exception chain
+        }
+        try {
+            Integer.parseInt("a");
+        } catch (Exception e) {
+            throw (IllegalStateException)new IllegalStateException().initCause(e); // second possibility to create exception chain.
+        }
+    }
+    void bad() {
+        try{
+            Integer.parseInt("a");
+        } catch (Exception e) {
+            throw new Exception(e.getMessage());
+        }
+    }
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="UseCollectionIsEmpty" since="3.9"
+		message="Substitute calls to size() == 0 (or size() != 0, size() &gt; 0, size() &lt; 1) with calls to isEmpty()"
+		class="net.sourceforge.pmd.lang.java.rule.design.UseCollectionIsEmptyRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UseCollectionIsEmpty">
+		<description>
+The isEmpty() method on java.util.Collection is provided to determine if a collection has any elements.
+Comparing the value of size() to 0 does not convey intent as well as the isEmpty() method.
+      </description>
+		<priority>3</priority>
+		<example>
+    <![CDATA[
+public class Foo {
+	void good() {
+       	List foo = getList();
+		if (foo.isEmpty()) {
+			// blah
+		}
+   	}
+
+    void bad() {
+   	    List foo = getList();
+			if (foo.size() == 0) {
+				// blah
+			}
+    	}
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="ClassWithOnlyPrivateConstructorsShouldBeFinal"
+		language="java" since="4.1" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		message="A class which only has private constructors should be final"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ClassWithOnlyPrivateConstructorsShouldBeFinal">
+		<description>
+A class with only private constructors should be final, unless the private constructor 
+is invoked by a inner class.
+        </description>
+		<priority>1</priority>
+		<properties>
+			<property name="xpath">
+				<value><![CDATA[
+TypeDeclaration[count(../TypeDeclaration) = 1]/ClassOrInterfaceDeclaration
+[@Final = 'false']
+[count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[@Private = 'true']) >= 1 ]
+[count(./ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration/ConstructorDeclaration[(@Public = 'true') or (@Protected = 'true') or (@PackagePrivate = 'true')]) = 0 ]
+[not(.//ClassOrInterfaceDeclaration)]
+             ]]></value>
+			</property>
+		</properties>
+		<example><![CDATA[
+public class Foo {  //Should be final
+    private Foo() { }
+}
+     ]]></example>
+	</rule>
+
+
+	<rule name="EmptyMethodInAbstractClassShouldBeAbstract" language="java"
+		since="4.1" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		message="An empty method in an abstract class should be abstract instead"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#EmptyMethodInAbstractClassShouldBeAbstract">
+		<description>
+Empty or auto-generated methods in an abstract class should be tagged as abstract. This helps to remove their inapproprate 
+usage by developers who should be implementing their own versions in the concrete subclasses.
+        </description>
+		<priority>1</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+                    //ClassOrInterfaceDeclaration[@Abstract = 'true']
+                        /ClassOrInterfaceBody
+                        /ClassOrInterfaceBodyDeclaration
+                        /MethodDeclaration[@Abstract = 'false' and @Native = 'false']
+                        [
+                            ( boolean(./Block[count(./BlockStatement) =  1]/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral) = 'true' )
+                            or
+                            ( boolean(./Block[count(./BlockStatement) =  1]/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal[@Image = '0']) = 'true' )
+                            or
+                            ( boolean(./Block[count(./BlockStatement) =  1]/BlockStatement/Statement/ReturnStatement/Expression/PrimaryExpression/PrimaryPrefix/Literal[string-length(@Image) = 2]) = 'true' )
+                            or
+                            (./Block[count(./BlockStatement) =  1]/BlockStatement/Statement/EmptyStatement)
+                            or
+                            ( count (./Block/*) = 0 )
+                        ]
+                ]]>
+             </value>
+			</property>
+		</properties>
+		<example>
+        	<![CDATA[
+public abstract class ShouldBeAbstract {
+    public Object couldBeAbstract() {
+        // Should be abstract method ?
+        return null;
+    }
+
+    public void couldBeAbstract() {
+    }
+}
+	     	]]>
+    	</example>
+	</rule>
+
+	<rule name="SingularField" since="3.1"
+		message="Perhaps ''{0}'' could be replaced by a local variable."
+		class="net.sourceforge.pmd.lang.java.rule.design.SingularFieldRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#SingularField">
+		<description>
+      		<![CDATA[
+Fields whose scopes are limited to just single methods do not rely on the containing
+object to provide them to other methods. They may be better implemented as local variables
+within those methods.
+			]]>
+      </description>
+		<priority>3</priority>
+		<example><![CDATA[
+public class Foo {
+    private int x;  // no reason to exist at the Foo instance level
+    public void foo(int y) {
+     x = y + 5;
+     return x;
+    }
+}
+   ]]></example>
+	</rule>
+
+	<!-- Skipped ReturnEmptyArrayRatherThanNull -->
+	<!-- Skipped AbstractClassWithoutAnyMethod -->
+	<rule name="TooFewBranchesForASwitchStatement" language="java"
+		since="4.2" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		message="A switch with less than three branches is inefficient, use a 'if statement' instead."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#TooFewBranchesForASwitchStatement">
+		<description>
+Switch statements are indended to be used to support complex branching behaviour. Using a switch for only a few 
+cases is ill-advised, since switches are not as easy to understand as if-then statements. In these cases use the
+if-then statement to increase code readability.
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="minimumNumberCaseForASwitch" type="Integer"
+				description="Minimum number of branches for a switch" min="1" max="100"
+				value="3" />
+			<property name="xpath">
+				<value>
+                    <![CDATA[
+//SwitchStatement[
+    (count(.//SwitchLabel) < $minimumNumberCaseForASwitch)
+]
+                    ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+            <![CDATA[
+// With a minimumNumberCaseForASwitch of 3
+public class Foo {
+    public void bar() {
+        switch (condition) {
+            case ONE:
+                instruction;
+                break;
+            default:
+                break; // not enough for a 'switch' stmt, a simple 'if' stmt would have been more appropriate
+        }
+    }
+}
+            ]]>
+        </example>
+	</rule>
+
+
+	<rule name="LogicInversion" language="java" since="5.0"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		message="Use opposite operator instead of the logic complement operator."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#LogicInversion">
+		<description>
+Use opposite operator instead of negating the whole expression with a logic complement operator.
+	</description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+          <![CDATA[
+//UnaryExpressionNotPlusMinus[@Image='!']/PrimaryExpression/PrimaryPrefix/Expression[EqualityExpression or RelationalExpression]
+          ]]>
+          </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public boolean bar(int a, int b) {
+
+    if (!(a == b)) { // use !=
+         return false;
+     }
+
+    if (!(a < b)) { // use >=
+         return false;
+    }
+
+    return true;
+}
+    ]]>
+    </example>
+	</rule>
+
+	<rule name="UseVarargs" language="java" minimumLanguageVersion="1.5"
+		since="5.0"
+		message="Consider using varargs for methods or constructors which take an array the last parameter."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#UseVarargs">
+		<description>
+Java 5 introduced the varargs parameter declaration for methods and constructors.  This syntactic 
+sugar provides flexibility for users of these methods and constructors, allowing them to avoid 
+having to deal with the creation of an array.
+</description>
+		<priority>4</priority>
+		<properties>
+			<property name="xpath">
+				<value><![CDATA[
+//FormalParameters/FormalParameter
+    [position()=last()]
+    [@Array='true']
+    [@Varargs='false']
+    [not (./Type/ReferenceType[@Array='true'][PrimitiveType[@Image='byte']])]
+    [not (./Type/ReferenceType[ClassOrInterfaceType[@Image='Byte']])]
+    [not (./Type/PrimitiveType[@Image='byte'])]
+    [not (ancestor::MethodDeclaration/preceding-sibling::Annotation/*/Name[@Image='Override'])]
+    [not(
+        ancestor::MethodDeclaration
+            [@Public='true' and @Static='true']
+            [child::ResultType[@Void='true']] and
+        ancestor::MethodDeclarator[@Image='main'] and
+        ..[@ParameterCount='1'] and
+        ./Type/ReferenceType[ClassOrInterfaceType[@Image='String']]
+    )]
+            ]]></value>
+			</property>
+		</properties>
+		<example><![CDATA[
+public class Foo {
+   public void foo(String s, Object[] args) {
+      // Do something here...
+   }
+
+   public void bar(String s, Object... args) {
+      // Ahh, varargs tastes much better...
+   }
+}
+        ]]></example>
+	</rule>
+
+	<rule name="FieldDeclarationsShouldBeAtStartOfClass" language="java"
+		since="5.0"
+		message="Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes."
+		class="net.sourceforge.pmd.lang.java.rule.design.FieldDeclarationsShouldBeAtStartOfClassRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#FieldDeclarationsShouldBeAtStartOfClass">
+		<description>
+Fields should be declared at the top of the class, before any method declarations, constructors, initializers or inner classes.
+    </description>
+		<priority>3</priority>
+		<example>
+      <![CDATA[
+public class HelloWorldBean {
+
+  // Field declared before methods / inner classes - OK
+  private String _thing;
+
+  public String getMessage() {
+    return "Hello World!";
+  }
+
+  // Field declared after methods / inner classes - avoid this
+  private String _fieldInWrongLocation;
+}
+      ]]>
+    </example>
+	</rule>
+
+	<rule name="GodClass" language="java" since="5.0" message="Possible God class"
+		class="net.sourceforge.pmd.lang.java.rule.design.GodClassRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#GodClass">
+		<description>
+The God Class rule detects the God Class design flaw using metrics. God classes do too many things,
+are very big and overly complex. They should be split apart to be more object-oriented.
+The rule uses the detection strategy described in "Object-Oriented Metrics in Practice".
+The violations are reported against the entire class. See also the references:
+Michele Lanza and Radu Marinescu. Object-Oriented Metrics in Practice:
+Using Software Metrics to Characterize, Evaluate, and Improve the Design
+of Object-Oriented Systems. Springer, Berlin, 1 edition, October 2006. Page 80.
+        </description>
+		<priority>3</priority>
+	</rule>
+
+	<rule name="AvoidProtectedMethodInFinalClassNotExtending"
+		language="java" since="5.1"
+		message="Avoid protected methods in a final class that doesn't extend anything other than Object.  Change to private or package access."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#AvoidProtectedMethodInFinalClassNotExtending">
+		<description>
+Do not use protected methods in most final classes since they cannot be subclassed. This should 
+only be allowed in final classes that extend other classes with protected methods (whose
+visibility cannot be reduced). Clarify your intent by using private or package access modifiers instead.
+         </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[@Final='true' and not(ExtendsList)]
+/ClassOrInterfaceBody/ClassOrInterfaceBodyDeclaration
+/MethodDeclaration[@Protected='true'][MethodDeclarator/@Image != 'finalize']
+ ]]>
+                 </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public final class Foo {
+  private int bar() {}
+  protected int baz() {} // Foo cannot be subclassed, and doesn't extend anything, so is baz() really private or package visible? 
+}
+ ]]>
+         </example>
+	</rule>
+
+	<rule name="ConstantsInInterface" language="java" since="5.5"
+		message="Avoid constants in interfaces. Interfaces define types, constants are implementation details better placed in classes or enums. See Effective Java, item 19."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/design.html#ConstantsInInterface">
+		<description>
+Avoid constants in interfaces. Interfaces should define types, constants are implementation details
+better placed in classes or enums. See Effective Java, item 19.
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="ignoreIfHasMethods" type="Boolean"
+				description="Whether to ignore constants in interfaces if the interface defines any methods"
+				value="true" />
+			<property name="xpath">
+				<value>
+<![CDATA[
+//ClassOrInterfaceDeclaration[@Interface='true'][$ignoreIfHasMethods='false' or not(.//MethodDeclaration)]//FieldDeclaration
+ ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public interface ConstantInterface {
+    public static final int CONST1 = 1; // violation, no fields allowed in interface!
+    static final int CONST2 = 1; // violation, no fields allowed in interface!
+    final int CONST3 = 1; // violation, no fields allowed in interface!
+    int CONST4 = 1; // violation, no fields allowed in interface!
+}
+
+// with ignoreIfHasMethods = false
+public interface AnotherConstantInterface {
+    public static final int CONST1 = 1; // violation, no fields allowed in interface!
+    
+    int anyMethod();
+}
+
+// with ignoreIfHasMethods = true
+public interface YetAnotherConstantInterface {
+    public static final int CONST1 = 1; // no violation
+    
+    int anyMethod();
+}
+ ]]>
+        </example>
+	</rule>
+
+	<!-- codesize.xml -->
+	<rule name="NPathComplexity" since="3.9"
+		message="The method {0}() has an NPath complexity of {1}"
+		class="net.sourceforge.pmd.lang.java.rule.codesize.NPathComplexityRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#NPathComplexity">
+		<description>
+The NPath complexity of a method is the number of acyclic execution paths through that method.
+A threshold of 200 is generally considered the point where measures should be taken to reduce 
+complexity and increase readability.
+   </description>
+		<priority>3</priority>
+		<example>
+ <![CDATA[
+void bar() {	// this is something more complex than it needs to be,
+	if (y) {	// it should be broken down into smaller methods or functions
+		for (j = 0; j < m; j++) {
+			if (j > r) {
+				doSomething();
+				while (f < 5 ) {
+					anotherThing();
+					f -= 27;
+					}
+				} else {
+					tryThis();
+				}
+			}
+		}
+		if ( r - n > 45) {
+		   while (doMagic()) {
+		      findRabbits();
+		   }
+		}
+		try {
+			doSomethingDangerous();
+		} catch (Exception ex) {
+			makeAmends();
+			} finally {
+				dontDoItAgain();
+				}
+	}
+}
+
+ ]]>
+    </example>
+	</rule>
+
+	<rule name="ExcessiveMethodLength" since="0.6"
+		message="Avoid really long methods."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.ExcessiveMethodLengthRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#ExcessiveMethodLength">
+		<description>
+When methods are excessively long this usually indicates that the method is doing more than its
+name/signature might suggest. They also become challenging for others to digest since excessive 
+scrolling causes readers to lose focus.
+Try to reduce the method length by creating helper methods and removing any copy/pasted code.
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public void doSomething() {
+	System.out.println("Hello world!");
+	System.out.println("Hello world!");
+		// 98 copies omitted for brevity.
+}
+
+]]>
+   </example>
+
+	</rule>
+
+
+	<rule name="ExcessiveParameterList" since="0.9"
+		message="Avoid long parameter lists."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.ExcessiveParameterListRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#ExcessiveParameterList">
+		<description>
+Methods with numerous parameters are a challenge to maintain, especially if most of them share the
+same datatype. These situations usually denote the need for new objects to wrap the numerous parameters.
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public void addPerson(		// too many arguments liable to be mixed up
+	int birthYear, int birthMonth, int birthDate, int height, int weight, int ssn) {
+
+	. . . .
+}
+ 
+public void addPerson(		// preferred approach
+	Date birthdate, BodyMeasurements measurements, int ssn) {
+
+	. . . .
+}
+]]>
+   </example>
+
+	</rule>
+
+
+	<rule name="ExcessiveClassLength" since="0.6"
+		message="Avoid really long classes."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.ExcessiveClassLengthRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#ExcessiveClassLength">
+		<description>
+Excessive class file lengths are usually indications that the class may be burdened with excessive 
+responsibilities that could be provided by external classes or functions. In breaking these methods
+apart the code becomes more managable and ripe for reuse.
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo {
+	public void bar1() {
+    // 1000 lines of code
+	}
+	public void bar2() {
+    // 1000 lines of code
+	}
+    public void bar3() {
+    // 1000 lines of code
+	}
+	
+	
+    public void barN() {
+    // 1000 lines of code
+	}
+}
+]]>
+   </example>
+	</rule>
+
+
+	<rule name="CyclomaticComplexity" since="1.03"
+		message="The {0} ''{1}'' has a Cyclomatic Complexity of {2}."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.CyclomaticComplexityRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#CyclomaticComplexity">
+		<description>
+   		<![CDATA[
+Complexity directly affects maintenance costs is determined by the number of decision points in a method 
+plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity.
+		]]>
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo {		// This has a Cyclomatic Complexity = 12
+1   public void example()  {
+2       if (a == b)  {
+3           if (a1 == b1) {
+                fiddle();
+4           } else if a2 == b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+5       } else if (c == d) {
+6           while (c == d) {
+                fiddle();
+            }
+7        } else if (e == f) {
+8           for (int n = 0; n < h; n++) {
+                fiddle();
+            }
+        } else{
+            switch (z) {
+9               case 1:
+                    fiddle();
+                    break;
+10              case 2:
+                    fiddle();
+                    break;
+11              case 3:
+                    fiddle();
+                    break;
+12              default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="StdCyclomaticComplexity" since="5.1.2"
+		message="The {0} ''{1}'' has a Standard Cyclomatic Complexity of {2}."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.StdCyclomaticComplexityRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#StdCyclomaticComplexity">
+		<description>
+      <![CDATA[
+Complexity directly affects maintenance costs is determined by the number of decision points in a method 
+plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity.
+    ]]>
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo {    // This has a Cyclomatic Complexity = 12
+1   public void example()  {
+2       if (a == b || (c == d && e == f))  { // Only one
+3           if (a1 == b1) {
+                fiddle();
+4           } else if a2 == b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+5       } else if (c == d) {
+6           while (c == d) {
+                fiddle();
+            }
+7        } else if (e == f) {
+8           for (int n = 0; n < h; n++) {
+                fiddle();
+            }
+        } else{
+            switch (z) {
+9               case 1:
+                    fiddle();
+                    break;
+10              case 2:
+                    fiddle();
+                    break;
+11              case 3:
+                    fiddle();
+                    break;
+12              default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="ModifiedCyclomaticComplexity" since="5.1.2"
+		message="The {0} ''{1}'' has a Modified Cyclomatic Complexity of {2}."
+		class="net.sourceforge.pmd.lang.java.rule.codesize.ModifiedCyclomaticComplexityRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#ModifiedCyclomaticComplexity">
+		<description>
+      <![CDATA[
+Complexity directly affects maintenance costs is determined by the number of decision points in a method 
+plus one for the method entry.  The decision points include 'if', 'while', 'for', and 'case labels' calls.  
+Generally, numbers ranging from 1-4 denote low complexity, 5-7 denote moderate complexity, 8-10 denote
+high complexity, and 11+ is very high complexity. Modified complexity treats switch statements as a single
+decision point.
+    ]]>
+   </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo {    // This has a Cyclomatic Complexity = 9
+1   public void example()  {
+2       if (a == b)  {
+3           if (a1 == b1) {
+                fiddle();
+4           } else if a2 == b2) {
+                fiddle();
+            }  else {
+                fiddle();
+            }
+5       } else if (c == d) {
+6           while (c == d) {
+                fiddle();
+            }
+7        } else if (e == f) {
+8           for (int n = 0; n < h; n++) {
+                fiddle();
+            }
+        } else{
+9           switch (z) {
+                case 1:
+                    fiddle();
+                    break;
+                case 2:
+                    fiddle();
+                    break;
+                case 3:
+                    fiddle();
+                    break;
+                default:
+                    fiddle();
+                    break;
+            }
+        }
+    }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="ExcessivePublicCount" since="1.04"
+		message="This class has a bunch of public methods and attributes"
+		class="net.sourceforge.pmd.lang.java.rule.codesize.ExcessivePublicCountRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#ExcessivePublicCount">
+		<description>
+Classes with large numbers of public methods and attributes require disproportionate testing efforts
+since combinational side effects grow rapidly and increase risk. Refactoring these classes into
+smaller ones not only increases testability and reliability but also allows new variations to be
+developed easily.
+    </description>
+		<priority>3</priority>
+		<example>
+    <![CDATA[
+public class Foo {
+	public String value;
+	public Bar something;
+	public Variable var;
+ // [... more more public attributes ...]
+ 
+	public void doWork() {}
+	public void doMoreWork() {}
+	public void doWorkAgain() {}
+ // [... more more public methods ...]
+}
+    ]]>
+    </example>
+	</rule>
+
+	<rule name="TooManyFields" since="3.0" message="Too many fields"
+		class="net.sourceforge.pmd.lang.java.rule.codesize.TooManyFieldsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#TooManyFields">
+		<description>
+Classes that have too many fields can become unwieldy and could be redesigned to have fewer fields,
+possibly through grouping related fields in new objects.  For example, a class with individual 
+city/state/zip fields could park them within a single Address field.
+      </description>
+		<priority>3</priority>
+		<example>
+   <![CDATA[
+public class Person {	// too many separate fields
+   int birthYear;
+   int birthMonth;
+   int birthDate;
+   float height;
+   float weight;
+}
+
+public class Person {	// this is more manageable
+   Date birthDate;
+   BodyMeasurements measurements;
+}
+   ]]>
+      </example>
+	</rule>
+
+	<rule name="NcssMethodCount" message="The method {0}() has an NCSS line count of {1}"
+		since="3.9"
+		class="net.sourceforge.pmd.lang.java.rule.codesize.NcssMethodCountRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#NcssMethodCount">
+		<description>
+This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
+of code for a given method. NCSS ignores comments, and counts actual statements. Using this algorithm,
+lines of code that are split are counted as one.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo extends Bar {
+ public int methd() {
+     super.methd();
+
+
+
+
+
+ //this method only has 1 NCSS lines
+      return 1;
+ }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="NcssTypeCount" message="The type has an NCSS line count of {0}"
+		since="3.9" class="net.sourceforge.pmd.lang.java.rule.codesize.NcssTypeCountRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#NcssTypeCount">
+		<description>
+This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
+of code for a given type. NCSS ignores comments, and counts actual statements. Using this algorithm,
+lines of code that are split are counted as one.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo extends Bar {
+ public Foo() {
+ //this class only has 6 NCSS lines
+     super();
+
+
+
+
+
+      super.foo();
+ }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="NcssConstructorCount"
+		message="The constructor with {0} parameters has an NCSS line count of {1}"
+		since="3.9"
+		class="net.sourceforge.pmd.lang.java.rule.codesize.NcssConstructorCountRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#NcssConstructorCount">
+		<description>
+This rule uses the NCSS (Non-Commenting Source Statements) algorithm to determine the number of lines
+of code for a given constructor. NCSS ignores comments, and counts actual statements. Using this algorithm,
+lines of code that are split are counted as one.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Foo extends Bar {
+ public Foo() {
+     super();
+
+
+
+
+
+ //this constructor only has 1 NCSS lines
+      super.foo();
+ }
+}
+]]>
+   </example>
+	</rule>
+
+	<rule name="TooManyMethods" language="java" since="4.2"
+		class="net.sourceforge.pmd.lang.rule.XPathRule" message="This class has too many methods, consider refactoring it."
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/codesize.html#TooManyMethods">
+		<description>
+            <![CDATA[
+A class with too many methods is probably a good suspect for refactoring, in order to reduce its complexity and find a way to
+have more fine grained objects.
+            ]]>
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="maxmethods" type="Integer"
+				description="The method count reporting threshold" min="1" max="1000"
+				value="15" />
+			<property name="xpath">
+				<value>
+                    <!--  FIXME: Refine XPath to discard 'get' and 'set' methods with Block no more than 3 lines,
+                                something like this:
+                                    not (
+                                            (
+                                                starts-with(@Image,'get')
+                                                or
+                                                starts-with(@Image,'set')
+                                                or
+                                                starts-with(@Image,'is')
+                                                or
+                                                starts-with(@Image,'create')
+                                                or
+                                                starts-with(@Image,'test')
+                                            )
+                                            and (
+                                                    (
+                                                        (../Block/attribute::endLine)
+                                                         -
+                                                        (../Block/attribute::beginLine)
+                                                    ) <= 3
+                                            )
+                                        )
+                                This will avoid discarding 'real' method...
+                     -->
+                    <![CDATA[
+ //ClassOrInterfaceDeclaration/ClassOrInterfaceBody
+     [
+      count(./ClassOrInterfaceBodyDeclaration/MethodDeclaration/MethodDeclarator[
+         not (
+                starts-with(@Image,'get')
+                or
+                starts-with(@Image,'set')
+                or
+                starts-with(@Image,'is')
+                or
+                starts-with(@Image,'create')
+                or
+                starts-with(@Image,'test')
+            )
+      ]) > $maxmethods
+   ]
+                    ]]>
+                </value>
+			</property>
+		</properties>
+	</rule>
+
+	<!-- comments -->
+	<rule name="CommentRequired" since="5.1" message="Comment is required"
+		class="net.sourceforge.pmd.lang.java.rule.comments.CommentRequiredRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/comments.html#CommentRequired">
+		<description>
+Denotes whether comments are required (or unwanted) for specific language elements.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+/**
+* 
+*
+* @author George Bush
+*/
+]]>
+    </example>
+	</rule>
+
+	<rule name="CommentSize" since="5.0" message="Comment is too large"
+		class="net.sourceforge.pmd.lang.java.rule.comments.CommentSizeRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/comments.html#CommentSize">
+		<description>
+Determines whether the dimensions of non-header comments found are within the specified limits.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+/**
+*
+*	too many lines!
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*
+*/
+]]>
+    </example>
+	</rule>
+
+	<rule name="CommentContent" since="5.0" message="Invalid words or phrases found"
+		class="net.sourceforge.pmd.lang.java.rule.comments.CommentContentRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/comments.html#CommentContent">
+		<description>
+A rule for the politically correct... we don't want to offend anyone.
+  </description>
+		<priority>3</priority>
+		<example>
+      <![CDATA[
+//	OMG, this is horrible, Bob is an idiot !!!
+      ]]>
+  </example>
+	</rule>
+
+	<!-- junit -->
+	<rule name="JUnitStaticSuite" language="java" since="1.0"
+		message="You have a suite() method that is not both public and static, so JUnit won't call it to get your TestSuite.  Is that what you wanted to do?"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#JUnitStaticSuite">
+		<description>
+The suite() method in a JUnit test needs to be both public and static.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//MethodDeclaration[not(@Static='true') or not(@Public='true')]
+[MethodDeclarator/@Image='suite']
+[MethodDeclarator/FormalParameters/@ParameterCount=0]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+                ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+import junit.framework.*;
+
+public class Foo extends TestCase {
+   public void suite() {}         // oops, should be static
+   private static void suite() {} // oops, should be public
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="JUnitSpelling" language="java" since="1.0"
+		message="You may have misspelled a JUnit framework method (setUp or tearDown)"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#JUnitSpelling">
+		<description>
+Some JUnit framework methods are easy to misspell.
+    </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+              <![CDATA[
+//MethodDeclarator[(not(@Image = 'setUp')
+ and translate(@Image, 'SETuP', 'setUp') = 'setUp')
+ or (not(@Image = 'tearDown')
+ and translate(@Image, 'TEARdOWN', 'tearDown') = 'tearDown')]
+ [FormalParameters[count(*) = 0]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+              ]]>
+          </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+import junit.framework.*;
+
+public class Foo extends TestCase {
+   public void setup() {}    // oops, should be setUp
+   public void TearDown() {} // oops, should be tearDown
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="JUnitAssertionsShouldIncludeMessage" since="1.04"
+		message="JUnit assertions should include a message"
+		class="net.sourceforge.pmd.lang.java.rule.junit.JUnitAssertionsShouldIncludeMessageRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#JUnitAssertionsShouldIncludeMessage">
+		<description>
+JUnit assertions should include an informative message - i.e., use the three-argument version of 
+assertEquals(), not the two-argument version.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Foo extends TestCase {
+ public void testSomething() {
+  assertEquals("foo", "bar");
+  // Use the form:
+  // assertEquals("Foo does not equals bar", "foo", "bar");
+  // instead
+ }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="JUnitTestsShouldIncludeAssert" since="2.0"
+		message="JUnit tests should include assert() or fail()"
+		class="net.sourceforge.pmd.lang.java.rule.junit.JUnitTestsShouldIncludeAssertRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#JUnitTestsShouldIncludeAssert">
+		<description>
+JUnit tests should include at least one assertion.  This makes the tests more robust, and using assert 
+with messages provide the developer a clearer idea of what the test does.
+        </description>
+		<priority>3</priority>
+		<example>
+    <![CDATA[
+public class Foo extends TestCase {
+   public void testSomething() {
+      Bar b = findBar();
+   // This is better than having a NullPointerException
+   // assertNotNull("bar not found", b);
+   b.work();
+   }
+}
+    ]]>
+        </example>
+	</rule>
+
+	<rule name="TestClassWithoutTestCases" since="3.0"
+		message="This class name ends with 'Test' but contains no test cases"
+		class="net.sourceforge.pmd.lang.java.rule.junit.TestClassWithoutTestCasesRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#TestClassWithoutTestCases">
+		<description>
+Test classes end with the suffix Test. Having a non-test class with that name is not a good practice, 
+since most people will assume it is a test case. Test classes have test methods named testXXX.
+      </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+//Consider changing the name of the class if it is not a test
+//Consider adding test methods if it is a test
+public class CarTest {
+   public static void main(String[] args) {
+    // do something
+   }
+   // code
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="UnnecessaryBooleanAssertion" language="java" since="3.0"
+		message="assertTrue(true) or similar statements are unnecessary"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#UnnecessaryBooleanAssertion">
+		<description>
+A JUnit test assertion with a boolean literal is unnecessary since it always will evaluate to the same thing.
+Consider using flow control (in case of assertTrue(false) or similar) or simply removing
+statements like assertTrue(true) and assertFalse(false).  If you just want a test to halt after finding
+an error, use the fail() method and provide an indication message of why it did.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//StatementExpression
+[
+PrimaryExpression/PrimaryPrefix/Name[@Image='assertTrue' or  @Image='assertFalse']
+and
+PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression
+[PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
+or
+UnaryExpressionNotPlusMinus[@Image='!']
+/PrimaryExpression/PrimaryPrefix[Literal/BooleanLiteral or Name[count(../../*)=1]]]
+]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class SimpleTest extends TestCase {
+	public void testX() {
+		assertTrue(true);		 // serves no real purpose
+	}
+}
+]]>
+          </example>
+	</rule>
+
+	<rule name="UseAssertEqualsInsteadOfAssertTrue" language="java"
+		since="3.1" message="Use assertEquals(x, y) instead of assertTrue(x.equals(y))"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#UseAssertEqualsInsteadOfAssertTrue">
+		<description>
+This rule detects JUnit assertions in object equality. These assertions should be made by more specific methods, like assertEquals.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//PrimaryExpression[
+    PrimaryPrefix/Name[@Image = 'assertTrue']
+][
+    PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
+    [ends-with(@Image, '.equals')]
+]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+ ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class FooTest extends TestCase {
+	void testCode() {
+		Object a, b;
+		assertTrue(a.equals(b)); 					// bad usage
+		assertEquals(?a should equals b?, a, b);	// good usage
+	}
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="UseAssertSameInsteadOfAssertTrue" language="java"
+		since="3.1"
+		message="Use assertSame(x, y) instead of assertTrue(x==y), or assertNotSame(x,y) vs assertFalse(x==y)"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#UseAssertSameInsteadOfAssertTrue">
+		<description>
+This rule detects JUnit assertions in object references equality. These assertions should be made 
+by more specific methods, like assertSame, assertNotSame.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                <![CDATA[
+//PrimaryExpression[
+    PrimaryPrefix/Name
+     [@Image = 'assertTrue' or @Image = 'assertFalse']
+]
+[PrimarySuffix/Arguments
+ /ArgumentList/Expression
+ /EqualityExpression[count(.//NullLiteral) = 0]]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+ ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class FooTest extends TestCase {
+ void testCode() {
+  Object a, b;
+  assertTrue(a == b); // bad usage
+  assertSame(a, b);  // good usage
+ }
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="UseAssertNullInsteadOfAssertTrue" language="java"
+		since="3.5"
+		message="Use assertNull(x) instead of assertTrue(x==null), or assertNotNull(x) vs assertFalse(x==null)"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#UseAssertNullInsteadOfAssertTrue">
+		<description>
+This rule detects JUnit assertions in object references equality. These assertions should be made by 
+more specific methods, like assertNull, assertNotNull.
+       </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                 <![CDATA[
+//PrimaryExpression[
+ PrimaryPrefix/Name[@Image = 'assertTrue' or @Image = 'assertFalse']
+][
+ PrimarySuffix/Arguments/ArgumentList[
+  Expression/EqualityExpression/PrimaryExpression/PrimaryPrefix/Literal/NullLiteral
+ ]
+]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+  ]]>
+             </value>
+			</property>
+		</properties>
+		<example>
+ <![CDATA[
+ public class FooTest extends TestCase {
+  void testCode() {
+   Object a = doSomething();
+   assertTrue(a==null); // bad usage
+   assertNull(a);  // good usage
+   assertTrue(a != null); // bad usage
+   assertNotNull(a);  // good usage
+  }
+ }
+ ]]>
+       </example>
+	</rule>
+
+	<rule name="SimplifyBooleanAssertion" language="java" since="3.6"
+		message="assertTrue(!expr) can be replaced by assertFalse(expr)"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#SimplifyBooleanAssertion">
+		<description>
+Avoid negation in an assertTrue or assertFalse test.
+
+For example, rephrase:
+
+   assertTrue(!expr);
+   
+as:
+
+   assertFalse(expr);
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//StatementExpression
+[
+.//Name[@Image='assertTrue' or  @Image='assertFalse']
+and
+PrimaryExpression/PrimarySuffix/Arguments/ArgumentList
+ /Expression/UnaryExpressionNotPlusMinus[@Image='!']
+/PrimaryExpression/PrimaryPrefix
+]
+[ancestor::ClassOrInterfaceDeclaration[//ClassOrInterfaceType[pmd-java:typeof(@Image, 'junit.framework.TestCase','TestCase')] or //MarkerAnnotation/Name[pmd-java:typeof(@Image, 'org.junit.Test', 'Test')]]]
+]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class SimpleTest extends TestCase {
+   public void testX() {
+     assertTrue("not empty", !r.isEmpty()); // replace with assertFalse("not empty", r.isEmpty())
+     assertFalse(!r.isEmpty()); // replace with assertTrue(r.isEmpty())
+   }
+}
+]]>
+          </example>
+	</rule>
+	<rule name="JUnitTestContainsTooManyAsserts" language="java"
+		since="5.0"
+		message="JUnit tests should not contain more than ${maximumAsserts} assert(s)."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#JUnitTestContainsTooManyAsserts">
+		<description>
+JUnit tests should not contain too many asserts.  Many asserts are indicative of a complex test, for which 
+it is harder to verify correctness.  Consider breaking the test scenario into multiple, shorter test scenarios.  
+Customize the maximum number of assertions used by this Rule to suit your needs.
+		</description>
+		<priority>3</priority>
+		<properties>
+			<property name="maximumAsserts" type="Integer" min="1" max="1000"
+				description="Maximum number of Asserts in a test method" value="1" />
+			<property name="xpath">
+				<value>
+<![CDATA[
+//MethodDeclarator[(@Image[fn:matches(.,'^test')] or ../../Annotation/MarkerAnnotation/Name[@Image='Test']) and count(..//PrimaryPrefix/Name[@Image[fn:matches(.,'^assert')]]) > $maximumAsserts]
+]]>
+				</value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class MyTestCase extends TestCase {
+	// Ok
+	public void testMyCaseWithOneAssert() {
+		boolean myVar = false;		
+		assertFalse("should be false", myVar);
+	}
+
+	// Bad, too many asserts (assuming max=1)
+	public void testMyCaseWithMoreAsserts() {
+		boolean myVar = false;		
+		assertFalse("myVar should be false", myVar);
+		assertEquals("should equals false", false, myVar);
+	}
+}
+]]>
+		</example>
+	</rule>
+	<rule name="UseAssertTrueInsteadOfAssertEquals" language="java"
+		since="5.0"
+		message="Use assertTrue(x)/assertFalse(x) instead of assertEquals(true, x)/assertEquals(false, x)
+		or assertEquals(Boolean.TRUE, x)/assertEquals(Boolean.FALSE, x)."
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/junit.html#UseAssertTrueInsteadOfAssertEquals">
+		<description>
+When asserting a value is the same as a literal or Boxed boolean, use assertTrue/assertFalse, instead of assertEquals.
+		</description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//PrimaryExpression[PrimaryPrefix/Name[@Image = 'assertEquals']]
+[
+  PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Literal/BooleanLiteral
+  or
+  PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix
+  /Name[(@Image = 'Boolean.TRUE' or @Image = 'Boolean.FALSE')]
+]
+]]>
+			</value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class MyTestCase extends TestCase {
+	public void testMyCase() {
+		boolean myVar = true;
+		// Ok
+		assertTrue("myVar is true", myVar);
+		// Bad
+		assertEquals("myVar is true", true, myVar);
+		// Bad
+		assertEquals("myVar is false", false, myVar);
+		// Bad
+		assertEquals("myVar is true", Boolean.TRUE, myVar);
+		// Bad
+		assertEquals("myVar is false", Boolean.FALSE, myVar);
+	}
+}
+]]>
+		</example>
+	</rule>
+
+	<!-- optimizations -->
+	<rule name="LocalVariableCouldBeFinal" since="2.2"
+		message="Local variable ''{0}'' could be declared final"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.LocalVariableCouldBeFinalRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#LocalVariableCouldBeFinal">
+		<description>
+A local variable assigned only once can be declared final.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Bar {
+	public void foo () {
+		String txtA = "a"; 		// if txtA will not be assigned again it is better to do this:
+		final String txtB = "b";
+	}
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="MethodArgumentCouldBeFinal" since="2.2"
+		message="Parameter ''{0}'' is not assigned and could be declared final"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.MethodArgumentCouldBeFinalRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#MethodArgumentCouldBeFinal">
+		<description>
+A method argument that is never re-assigned within the method can be declared final.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public void foo1 (String param) {	// do stuff with param never assigning it
+  
+}
+
+public void foo2 (final String param) {	// better, do stuff with param never assigning it
+  
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="AvoidInstantiatingObjectsInLoops" since="2.2"
+		message="Avoid instantiating new objects inside loops"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.AvoidInstantiatingObjectsInLoopsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#AvoidInstantiatingObjectsInLoops">
+		<description>
+New objects created within loops should be checked to see if they can created outside them and reused.
+    </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public class Something {
+	public static void main( String as[] ) {  
+		for (int i = 0; i < 10; i++) {
+		    Foo f = new Foo(); // Avoid this whenever you can it's really expensive
+		}
+	}
+}
+]]>
+    </example>
+	</rule>
+
+	<rule name="UseArrayListInsteadOfVector" language="java" since="3.0"
+		message="Use ArrayList instead of Vector" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#UseArrayListInsteadOfVector">
+		<description>
+ArrayList is a much better Collection implementation than Vector if thread-safe operation is not required.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//CompilationUnit[count(ImportDeclaration) = 0 or count(ImportDeclaration/Name[@Image='java.util.Vector']) > 0]
+  //AllocationExpression/ClassOrInterfaceType
+    [@Image='Vector' or @Image='java.util.Vector']
+]]>
+              </value>
+			</property>
+		</properties>
+		<example>
+<![CDATA[
+public class SimpleTest extends TestCase {
+	public void testX() {
+		Collection c1 = new Vector();		
+		Collection c2 = new ArrayList();	// achieves the same with much better performance
+	}
+}
+]]>
+          </example>
+	</rule>
+
+	<rule name="SimplifyStartsWith" language="java" since="3.1"
+		message="This call to String.startsWith can be rewritten using String.charAt(0)"
+		class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#SimplifyStartsWith">
+		<description>
+Since it passes in a literal of length 1, calls to (string).startsWith can be rewritten using (string).charAt(0)
+at the expense of some readability.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+<![CDATA[
+//PrimaryExpression
+ [PrimaryPrefix/Name
+  [ends-with(@Image, '.startsWith')] or PrimarySuffix[@Image='startsWith']]
+ [PrimarySuffix/Arguments/ArgumentList
+  /Expression/PrimaryExpression/PrimaryPrefix
+  /Literal
+   [string-length(@Image)=3]
+   [starts-with(@Image, '"')]
+   [ends-with(@Image, '"')]
+ ]
+ ]]>
+            </value>
+			</property>
+		</properties>
+		<example>
+  <![CDATA[
+public class Foo {
+
+	boolean checkIt(String x) {
+		return x.startsWith("a");	// suboptimal
+	}
+  
+	boolean fasterCheckIt(String x) {
+		return x.charAt(0) == 'a';	//	faster approach
+	}
+}
+]]>
+      </example>
+	</rule>
+
+	<rule name="UseStringBufferForStringAppends" since="3.1"
+		message="Prefer StringBuffer over += for concatenating strings"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.UseStringBufferForStringAppendsRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#UseStringBufferForStringAppends">
+		<description>
+The use of the '+=' operator for appending strings causes the JVM to create and use an internal StringBuffer.
+If a non-trivial number of these concatenations are being used then the explicit use of a StringBuilder or 
+threadsafe StringBuffer is recommended to avoid this.
+           </description>
+		<priority>3</priority>
+		<example>
+      <![CDATA[
+public class Foo {
+  void bar() {
+    String a;
+    a = "foo";
+    a += " bar";
+   // better would be:
+   // StringBuilder a = new StringBuilder("foo");
+   // a.append(" bar);
+  }
+}
+      ]]>
+           </example>
+	</rule>
+
+	<rule name="UseArraysAsList" language="java" since="3.5"
+		message="Use asList instead of tight loops" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#UseArraysAsList">
+		<description>
+The java.util.Arrays class has a "asList" method that should be used when you want to create a new List from
+an array of objects. It is faster than executing a loop to copy all the elements of the array one by one.
+     </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+   <![CDATA[
+//Statement[
+    (ForStatement) and (ForStatement//VariableInitializer//Literal[@IntLiteral='true' and @Image='0']) and (count(.//IfStatement)=0)
+   ]
+   //StatementExpression[
+    PrimaryExpression/PrimaryPrefix/Name[
+     substring-before(@Image,'.add') = ancestor::MethodDeclaration//LocalVariableDeclaration[
+      ./Type//ClassOrInterfaceType[
+       @Image = 'Collection' or 
+       @Image = 'List' or @Image='ArrayList'
+      ]
+     ]
+     /VariableDeclarator/VariableDeclaratorId[
+      count(..//AllocationExpression/ClassOrInterfaceType[
+       @Image="ArrayList"
+      ]
+      )=1
+     ]/@Image
+    ]
+   and
+   PrimaryExpression/PrimarySuffix/Arguments/ArgumentList/Expression/PrimaryExpression/PrimaryPrefix/Name
+   [
+     @Image = ancestor::MethodDeclaration//LocalVariableDeclaration[@Array="true"]/VariableDeclarator/VariableDeclaratorId/@Image
+     or
+     @Image = ancestor::MethodDeclaration//FormalParameter/VariableDeclaratorId/@Image
+   ]
+   /../..[count(.//PrimarySuffix)
+   =1]/PrimarySuffix/Expression/PrimaryExpression/PrimaryPrefix
+   /Name
+   ]
+   ]]>
+       </value>
+			</property>
+		</properties>
+		<example>
+   <![CDATA[
+public class Test {
+  public void foo(Integer[] ints) {
+    // could just use Arrays.asList(ints)
+     List l= new ArrayList(10);
+     for (int i=0; i< 100; i++) {
+       l.add(ints[i]);
+     }
+     for (int i=0; i< 100; i++) {
+       l.add(a[i].toString()); // won't trigger the rule
+     }
+  }
+}
+   ]]>
+     </example>
+	</rule>
+
+
+	<rule name="AvoidArrayLoops" language="java" since="3.5"
+		message="System.arraycopy is more efficient" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#AvoidArrayLoops">
+		<description>
+Instead of manually copying data between two arrays, use the efficient System.arraycopy method instead.
+      </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+    <![CDATA[
+//Statement[(ForStatement or WhileStatement) and
+count(*//AssignmentOperator[@Image = '='])=1
+and
+*/Statement
+[
+./Block/BlockStatement/Statement/StatementExpression/PrimaryExpression
+/PrimaryPrefix/Name/../../PrimarySuffix/Expression
+[(PrimaryExpression or AdditiveExpression) and count
+(.//PrimaryPrefix/Name)=1]//PrimaryPrefix/Name/@Image
+and
+./Block/BlockStatement/Statement/StatementExpression/Expression/PrimaryExpression
+/PrimaryPrefix/Name/../../PrimarySuffix[count
+(..//PrimarySuffix)=1]/Expression[(PrimaryExpression
+or AdditiveExpression) and count(.//PrimaryPrefix/Name)=1]
+//PrimaryPrefix/Name/@Image
+]]
+    ]]>
+        </value>
+			</property>
+		</properties>
+		<example>
+    <![CDATA[
+public class Test {
+  public void bar() {
+    int[] a = new int[10];
+    int[] b = new int[10];
+    for (int i=0;i<10;i++) {
+      b[i]=a[i];
+    }
+  }
+}
+     // this will trigger the rule
+     for (int i=0;i<10;i++) {
+       b[i]=a[c[i]];
+     }
+
+  }
+}
+    ]]>
+      </example>
+	</rule>
+
+	<rule name="UnnecessaryWrapperObjectCreation" since="3.8"
+		message="Unnecessary wrapper object creation"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.UnnecessaryWrapperObjectCreationRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#UnnecessaryWrapperObjectCreation">
+		<description>
+Most wrapper classes provide static conversion methods that avoid the need to create intermediate objects
+just to create the primitive forms. Using these avoids the cost of creating objects that also need to be 
+garbage-collected later.
+      </description>
+		<priority>3</priority>
+		<example>
+<![CDATA[
+public int convert(String s) {
+  int i, i2;
+
+  i = Integer.valueOf(s).intValue(); // this wastes an object
+  i = Integer.parseInt(s); 			 // this is better
+
+  i2 = Integer.valueOf(i).intValue(); // this wastes an object
+  i2 = i; // this is better
+
+  String s3 = Integer.valueOf(i2).toString(); // this wastes an object
+  s3 = Integer.toString(i2); 		// this is better
+
+  return i2;
+}
+]]>
+          </example>
+	</rule>
+
+	<rule name="AddEmptyString" language="java" since="4.0"
+		message="Do not add empty strings" class="net.sourceforge.pmd.lang.rule.XPathRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#AddEmptyString">
+		<description>
+The conversion of literals to strings by concatenating them with empty strings is inefficient.
+It is much better to use one of the type-specific toString() methods instead.
+        </description>
+		<priority>3</priority>
+		<properties>
+			<property name="xpath">
+				<value>
+                    <![CDATA[ 
+//AdditiveExpression/PrimaryExpression/PrimaryPrefix/Literal[@Image='""']
+                ]]>
+                </value>
+			</property>
+		</properties>
+		<example>
+            <![CDATA[ 
+String s = "" + 123; 				// inefficient 
+String t = Integer.toString(456); 	// preferred approach
+            ]]>
+        </example>
+	</rule>
+
+	<rule name="RedundantFieldInitializer" language="java" since="5.0"
+		message="Avoid using redundant field initializer for ''${variableName}''"
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.RedundantFieldInitializerRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#RedundantFieldInitializer">
+		<description>
+Java will initialize fields with known default values so any explicit initialization of those same defaults
+is redundant and results in a larger class file (approximately three additional bytecode instructions per field).
+		</description>
+		<priority>3</priority>
+		<example>
+              <![CDATA[
+public class C {
+	boolean b	= false;	// examples of redundant initializers
+	byte by		= 0;
+	short s		= 0;
+	char c		= 0;
+	int i		= 0;
+	long l		= 0;
+	
+	float f		= .0f;    // all possible float literals
+	doable d	= 0d;     // all possible double literals
+	Object o	= null;
+	
+	MyClass mca[] = null;
+	int i1 = 0, ia1[] = null;
+	
+	class Nested {
+		boolean b = false;
+	}
+}
+              ]]>
+              </example>
+	</rule>
+
+	<rule name="PrematureDeclaration" language="java" since="5.0"
+		message="Avoid declaring a variable if it is unreferenced before a possible exit point."
+		class="net.sourceforge.pmd.lang.java.rule.optimizations.PrematureDeclarationRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/optimizations.html#PrematureDeclaration">
+		<description>
+Checks for variables that are defined before they might be used. A reference is deemed to be premature if it is created right before a block of code that doesn't use it that also has the ability to return or throw an exception.
+		</description>
+		<priority>3</priority>
+		<example>
+              <![CDATA[
+public int getLength(String[] strings) {
+  
+  int length = 0;	// declared prematurely
+
+  if (strings == null || strings.length == 0) return 0;
+  
+  for (String str : strings) {
+    length += str.length();
+    }
+
+  return length;
+}
+              ]]>
+              </example>
+	</rule>
+	<!-- sunsecure -->
+	<rule name="MethodReturnsInternalArray" since="2.2"
+		message="Returning ''{0}'' may expose an internal array."
+		class="net.sourceforge.pmd.lang.java.rule.sunsecure.MethodReturnsInternalArrayRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/sunsecure.html#MethodReturnsInternalArray">
+		<description>
+Exposing internal arrays to the caller violates object encapsulation since elements can be 
+removed or replaced outside of the object that owns it. It is safer to return a copy of the array.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class SecureSystem {
+  UserData [] ud;
+  public UserData [] getUserData() {
+      // Don't return directly the internal array, return a copy
+      return ud;
+  }
+}
+  ]]>
+      </example>
+	</rule>
+
+	<rule name="ArrayIsStoredDirectly" since="2.2"
+		message="The user-supplied array ''{0}'' is stored directly."
+		class="net.sourceforge.pmd.lang.java.rule.sunsecure.ArrayIsStoredDirectlyRule"
+		externalInfoUrl="https://pmd.github.io/pmd-5.5.1/pmd-java/rules/java/sunsecure.html#ArrayIsStoredDirectly">
+		<description>
+Constructors and methods receiving arrays should clone objects and store the copy.
+This prevents future changes from the user from affecting the original array.
+      </description>
+		<priority>3</priority>
+		<example>
+  <![CDATA[
+public class Foo {
+  private String [] x;
+    public void foo (String [] param) {
+      // Don't do this, make a copy of the array at least
+      this.x=param;
+    }
+}
+  ]]>
+      </example>
+	</rule>
 </ruleset>

--- a/gedbrowser-analytics/.eclipse-pmd
+++ b/gedbrowser-analytics/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-dao/.eclipse-pmd
+++ b/gedbrowser-dao/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-datamodel/.eclipse-pmd
+++ b/gedbrowser-datamodel/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-geographics/.eclipse-pmd
+++ b/gedbrowser-geographics/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-mongo-dao/.eclipse-pmd
+++ b/gedbrowser-mongo-dao/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-reader/.eclipse-pmd
+++ b/gedbrowser-reader/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedLine.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedLine.java
@@ -65,7 +65,7 @@ public abstract class AbstractGedLine {
     /**
      * @param arraySource Array of strings containing lines of GEDCOM.
      */
-    @SuppressWarnings("PMD.UseVarargs")
+    @SuppressWarnings({ "PMD.UseVarargs", "PMD.ArrayIsStoredDirectly" })
     protected AbstractGedLine(final String[] arraySource) {
         this.source = new ArraySource(arraySource);
         this.lineNumber = 0;

--- a/gedbrowser-renderer/.eclipse-pmd
+++ b/gedbrowser-renderer/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/gedbrowser/.eclipse-pmd
+++ b/gedbrowser/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/geoservice-client/.eclipse-pmd
+++ b/geoservice-client/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/geoservice-common/.eclipse-pmd
+++ b/geoservice-common/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/geoservice-persistence-mongo/.eclipse-pmd
+++ b/geoservice-persistence-mongo/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/geoservice-persistence/.eclipse-pmd
+++ b/geoservice-persistence/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>

--- a/geoservice/.eclipse-pmd
+++ b/geoservice/.eclipse-pmd
@@ -2,15 +2,6 @@
 <eclipse-pmd xmlns="http://acanda.ch/eclipse-pmd/0.8" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://acanda.ch/eclipse-pmd/0.8 http://acanda.ch/eclipse-pmd/eclipse-pmd-0.8.xsd">
   <analysis enabled="true" />
   <rulesets>
-    <ruleset name="Basic" ref="gedbrowser-top/config/rulesets/java/basic.xml" refcontext="workspace" />
-    <ruleset name="Code Size" ref="gedbrowser-top/config/rulesets/java/codesize.xml" refcontext="workspace" />
-    <ruleset name="Comments" ref="gedbrowser-top/config/rulesets/java/comments.xml" refcontext="workspace" />
-    <ruleset name="Coupling" ref="gedbrowser-top/config/rulesets/java/coupling.xml" refcontext="workspace" />
-    <ruleset name="Design" ref="gedbrowser-top/config/rulesets/java/design.xml" refcontext="workspace" />
-    <ruleset name="Import Statements" ref="gedbrowser-top/config/rulesets/java/imports.xml" refcontext="workspace" />
-    <ruleset name="JUnit" ref="gedbrowser-top/config/rulesets/java/junit.xml" refcontext="workspace" />
-    <ruleset name="Optimization" ref="gedbrowser-top/config/rulesets/java/optimizations.xml" refcontext="workspace" />
-    <ruleset name="Security Code Guidelines" ref="gedbrowser-top/config/rulesets/java/sunsecure.xml" refcontext="workspace" />
-    <ruleset name="Unused Code" ref="gedbrowser-top/config/rulesets/java/unusedcode.xml" refcontext="workspace" />
+    <ruleset name="pmd" ref="gedbrowser-top/config/pmd.xml" refcontext="workspace" />
   </rulesets>
 </eclipse-pmd>


### PR DESCRIPTION
The Eclipse plugin doesn't like the rule reference syntax.
Copied the rule definitions from the various individual
files into the main pmd.xml. That allows both Maven and
Eclipse to builds to work off of the exact same definition.