### PR TITLE
Fixes #213 - travis build on master publish when label

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  except: master
+
 language: java
 
 services:
@@ -68,31 +71,6 @@ after_success:
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=iexplore      -Dselenium.platform=win8  -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=MicrosoftEdge -Dselenium.platform=win10 -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=chrome        -Dselenium.platform=win10 -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
+  - ./config/before-deploy.sh
+  - ./config/deploy.sh
 #  - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=firefox       -Dselenium.platform=linux -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
-#  - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=htmlunit 2>&1 | grep -v org.apache.http
-
-
-#### old after_success stuff #####
-
-#  - ./config/docker-shakedown.sh
-#  - ./config/before-deploy.sh
-#  - ./config/deploy.sh
-#  - wget http://chromedriver.storage.googleapis.com/2.10/chromedriver_linux64.zip
-#  - mkdir -p /home/travis/bin
-#  - unzip chromedriver_linux64.zip -d /home/travis/bin/
-#  - sudo apt-get update
-#  - sudo apt-get install -y libappindicator1 fonts-liberation
-#  - wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
-#  - sudo dpkg -i google-chrome*.deb
-#  - which google-chrome
-#  - export CHROME_DRIVER=/home/travis/bin/chromedriver
-#  - export CHROME_BIN=/usr/bin/google-chrome
-#  # - export CHROME="-Dwebdriver.chrome.driver=${CHROME_DRIVER} -Dchrome.binary=${CHROME_BIN}"
-#  - wget https://github.com/mozilla/geckodriver/releases/download/v0.14.0/geckodriver-v0.14.0-linux64.tar.gz
-#  - tar -xzf geckodriver-v0.14.0-linux64.tar.gz -C /home/travis/bin
-#  - export DISPLAY=:99.0
-#  - sh -e /etc/init.d/xvfb start
-#  - sleep 3
-#  - ps -ef | grep -i xvfb
-#  - cd gedbrowser-selenium
-#  - mvn integration-test --settings=../config/settings.xml -Pintegration-test -Dselenium.port=8080 -DprintNavigation=true ${CHROME}

--- a/gedbrowser-analytics/pom.xml
+++ b/gedbrowser-analytics/pom.xml
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gedbrowser-dao/pom.xml
+++ b/gedbrowser-dao/pom.xml
@@ -133,12 +133,12 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/gedbrowser-geographics/pom.xml
+++ b/gedbrowser-geographics/pom.xml
@@ -40,12 +40,12 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/gedbrowser-mongo-dao/pom.xml
+++ b/gedbrowser-mongo-dao/pom.xml
@@ -133,17 +133,17 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-dao</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/gedbrowser-reader/pom.xml
+++ b/gedbrowser-reader/pom.xml
@@ -40,7 +40,7 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/gedbrowser-renderer/pom.xml
+++ b/gedbrowser-renderer/pom.xml
@@ -40,22 +40,22 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-analytics</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-client</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/gedbrowser/pom.xml
+++ b/gedbrowser/pom.xml
@@ -55,37 +55,37 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-datamodel</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-reader</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-renderer</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-mongo-dao</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-analytics</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>gedbrowser-geographics</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-client</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/geoservice-client/pom.xml
+++ b/geoservice-client/pom.xml
@@ -147,12 +147,11 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-persistence</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>de.grundid.opendatalab</groupId>
       <artifactId>geojson-jackson</artifactId>
-      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/geoservice-persistence-mongo/pom.xml
+++ b/geoservice-persistence-mongo/pom.xml
@@ -133,12 +133,12 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-common</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-persistence</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>

--- a/geoservice-persistence/pom.xml
+++ b/geoservice-persistence/pom.xml
@@ -133,12 +133,11 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-common</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>de.grundid.opendatalab</groupId>
       <artifactId>geojson-jackson</artifactId>
-      <version>1.8</version>
     </dependency>
     <dependency>
       <groupId>com.google.maps</groupId>

