### PR TITLE
Fixes #78 - firefox clicks not working

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -71,8 +71,7 @@ after_success:
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=iexplore      -Dselenium.platform=win8  -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=MicrosoftEdge -Dselenium.platform=win10 -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
   - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=chrome        -Dselenium.platform=win10 -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
+  - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=firefox       -Dselenium.platform=win8  -Dselenium.timeout=45 -Dselenium.version=3.3.1 2>&1 | grep 'Tests run'
   - cd ..
   - ./config/before-deploy.sh
   - ./config/deploy.sh
-# Tried firefox 33.0 and tests still go south
-#  - mvn integration-test verify --settings=../config/settings.xml -B ${INTEGRATION_TEST_ARGS} -Dselenium.browser.name=firefox       -Dselenium.platform=win8  -Dselenium.timeout=45 -Dselenium.version=3.3.1 -Dselenium.browser.version=33.0 2>&1 | grep 'Tests run'

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PageBase.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PageBase.java
@@ -13,7 +13,6 @@ import org.openqa.selenium.WebElement;
  * @author Dick Schoeller
  */
 public class PageBase {
-
     /** Associated Selenium driver. */
     private final WebDriver driver;
 
@@ -166,6 +165,16 @@ public class PageBase {
      */
     public final void waitForPageLoaded() {
         waiter.waitForPageLoaded(driver);
+    }
+
+
+    /**
+     * Wait for page load on real browser. Doesn't work for HTML driver.
+     *
+     * @param newUrl the target URL of the load
+     */
+    public void waitForPageLoaded(final String newUrl) {
+        waiter.waitForPageLoaded(driver, newUrl);
     }
 
     /**

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PageWaiter.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PageWaiter.java
@@ -13,4 +13,13 @@ public interface PageWaiter {
      * @param driver the driver
      */
     void waitForPageLoaded(WebDriver driver);
+
+    /**
+     * Wait for the page to load. Different implementations for different
+     * drivers.
+     *
+     * @param driver the driver
+     * @param newUrl the target URL
+     */
+    void waitForPageLoaded(WebDriver driver, String newUrl);
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PersonPage.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/PersonPage.java
@@ -456,8 +456,9 @@ public final class PersonPage extends PageBase {
      * @return the newly created page object
      */
     private PersonPage navigate(final WebElement element) {
+        final String newUrl = element.getAttribute("href");
         element.click();
-        waitForPageLoaded();
+        waitForPageLoaded(newUrl);
         final String url = getCurrentUrl();
         final int index = url.indexOf("id=") + "id=".length();
         final String idText = url.substring(index);

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/RemotePageWaiter.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/RemotePageWaiter.java
@@ -2,6 +2,8 @@ package org.schoellerfamily.gedbrowser.selenium.test;
 
 import static org.junit.Assert.fail;
 
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
 import org.openqa.selenium.By;
 import org.openqa.selenium.JavascriptExecutor;
 import org.openqa.selenium.WebDriver;
@@ -14,6 +16,9 @@ import org.openqa.selenium.support.ui.WebDriverWait;
  * @author Dick Schoeller
  */
 public class RemotePageWaiter implements PageWaiter {
+    /** Logger. */
+    private final transient Log logger = LogFactory.getLog(getClass());
+
     /** */
     private final long timeout;
 
@@ -31,6 +36,7 @@ public class RemotePageWaiter implements PageWaiter {
      */
     @Override
     public void waitForPageLoaded(final WebDriver driver) {
+        logger.debug("Waiting for readState");
         final ExpectedCondition<Boolean> expectation =
                 new ExpectedCondition<Boolean>() {
             /**
@@ -49,6 +55,7 @@ public class RemotePageWaiter implements PageWaiter {
         } catch (Throwable error) {
             fail("Timeout waiting for Page Load Request to complete.");
         }
+        logger.debug("Waiting for maintainerMail");
         final Wait<WebDriver> wait2 = new WebDriverWait(driver, timeout);
         try {
             wait2.until(ExpectedConditions
@@ -58,4 +65,18 @@ public class RemotePageWaiter implements PageWaiter {
         }
     }
 
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public void waitForPageLoaded(final WebDriver driver, final String newUrl) {
+        logger.debug("Waiting for new URL");
+        final Wait<WebDriver> wait3 = new WebDriverWait(driver, timeout);
+        try {
+            wait3.until(ExpectedConditions.urlToBe(newUrl));
+        } catch (Throwable error) {
+            fail("Timeout waiting for url.");
+        }
+        waitForPageLoaded(driver);
+    }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/SourcePage.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/SourcePage.java
@@ -54,7 +54,10 @@ public final class SourcePage extends PageBase {
         this.baseUrl = baseUrl;
         final WebElement source = driver.findElements(By.linkText(id))
                 .get(0);
+
+        final String newUrl = source.getAttribute("href");
         source.click();
+        waitForPageLoaded(newUrl);
     }
 
     /**


### PR DESCRIPTION
It turns out the wait needs to be slightly different. This is
fixed by first waiting for a URL change, then the rest of the
wait behavior.