### PR TITLE
Fixes #526 - GedDocumentFileLoader tests

### DIFF
--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
@@ -57,7 +57,7 @@ public class GedDocumentFileLoader {
     private transient GedObjectToGedDocumentMongoConverter toDocConverter;
 
     /** */
-    @Value("${gedbrowser.home}")
+    @Value("${gedbrowser.home:/var/lib/gedbrowser}")
     private transient String gedbrowserHome;
 
     /**
@@ -144,6 +144,7 @@ public class GedDocumentFileLoader {
             repositoryManager.getRootDocumentRepository().save(rootdoc);
         } catch (DataAccessException e) {
             logger.error("Could not save root: " + root.getDbName(), e);
+            return null;
         }
         return rootdoc;
     }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
@@ -1,0 +1,170 @@
+package org.schoellerfamily.gedbrowser.persistence.mongo.loader.test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+
+import java.util.Iterator;
+import java.util.Map;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
+import org.schoellerfamily.gedbrowser.persistence.mongo.domain.RootDocumentMongo;
+import org.schoellerfamily.gedbrowser.persistence.mongo.loader.GedDocumentFileLoader;
+import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryManagerMongo;
+import org.schoellerfamily.gedbrowser.persistence.mongo.repository.test.MongoTestConfiguration;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Dick Schoeller
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@ContextConfiguration(classes = { MongoTestConfiguration.class })
+public class GedDocumentFileLoaderTest {
+    /** */
+    @Autowired
+    private transient GedDocumentFileLoader loader;
+
+    /**
+     * Manages the persistence repository.
+     */
+    @Autowired
+    private transient RepositoryManagerMongo repositoryManager;
+
+    /** */
+    @Test
+    public void testReset() {
+        loader.loadDocument("mini-schoeller");
+        loader.reset();
+        assertRepositoryEmpty();
+    }
+
+    /** */
+    @Test
+    public void testLoad() {
+        loader.reset();
+        assertJustThisOne(loader.loadDocument("mini-schoeller"));
+    }
+
+    /** */
+    @Test
+    public void testBadLoad() {
+        loader.reset();
+        assertNull("Should be not found", loader.loadDocument("foofy"));
+    }
+
+    /** */
+    @Test
+    public void testReloadAll() {
+        loader.reset();
+        loader.loadDocument("mini-schoeller");
+        loader.reloadAll();
+        assertRepositoryHasOne();
+    }
+
+    /** */
+    @Test
+    public void testDetails() {
+        loader.reset();
+        loader.loadDocument("mini-schoeller");
+        final Map<String, Object> details = loader.details("mini-schoeller");
+        assertDetails(details);
+    }
+
+    /** */
+    @Test
+    public void testAllDetails() {
+        loader.reset();
+        loader.loadDocument("mini-schoeller");
+        for (final Map<String, Object> details : loader.details()) {
+            assertDetails(details);
+        }
+    }
+
+    /**
+     * @param details the details map
+     */
+    private void assertDetails(final Map<String, Object> details) {
+        assertEquals("dbname mismatch", "mini-schoeller",
+                details.get("dbname"));
+        assertEquals("filename mismatch",
+                "/var/lib/gedbrowser/mini-schoeller.ged",
+                details.get("filename"));
+        final long expectedPersonsCount = 20;
+        final long expectedFamiliesCount = 7;
+        final long expectedSourceCount = 11;
+        assertEquals("person count mismatch",
+                expectedPersonsCount, details.get("persons"));
+        assertEquals("family count mismatch",
+                expectedFamiliesCount, details.get("families"));
+        assertEquals("sources count mismatch",
+                expectedSourceCount, details.get("sources"));
+    }
+
+    /** */
+    @Test
+    public void testReload() {
+        loader.reset();
+        final RootDocument rootDocument1 =
+                loader.loadDocument("mini-schoeller");
+        final RootDocument resultDoc =
+                loader.loadDocument("mini-schoeller");
+        checkSame(rootDocument1, resultDoc);
+        assertJustThisOne(resultDoc);
+    }
+
+    /**
+     * Assert that we should have only the newly loaded document
+     * this because we first cleared everything.
+     *
+     * @param resultDoc the newly loaded document
+     */
+    private void assertJustThisOne(final RootDocument resultDoc) {
+        for (final RootDocument foundDoc : findAll()) {
+            checkSame(resultDoc, foundDoc);
+        }
+    }
+
+    /**
+     * Check that the 2 documents are actually the same object.
+     *
+     * @param doc1 first document
+     * @param doc2 second document
+     */
+    private void checkSame(final RootDocument doc1, final RootDocument doc2) {
+        assertEquals("should be the same DB object",
+                doc1.getIdString(), doc2.getIdString());
+    }
+
+    /**
+     * Check that the repository is empty.
+     */
+    private void assertRepositoryEmpty() {
+        for (final RootDocument doc : findAll()) {
+            fail("should not have found document " + doc.getDbName());
+        }
+    }
+
+    /**
+     * Check that the repository is empty.
+     */
+    private void assertRepositoryHasOne() {
+        int count = 0;
+        final Iterator<RootDocumentMongo> iterator = findAll().iterator();
+        while (iterator.hasNext()) {
+            iterator.next();
+            count++;
+        }
+        assertEquals("Count should be 1", 1, count);
+    }
+
+    /**
+     * @return all of the root documents in the repository
+     */
+    private Iterable<RootDocumentMongo> findAll() {
+        return repositoryManager.getRootDocumentRepository().findAll();
+    }
+}

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
@@ -15,6 +15,7 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.loader.GedDocumentFileLo
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryManagerMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.test.MongoTestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 
@@ -33,6 +34,10 @@ public class GedDocumentFileLoaderTest {
      */
     @Autowired
     private transient RepositoryManagerMongo repositoryManager;
+
+    /** */
+    @Value("${gedbrowser.home:/var/lib/gedbrowser}")
+    private transient String gedbrowserHome;
 
     /** */
     @Test
@@ -91,7 +96,7 @@ public class GedDocumentFileLoaderTest {
         assertEquals("dbname mismatch", "mini-schoeller",
                 details.get("dbname"));
         assertEquals("filename mismatch",
-                "/var/lib/gedbrowser/mini-schoeller.ged",
+                gedbrowserHome + "/mini-schoeller.ged",
                 details.get("filename"));
         final long expectedPersonsCount = 20;
         final long expectedFamiliesCount = 7;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/package-info.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/package-info.java
@@ -1,0 +1,5 @@
+/**
+ * Copyright 2017 Richard Schoeller
+ * Tests for gedbrowser file reader that loads into MongoDB.
+ */
+package org.schoellerfamily.gedbrowser.persistence.mongo.loader.test;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/MongoTestConfiguration.java
@@ -7,6 +7,7 @@ import org.schoellerfamily.gedbrowser.datamodel.finder.FinderStrategy;
 import org.schoellerfamily.gedbrowser.persistence.mongo.fixture.RepositoryFixture;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedDocumentMongoToGedObjectConverter;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
+import org.schoellerfamily.gedbrowser.persistence.mongo.loader.GedDocumentFileLoader;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.FamilyDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.HeadDocumentRepositoryMongo;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.NoteDocumentRepositoryMongo;
@@ -53,6 +54,7 @@ import com.mongodb.MongoClient;
                         TrailerDocumentRepositoryMongo.class
                 },
                 type = FilterType.ASSIGNABLE_TYPE))
+@SuppressWarnings("PMD.ExcessiveImports")
 public class MongoTestConfiguration {
     /** */
     @Value("${spring.data.mongodb.host:localhost}")
@@ -144,5 +146,13 @@ public class MongoTestConfiguration {
     @Bean
     public GedObjectToGedDocumentMongoConverter toGedDocumentConverter() {
         return new GedObjectToGedDocumentMongoConverter();
+    }
+
+    /**
+     * @return the loader
+     */
+    @Bean
+    public GedDocumentFileLoader gedDocumentFileLoader() {
+        return new GedDocumentFileLoader();
     }
 }


### PR DESCRIPTION
Expand the test coverage. Because the underlying functionality
that the loader uses is tested elsewhere, this is really just
a smoke test of the exposed methods.