### PR TITLE
Fixes #307 - Make the GedObjectToGedDocumentMongoConverter a bean

### DIFF
--- a/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/GedDocumentLoader.java
+++ b/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/GedDocumentLoader.java
@@ -1,0 +1,18 @@
+package org.schoellerfamily.gedbrowser.persistence;
+
+import java.util.List;
+
+import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.domain.GedDocument;
+
+/**
+ * @author Dick Schoeller
+ */
+public interface GedDocumentLoader {
+    /**
+     * @param document the document
+     * @param gedAttributes the attributes to add
+     */
+    void loadAttributes(GedDocument<?> document,
+            List<GedObject> gedAttributes);
+}

--- a/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/domain/GedDocument.java
+++ b/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/domain/GedDocument.java
@@ -3,6 +3,7 @@ package org.schoellerfamily.gedbrowser.persistence.domain;
 import java.util.List;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 
 /**
  * @author Dick Schoeller
@@ -76,20 +77,23 @@ public interface GedDocument<G extends GedObject> {
     void setAttributes(List<GedDocument<? extends GedObject>> attributes);
 
     /**
+     * Add a single attribute to the set of attributes.
+     *
+     * @param attribute the attribute
+     */
+    void addAttribute(GedDocument<?> attribute);
+
+    /**
      * Empty out the attributes list.
      */
     void clearAttributes();
 
     /**
-     * @param gedAttributes load in all of the attributes (sub-objects)
-     */
-    void loadAttributes(List<GedObject> gedAttributes);
-
-    /**
      * This method is used to assign the GedObject and to pass its values along
      * to the fields for persistence.
      *
+     * @param loader load the document attributes
      * @param ged the associated gedObject
      */
-    void loadGedObject(GedObject ged);
+    void loadGedObject(GedDocumentLoader loader, GedObject ged);
 }

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/AttributeDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/AttributeDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.AttributeDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -27,7 +28,8 @@ public class AttributeDocumentMongo extends GedDocumentMongo<Attribute>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Attribute)) {
             throw new PersistenceException("Wrong type");
         }
@@ -36,7 +38,7 @@ public class AttributeDocumentMongo extends GedDocumentMongo<Attribute>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/ChildDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/ChildDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.Child;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.ChildDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class ChildDocumentMongo extends GedDocumentMongo<Child>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Child)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class ChildDocumentMongo extends GedDocumentMongo<Child>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/DateDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/DateDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.Date;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.DateDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class DateDocumentMongo extends GedDocumentMongo<Date>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Date)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class DateDocumentMongo extends GedDocumentMongo<Date>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamCDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamCDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.FamC;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.FamCDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class FamCDocumentMongo extends GedDocumentMongo<FamC>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof FamC)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class FamCDocumentMongo extends GedDocumentMongo<FamC>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamSDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamSDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.FamS;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.FamSDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class FamSDocumentMongo extends GedDocumentMongo<FamS>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof FamS)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class FamSDocumentMongo extends GedDocumentMongo<FamS>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamilyDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamilyDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.Family;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.FamilyDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class FamilyDocumentMongo extends GedDocumentMongo<Family>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Family)) {
             throw new PersistenceException("Wrong type");
         }
@@ -41,7 +43,7 @@ public class FamilyDocumentMongo extends GedDocumentMongo<Family>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/GedDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/GedDocumentMongo.java
@@ -4,10 +4,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.domain.GedDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
-import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.annotation.Transient;
 import org.springframework.data.mongodb.core.index.Indexed;
@@ -42,11 +42,6 @@ public abstract class GedDocumentMongo<G extends GedObject>
     /** */
     @Transient
     private G gedObject;
-
-    /** */
-    @Transient
-    private final transient GedObjectToGedDocumentMongoConverter
-        toDocConverter = GedObjectToGedDocumentMongoConverter.getInstance();
 
     /**
      * {@inheritDoc}
@@ -150,6 +145,14 @@ public abstract class GedDocumentMongo<G extends GedObject>
      * {@inheritDoc}
      */
     @Override
