### PR TITLE
Reduce the number of uncovered lines in GeoCodeLoader

### DIFF
--- a/config/before-install.sh
+++ b/config/before-install.sh
@@ -4,6 +4,7 @@ mkdir /home/travis/gedbrowser
 cp $(find . -name 'gl120368.ged' | head -n 1) /home/travis/gedbrowser
 cp $(find . -name 'mini-schoeller.ged' | head -n 1) /home/travis/gedbrowser
 cp $(find . -name 'testUserFile.csv' | head -n 1) /home/travis/gedbrowser
+cp $(find . -name 'test.txt' | head -n 1) /home/travis/gedbrowser
 echo $GOOGLE_GEOCODING_KEY > /home/travis/gedbrowser/google-geocoding-key
 echo $GOOGLE_MAPPING_KEY >> /home/travis/gedbrowser/google-geocoding-key
 docker run -v /home/travis/data:/data/db --name mongo -p 28001:27017 -d mongo 2>&1 | grep 'Status'

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/persistence/test/GeoCodeTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/persistence/test/GeoCodeTest.java
@@ -40,8 +40,8 @@ import com.google.maps.model.LatLng;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @ContextConfiguration(loader = AnnotationConfigContextLoader.class)
-@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.GodClass",
-        "PMD.TooManyStaticImports", "PMD.ExcessivePublicCount" })
+@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.ExcessivePublicCount",
+        "PMD.GodClass", "PMD.TooManyStaticImports" })
 public final class GeoCodeTest {
     /** Logger. */
     private final transient Log logger = LogFactory.getLog(getClass());


### PR DESCRIPTION
Fixes #346 - geocodeloader coverage

Added tests that load the file as a file, instead of only as a stream
resource.