### PR TITLE
disable too many returns check

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -5,6 +5,8 @@ checks:
   identical-code:
     config:
       threshold: 30
+  return-statements:
+    enabled: false
 engines:
 #  stylelint:
 #    enabled: true


### PR DESCRIPTION
Guard clauses and sequential checks improve readability. This is a rule that just shouldn't be there for most languages.