### PR TITLE
Fixes #385 - source in header isn't a link

### DIFF
--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedObjectFactory.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedObjectFactory.java
@@ -552,7 +552,11 @@ public abstract class AbstractGedObjectFactory {
             if (parent.getParent() == null) {
                 return new Source(parent, xref);
             } else {
-                return SOURLINK_FACTORY.create(parent, xref, tag, tail);
+                if (tail.contains("@")) {
+                    return SOURLINK_FACTORY.create(parent, xref, tag, tail);
+                } else {
+                    return ATTR_FACTORY.create(parent, xref, tag, tail);
+                }
             }
         }
     }


### PR DESCRIPTION
The source item in a GEDCOM header isn't a link. It is a block
describing the source software of that particular GEDCOM file.
As such it needs to be treated as an attribute of the header
and not as a link or as a source object.

Change the object factory used when parsing GEDCOM files to
reflect that changed thinking.