--- a/geoservice/pom.xml
+++ b/geoservice/pom.xml
@@ -55,12 +55,12 @@
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-persistence</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
     <dependency>
       <groupId>org.schoellerfamily.gedbrowser</groupId>
       <artifactId>geoservice-persistence-mongo</artifactId>
-      <version>1.1.2-SNAPSHOT</version>
+      <version>${project.parent.version}</version>
     </dependency>
 
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -46,9 +46,6 @@
   </developers>
 
   <properties>
-    <docker.image.prefix>dickschoeller</docker.image.prefix>
-    <docker.image.tag>snapshot</docker.image.tag>
-
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
@@ -70,12 +67,21 @@
     <selenium-client-driver.version>1.0.2</selenium-client-driver.version>
     <htmlunit-driver.version>2.26</htmlunit-driver.version>
 
+    <jxr-plugin.version>2.5</jxr-plugin.version>
+    <findbugs-plugin.version>3.0.4</findbugs-plugin.version>
+    <checkstyle-plugin.version>2.17</checkstyle-plugin.version>
+    <checkstyle-version>7.6.1</checkstyle-version>
+    <pmd-plugin.version>3.7</pmd-plugin.version>
     <!-- 5.6.0 has an incompatible API change. -->
     <!-- Can't upgrade until the maven-pmd-plugin is upgraded. -->
     <pmd-version>5.5.6</pmd-version>
-    <checkstyle-version>7.6.1</checkstyle-version>
+    <compiler-plugin.version>3.6.1</compiler-plugin.version>
     <failsafe.version>2.20</failsafe.version>
     <surefire.version>2.20</surefire.version>
+    <jacoco-plugin.version>0.7.9</jacoco-plugin.version>
+
+    <docker.image.prefix>dickschoeller</docker.image.prefix>
+    <docker.image.tag>snapshot</docker.image.tag>
 
     <config-dir>${project.basedir}/config</config-dir>
     <server.port>8080</server.port>
@@ -107,23 +113,23 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jxr-plugin</artifactId>
-        <version>2.5</version>
+        <version>${jxr-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>findbugs-maven-plugin</artifactId>
-        <version>3.0.4</version>
+        <version>${findbugs-plugin.version}</version>
       </plugin>
       <plugin>
         <!-- New vendor of checkstyle plugin out there. -->
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
-        <version>2.17</version>
+        <version>${checkstyle-plugin.version}</version>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-pmd-plugin</artifactId>
-        <version>3.7</version>
+        <version>${pmd-plugin.version}</version>
         <configuration>
           <linkXRef>true</linkXRef>
           <sourceEncoding>utf-8</sourceEncoding>
@@ -141,7 +147,7 @@
       <plugins>
         <plugin>
           <artifactId>maven-compiler-plugin</artifactId>
-          <version>3.6.1</version>
+          <version>${compiler-plugin.version}</version>
           <configuration>
             <source>1.8</source>
             <target>1.8</target>
@@ -171,7 +177,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-pmd-plugin</artifactId>
-          <version>3.7</version>
+          <version>${pmd-plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>net.sourceforge.pmd</groupId>
@@ -233,7 +239,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-checkstyle-plugin</artifactId>
-          <version>2.17</version>
+          <version>${checkstyle-plugin.version}</version>
           <dependencies>
             <dependency>
               <groupId>com.puppycrawl.tools</groupId>
@@ -254,7 +260,7 @@
         <plugin>
           <groupId>org.jacoco</groupId>
           <artifactId>jacoco-maven-plugin</artifactId>
-          <version>0.7.9</version>
+          <version>${jacoco-plugin.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -477,6 +483,11 @@
         <groupId>com.saucelabs</groupId>
         <artifactId>sauce_junit</artifactId>
         <version>2.1.23</version>
+      </dependency>
+      <dependency>
+        <groupId>de.grundid.opendatalab</groupId>
+        <artifactId>geojson-jackson</artifactId>
+        <version>1.8</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
1. Control the versions of all of gedbrowser from the top
2. Change travis to not build master. This should build on label drop.
3. Clean up other stuff in travis