+    public final void addAttribute(final GedDocument<?> attribute) {
+        attributes.add(attribute);
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
     public final void clearAttributes() {
         attributes.clear();
     }
@@ -158,25 +161,7 @@ public abstract class GedDocumentMongo<G extends GedObject>
      * {@inheritDoc}
      */
     @Override
-    public final void loadAttributes(final List<GedObject> gedAttributes) {
-        this.attributes.clear();
-        for (final GedObject ged : gedAttributes) {
-            // TODO this happens because appenders create a list entry when they
-            // are not retained.
-            if (ged == null) {
-                continue;
-            }
-            final GedDocument<?> documentAttribute =
-                    toDocConverter.createGedDocument(ged);
-            this.attributes.add(documentAttribute);
-        }
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public abstract void loadGedObject(GedObject ged);
+    public abstract void loadGedObject(GedDocumentLoader loader, GedObject ged);
 
     /**
      * Accept a visitor.

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HeadDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HeadDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Head;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.HeadDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class HeadDocumentMongo extends GedDocumentMongo<Head>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Head)) {
             throw new PersistenceException("Wrong type");
         }
@@ -41,7 +43,7 @@ public class HeadDocumentMongo extends GedDocumentMongo<Head>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HusbandDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HusbandDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Husband;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.HusbandDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class HusbandDocumentMongo extends GedDocumentMongo<Husband>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Husband)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class HusbandDocumentMongo extends GedDocumentMongo<Husband>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/MultimediaDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/MultimediaDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Multimedia;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.MultimediaDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -27,7 +28,8 @@ public class MultimediaDocumentMongo extends GedDocumentMongo<Multimedia>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Multimedia)) {
             throw new PersistenceException("Wrong type");
         }
@@ -36,7 +38,7 @@ public class MultimediaDocumentMongo extends GedDocumentMongo<Multimedia>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/NameDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/NameDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Name;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
@@ -22,7 +23,8 @@ public class NameDocumentMongo extends GedDocumentMongo<Name> {
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Name)) {
             throw new PersistenceException("Wrong type");
         }
@@ -30,7 +32,7 @@ public class NameDocumentMongo extends GedDocumentMongo<Name> {
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PersonDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PersonDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.PersonDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -38,7 +39,8 @@ public class PersonDocumentMongo extends GedDocumentMongo<Person>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Person)) {
             throw new PersistenceException("Wrong type");
         }
@@ -46,10 +48,9 @@ public class PersonDocumentMongo extends GedDocumentMongo<Person>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
         indexName = gedObject.getIndexName();
         surname = gedObject.getSurname();
-        // TODO may want to put in birth date handling for duplicate names
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PlaceDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PlaceDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Place;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.PlaceDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class PlaceDocumentMongo extends GedDocumentMongo<Place>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Place)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class PlaceDocumentMongo extends GedDocumentMongo<Place>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/RootDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/RootDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class RootDocumentMongo extends GedDocumentMongo<Root>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Root)) {
             throw new PersistenceException("Wrong type");
         }
@@ -42,7 +44,7 @@ public class RootDocumentMongo extends GedDocumentMongo<Root>
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
         this.setDbName(gedObject.getDbName());
-//        this.loadAttributes(gedObject.getAttributes());
+        // Note that we don't load attributes on purpose here.
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.SourceDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class SourceDocumentMongo extends GedDocumentMongo<Source>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Source)) {
             throw new PersistenceException("Wrong type");
         }
@@ -41,7 +43,7 @@ public class SourceDocumentMongo extends GedDocumentMongo<Source>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceLinkDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceLinkDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.SourceLink;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.SourceLinkDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class SourceLinkDocumentMongo extends GedDocumentMongo<SourceLink>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof SourceLink)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class SourceLinkDocumentMongo extends GedDocumentMongo<SourceLink>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmittorDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmittorDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Submittor;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.SubmittorDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class SubmittorDocumentMongo extends GedDocumentMongo<Submittor>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Submittor)) {
             throw new PersistenceException("Wrong type");
         }
@@ -41,7 +43,7 @@ public class SubmittorDocumentMongo extends GedDocumentMongo<Submittor>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmittorLinkDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmittorLinkDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.SubmittorLink;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.SubmittorLinkDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class SubmittorLinkDocumentMongo extends GedDocumentMongo<SubmittorLink>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof SubmittorLink)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class SubmittorLinkDocumentMongo extends GedDocumentMongo<SubmittorLink>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/TrailerDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/TrailerDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Trailer;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.TrailerDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -33,7 +34,8 @@ public class TrailerDocumentMongo extends GedDocumentMongo<Trailer>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Trailer)) {
             throw new PersistenceException("Wrong type");
         }
@@ -41,7 +43,7 @@ public class TrailerDocumentMongo extends GedDocumentMongo<Trailer>
         this.setGedObject(gedObject);
         this.setString(gedObject.getString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/WifeDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/WifeDocumentMongo.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain;
 
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Wife;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.WifeDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
@@ -24,7 +25,8 @@ public class WifeDocumentMongo extends GedDocumentMongo<Wife>
      * {@inheritDoc}
      */
     @Override
-    public final void loadGedObject(final GedObject ged) {
+    public final void loadGedObject(final GedDocumentLoader loader,
+            final GedObject ged) {
         if (!(ged instanceof Wife)) {
             throw new PersistenceException("Wrong type");
         }
@@ -32,7 +34,7 @@ public class WifeDocumentMongo extends GedDocumentMongo<Wife>
         this.setGedObject(gedObject);
         this.setString(gedObject.getToString());
         this.setFilename(gedObject.getFilename());
-        this.loadAttributes(gedObject.getAttributes());
+        loader.loadAttributes(this, gedObject.getAttributes());
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
@@ -43,8 +43,8 @@ public final class RepositoryFinderMongo
     private transient RepositoryManagerMongo repositoryManager;
 
     /** */
-    private final GedObjectToGedDocumentMongoConverter toDocConverter =
-            GedObjectToGedDocumentMongoConverter.getInstance();
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /**
      * Ordered list of classes to process. This order represents the

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
@@ -27,11 +28,23 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.domain.SubmittorDocument
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.SubmittorLinkDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.TrailerDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.WifeDocumentMongo;
+import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
+import org.schoellerfamily.gedbrowser.persistence.mongo.repository.test.MongoTestConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Dick Schoeller
  */
+@SuppressWarnings("PMD.ExcessiveImports")
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { MongoTestConfiguration.class })
 public final class BadLoadTest {
+    /** */
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
+
     /** */
     private final GedObject root = new Root();
     /** */
@@ -42,7 +55,7 @@ public final class BadLoadTest {
     public void testBadAttributeLoad() {
         final AttributeDocumentMongo ad = new AttributeDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -55,7 +68,7 @@ public final class BadLoadTest {
     public void testBadChildLoad() {
         final ChildDocumentMongo ad = new ChildDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -68,7 +81,7 @@ public final class BadLoadTest {
     public void testBadDateLoad() {
         final DateDocumentMongo ad = new DateDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -81,7 +94,7 @@ public final class BadLoadTest {
     public void testBadFamCLoad() {
         final FamCDocumentMongo ad = new FamCDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -94,7 +107,7 @@ public final class BadLoadTest {
     public void testBadFamilyLoad() {
         final FamilyDocumentMongo ad = new FamilyDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -107,7 +120,7 @@ public final class BadLoadTest {
     public void testBadFamSLoad() {
         final FamSDocumentMongo ad = new FamSDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -120,7 +133,7 @@ public final class BadLoadTest {
     public void testBadHeadLoad() {
         final HeadDocumentMongo ad = new HeadDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -133,7 +146,7 @@ public final class BadLoadTest {
     public void testBadHusbandLoad() {
         final HusbandDocumentMongo ad = new HusbandDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -146,7 +159,7 @@ public final class BadLoadTest {
     public void testBadMultimediaLoad() {
         final MultimediaDocumentMongo ad = new MultimediaDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -159,7 +172,7 @@ public final class BadLoadTest {
     public void testBadNameLoad() {
         final NameDocumentMongo ad = new NameDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -172,7 +185,7 @@ public final class BadLoadTest {
     public void testBadPersonLoad() {
         final PersonDocumentMongo ad = new PersonDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -185,7 +198,7 @@ public final class BadLoadTest {
     public void testBadPlaceLoad() {
         final PlaceDocumentMongo ad = new PlaceDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -198,7 +211,7 @@ public final class BadLoadTest {
     public void testBadRootLoad() {
         final RootDocumentMongo ad = new RootDocumentMongo();
         try {
-            ad.loadGedObject(attr);
+            ad.loadGedObject(toDocConverter, attr);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -211,7 +224,7 @@ public final class BadLoadTest {
     public void testBadSourceLoad() {
         final SourceDocumentMongo ad = new SourceDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -224,7 +237,7 @@ public final class BadLoadTest {
     public void testBadSourceLinkLoad() {
         final SourceLinkDocumentMongo ad = new SourceLinkDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -237,7 +250,7 @@ public final class BadLoadTest {
     public void testBadSubmittorLoad() {
         final SubmittorDocumentMongo ad = new SubmittorDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -250,7 +263,7 @@ public final class BadLoadTest {
     public void testBadSubmittorLinkLoad() {
         final SubmittorLinkDocumentMongo ad = new SubmittorLinkDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -263,7 +276,7 @@ public final class BadLoadTest {
     public void testBadTrailerLoad() {
         final TrailerDocumentMongo ad = new TrailerDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",
@@ -276,7 +289,7 @@ public final class BadLoadTest {
     public void testBadWifeLoad() {
         final WifeDocumentMongo ad = new WifeDocumentMongo();
         try {
-            ad.loadGedObject(root);
+            ad.loadGedObject(toDocConverter, root);
             fail("Expected to throw persistence exception");
         } catch (PersistenceException e) {
             assertEquals("Expected a wrong type exception",

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
@@ -26,6 +26,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Submittor;
 import org.schoellerfamily.gedbrowser.datamodel.SubmittorLink;
 import org.schoellerfamily.gedbrowser.datamodel.Trailer;
 import org.schoellerfamily.gedbrowser.datamodel.Wife;
+import org.schoellerfamily.gedbrowser.persistence.GedDocumentLoader;
 import org.schoellerfamily.gedbrowser.persistence.PersistenceException;
 import org.schoellerfamily.gedbrowser.persistence.domain.GedDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.AttributeDocumentMongo;
@@ -58,9 +59,9 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 /**
  * @author Dick Schoeller
  */
+@SuppressWarnings("PMD.ExcessiveImports")
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
-@SuppressWarnings("PMD.ExcessiveImports")
 public final class GedDocumentMongoToGedObjectConverterTest {
     /** */
     @Autowired
@@ -245,7 +246,8 @@ public final class GedDocumentMongoToGedObjectConverterTest {
              * {@inheritDoc}
              */
             @Override
-            public void loadGedObject(final GedObject ged) {
+            public void loadGedObject(final GedDocumentLoader loader,
+                    final GedObject ged) {
                 // Intentionally empty
             }
 

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
@@ -6,6 +6,7 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
 import org.schoellerfamily.gedbrowser.datamodel.Child;
 import org.schoellerfamily.gedbrowser.datamodel.Date;
@@ -49,15 +50,21 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.domain.SubmittorLinkDocu
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.TrailerDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.WifeDocumentMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
+import org.schoellerfamily.gedbrowser.persistence.mongo.repository.test.MongoTestConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
 /**
  * @author Dick Schoeller
  */
 @SuppressWarnings("PMD.ExcessiveImports")
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { MongoTestConfiguration.class })
 public class GedObjectToGedDocumentMongoConverterTest {
     /** */
-    private final GedObjectToGedDocumentMongoConverter toDocConverter =
-            GedObjectToGedDocumentMongoConverter.getInstance();
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /** */
     @Test

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
@@ -32,8 +32,8 @@ public final class RepositoryFixture {
     private transient TestDataReader reader;
 
     /** */
-    private final GedObjectToGedDocumentMongoConverter toDocConverter =
-            GedObjectToGedDocumentMongoConverter.getInstance();
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /**
      * This is private because this is a singleton.

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/HeadRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/HeadRepositoryTest.java
@@ -43,10 +43,6 @@ public final class HeadRepositoryTest {
     private static final String HEADER_STRING = "Header";
 
     /** */
-//    @Autowired
-//    private transient RootDocumentRepositoryMongo rootDocumentRepository;
-
-    /** */
     @Autowired
     private transient PersonDocumentRepositoryMongo personDocumentRepository;
     /** */
@@ -68,8 +64,8 @@ public final class HeadRepositoryTest {
     @Autowired
     private transient GedDocumentMongoToGedObjectConverter toObjConverter;
     /** */
-    private final GedObjectToGedDocumentMongoConverter toDocConverter =
-            GedObjectToGedDocumentMongoConverter.getInstance();
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /** */
     private transient Root root;
@@ -118,7 +114,6 @@ public final class HeadRepositoryTest {
         final HeadDocument headdoc = headDocumentRepository.
                 findByFileAndString(root.getFilename(), HEADER_STRING);
         final Head head = (Head) toObjConverter.createGedObject(root, headdoc);
-        // TODO fails, should string be "Head" "Header" or blank?
         assertEquals("Expected header string",
                 HEADER_STRING, head.getString());
     }
@@ -129,7 +124,6 @@ public final class HeadRepositoryTest {
         final HeadDocument headdoc = headDocumentRepository.
                 findByRootAndString(rootDocument, HEADER_STRING);
         final Head head = (Head) toObjConverter.createGedObject(root, headdoc);
-        // TODO fails, should string be "Head" "Header" or blank?
         assertEquals("Expected header string",
                 HEADER_STRING, head.getString());
     }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
@@ -6,6 +6,7 @@ import java.util.UUID;
 import org.schoellerfamily.gedbrowser.datamodel.finder.FinderStrategy;
 import org.schoellerfamily.gedbrowser.persistence.mongo.fixture.RepositoryFixture;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedDocumentMongoToGedObjectConverter;
+import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.FamilyDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.HeadDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.PersonDocumentRepositoryMongo;
@@ -131,5 +132,13 @@ public class MongoTestConfiguration {
     @Bean
     public GedDocumentMongoToGedObjectConverter toGedObjectConverter() {
         return new GedDocumentMongoToGedObjectConverter();
+    }
+
+    /**
+     * @return the converter
+     */
+    @Bean
+    public GedObjectToGedDocumentMongoConverter toGedDocumentConverter() {
+        return new GedObjectToGedDocumentMongoConverter();
     }
 }

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/MongoConfiguration.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/MongoConfiguration.java
@@ -9,6 +9,7 @@ import org.schoellerfamily.gedbrowser.controller.ApplicationInfoImpl;
 import org.schoellerfamily.gedbrowser.datamodel.finder.FinderStrategy;
 import org.schoellerfamily.gedbrowser.loader.GedFileLoader;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedDocumentMongoToGedObjectConverter;
+import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.
     FamilyDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.
@@ -189,5 +190,13 @@ public class MongoConfiguration {
     @Bean
     public GedDocumentMongoToGedObjectConverter toGedObjectConverter() {
         return new GedDocumentMongoToGedObjectConverter();
+    }
+
+    /**
+     * @return the converter
+     */
+    @Bean
+    public GedObjectToGedDocumentMongoConverter toGedDocumentConverter() {
+        return new GedObjectToGedDocumentMongoConverter();
     }
 }

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/loader/GedFileLoader.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/loader/GedFileLoader.java
@@ -52,9 +52,11 @@ public class GedFileLoader {
     @Autowired
     private transient GedObjectCreator g2g;
 
-    /** */
-    private final GedObjectToGedDocumentMongoConverter toDocConverter =
-            GedObjectToGedDocumentMongoConverter.getInstance();
+    /**
+     * Implements conversion from GedObject to GedDocumentMongo.
+     */
+    @Autowired
+    private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /** */
     @Value("${gedbrowser.home}")


### PR DESCRIPTION
* This required moving the loadAttributes algorithm out of
  GedDocumentMongo and into GedObjectToGedDocumentMongoConverter.
* Change the interface and all the implementations to pass in the
  converter to the loadGedObject.
* Configuration classes have an added bean defintion