### PR TITLE
Fixes #342 - RepositoryManagerMongo too many fields

### DIFF
--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
@@ -85,7 +85,7 @@ public final class RepositoryFinderMongo
             throw new IllegalArgumentException("Owner must be root");
         }
         final FindableDocument<? extends GedObject, ? extends GedDocument<?>>
-            repo = repositoryManager.getRepoMap().get(clazz);
+            repo = repositoryManager.get(clazz);
         if (repo == null) {
             return null;
         }
@@ -224,7 +224,7 @@ public final class RepositoryFinderMongo
             throw new IllegalArgumentException("Owner must be root");
         }
         final FindableDocument<? extends GedObject, ? extends GedDocument<?>>
-            repo = repositoryManager.getRepoMap().get(clazz);
+            repo = repositoryManager.get(clazz);
         if (repo == null) {
             return null;
         }

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryManagerMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryManagerMongo.java
@@ -7,6 +7,7 @@ import org.schoellerfamily.gedbrowser.datamodel.Family;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Head;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
+import org.schoellerfamily.gedbrowser.datamodel.Root;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
 import org.schoellerfamily.gedbrowser.datamodel.Submittor;
 import org.schoellerfamily.gedbrowser.datamodel.Trailer;
@@ -18,68 +19,106 @@ import org.springframework.beans.factory.annotation.Autowired;
  * @author Dick Schoeller
  */
 public class RepositoryManagerMongo {
-    /** */
-    @Autowired
-    private transient RootDocumentRepositoryMongo rootDocumentRepository;
+    /**
+     * This map manages the relationship between GedObject classes and
+     * repositories.
+     */
+    private final Map<Class<? extends GedObject>, Object>
+        classToRepoMap = new HashMap<>();
 
-    /** */
+    /**
+     * @param repository
+     *            the repository
+     */
     @Autowired
-    private transient PersonDocumentRepositoryMongo personDocumentRepository;
-
-    /** */
-    @Autowired
-    private transient FamilyDocumentRepositoryMongo familyDocumentRepository;
-
-    /** */
-    @Autowired
-    private transient SourceDocumentRepositoryMongo sourceDocumentRepository;
-
-    /** */
-    @Autowired
-    private transient HeadDocumentRepositoryMongo headDocumentRepository;
-
-    /** */
-    @Autowired
-    private transient SubmittorDocumentRepositoryMongo
-        submittorDocumentRepository;
-
-    /** */
-    @Autowired
-    private transient TrailerDocumentRepositoryMongo trailerDocumentRepository;
+    public void setRootDocumentRepository(
+            final RootDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Root.class, repository);
+    }
 
     /**
      * @return the repository
      */
     public final RootDocumentRepositoryMongo getRootDocumentRepository() {
-        return rootDocumentRepository;
+        return (RootDocumentRepositoryMongo) classToRepoMap.get(Root.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setPersonDocumentRepository(
+            final PersonDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Person.class, repository);
     }
 
     /**
      * @return the repository
      */
     public final PersonDocumentRepositoryMongo getPersonDocumentRepository() {
-        return personDocumentRepository;
+        return (PersonDocumentRepositoryMongo) classToRepoMap.get(Person.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setFamilyDocumentRepository(
+            final FamilyDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Family.class, repository);
     }
 
     /**
      * @return the repository
      */
     public final FamilyDocumentRepositoryMongo getFamilyDocumentRepository() {
-        return familyDocumentRepository;
+        return (FamilyDocumentRepositoryMongo) classToRepoMap.get(Family.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setSourceDocumentRepository(
+            final SourceDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Source.class, repository);
     }
 
     /**
      * @return the repository
      */
     public final SourceDocumentRepositoryMongo getSourceDocumentRepository() {
-        return sourceDocumentRepository;
+        return (SourceDocumentRepositoryMongo) classToRepoMap.get(Source.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setHeadDocumentRepository(
+            final HeadDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Head.class, repository);
     }
 
     /**
      * @return the repository
      */
     public final HeadDocumentRepositoryMongo getHeadDocumentRepository() {
-        return headDocumentRepository;
+        return (HeadDocumentRepositoryMongo) classToRepoMap.get(Head.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setSubmittorDocumentRepository(
+            final SubmittorDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Submittor.class, repository);
     }
 
     /**
@@ -87,49 +126,52 @@ public class RepositoryManagerMongo {
      */
     public final SubmittorDocumentRepositoryMongo
         getSubmittorDocumentRepository() {
-        return submittorDocumentRepository;
+        return (SubmittorDocumentRepositoryMongo) classToRepoMap
+                .get(Submittor.class);
+    }
+
+    /**
+     * @param repository
+     *            the repository
+     */
+    @Autowired
+    public void setTrailerDocumentRepository(
+            final TrailerDocumentRepositoryMongo repository) {
+        classToRepoMap.put(Trailer.class, repository);
     }
 
     /**
      * @return the repository
      */
     public final TrailerDocumentRepositoryMongo getTrailerDocumentRepository() {
-        return trailerDocumentRepository;
+        return (TrailerDocumentRepositoryMongo) classToRepoMap
+                .get(Trailer.class);
     }
 
     /**
-     * Get the map that we need to go from class to repository.
+     * Get a repository based on the class of ged object we are working with.
      *
-     * @return the map
+     * @param clazz
+     *            the class of ged object
+     * @return the repository
      */
-    public final Map<Class<? extends GedObject>,
-    FindableDocument<? extends GedObject,
-            ? extends GedDocument<?>>> getRepoMap() {
-        /**
-         * Holds the connections between ged classes and repositories.
-         */
-        final Map<Class<? extends GedObject>,
-            FindableDocument<? extends GedObject,
-                    ? extends GedDocument<?>>> repoMap = new HashMap<>();
-        repoMap.put(Family.class, familyDocumentRepository);
-        repoMap.put(Head.class, headDocumentRepository);
-        repoMap.put(Person.class, personDocumentRepository);
-        repoMap.put(Source.class, sourceDocumentRepository);
-        repoMap.put(Submittor.class, submittorDocumentRepository);
-        repoMap.put(Trailer.class, trailerDocumentRepository);
-        return repoMap;
+    @SuppressWarnings("unchecked")
+    public final FindableDocument<? extends GedObject, ? extends GedDocument<?>>
+        get(final Class<? extends GedObject> clazz) {
+        return (FindableDocument<? extends GedObject, ? extends GedDocument<?>>)
+                classToRepoMap .get(clazz);
     }
 
     /**
      * Clear all of the repositories in the dataset.
      */
     public void reset() {
-        rootDocumentRepository.deleteAll();
-        personDocumentRepository.deleteAll();
-        familyDocumentRepository.deleteAll();
-        sourceDocumentRepository.deleteAll();
-        headDocumentRepository.deleteAll();
-        submittorDocumentRepository.deleteAll();
-        trailerDocumentRepository.deleteAll();
+        getRootDocumentRepository().deleteAll();
+        getPersonDocumentRepository().deleteAll();
+        getFamilyDocumentRepository().deleteAll();
+        getSourceDocumentRepository().deleteAll();
+        getHeadDocumentRepository().deleteAll();
+        getSubmittorDocumentRepository().deleteAll();
+        getTrailerDocumentRepository().deleteAll();
     }
 }


### PR DESCRIPTION
Reduced the number of fields by autowiring setters and holding
the repositories in a map. This reduces the severity of complexity
warnings associated with the class as a whole.