### PR TITLE
Change from Materials to PrimeNG with Start theme

### DIFF
--- a/gedbrowser-client/package-lock.json
+++ b/gedbrowser-client/package-lock.json
@@ -364,9 +364,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.5",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.5.tgz",
-      "integrity": "sha512-NOLEgsT6UiDTjnWG5Hd2Mg25LRyz/oe8ql3wbjzgSFeRzRROhPmtlsvIrei4B46UjERF0td9SZ1ZXPLOdcrBHg==",
+      "version": "9.6.6",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.6.tgz",
+      "integrity": "sha512-SJe0g5cZeGNDP5sD8mIX3scb+eq8LQQZ60FXiKZHipYSeEFZ5EKml+NNMiO76F74TY4PoMWlNxF/YRY40FOvZQ==",
       "dev": true
     },
     "@types/q": {
@@ -380,16 +380,6 @@
       "resolved": "https://registry.npmjs.org/@types/selenium-webdriver/-/selenium-webdriver-2.53.43.tgz",
       "integrity": "sha512-UBYHWph6P3tutkbXpW6XYg9ZPbTKjw/YC2hGG1/GEvWwTbvezBUv3h+mmUFw79T3RFPnmedpiXdOBbXX+4l0jg==",
       "dev": true
-    },
-    "JSONStream": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/JSONStream/-/JSONStream-1.3.2.tgz",
-      "integrity": "sha1-wQI3G27Dp887hHygDCC7D85Mbeo=",
-      "dev": true,
-      "requires": {
-        "jsonparse": "1.3.1",
-        "through": "2.3.8"
-      }
     },
     "abbrev": {
       "version": "1.1.1",
@@ -428,16 +418,6 @@
           "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
           "dev": true
         }
-      }
-    },
-    "acorn-node": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/acorn-node/-/acorn-node-1.3.0.tgz",
-      "integrity": "sha512-efP54n3d1aLfjL2UMdaXa6DsswwzJeI5rqhbFvXMrKiJ6eJFpf+7R0zN7t8IC+XKn2YOAFAv6xbBNgHUkoHWLw==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.5.3",
-        "xtend": "4.0.1"
       }
     },
     "addressparser": {
@@ -696,7 +676,7 @@
       "dev": true,
       "requires": {
         "slashes": "1.0.5",
-        "typescript": "2.8.1"
+        "typescript": "2.8.3"
       }
     },
     "angular-in-memory-web-api": {
@@ -793,12 +773,6 @@
       "integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
       "dev": true
     },
-    "array-filter": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/array-filter/-/array-filter-0.0.1.tgz",
-      "integrity": "sha1-fajPLiZijtcygDWB/SH2fKzS7uw=",
-      "dev": true
-    },
     "array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
@@ -820,18 +794,6 @@
         "define-properties": "1.1.2",
         "es-abstract": "1.11.0"
       }
-    },
-    "array-map": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-map/-/array-map-0.0.0.tgz",
-      "integrity": "sha1-iKK6tz0c97zVwbEYoAP2b2ZfpmI=",
-      "dev": true
-    },
-    "array-reduce": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/array-reduce/-/array-reduce-0.0.0.tgz",
-      "integrity": "sha1-FziZ0//Rx9k4PkR5Ul2+J4yrXys=",
-      "dev": true
     },
     "array-slice": {
       "version": "0.2.3",
@@ -922,23 +884,6 @@
       "integrity": "sha512-XA5o5dsNw8MhyW0Q7MWXJWc4oOzZKbdsEJq45h7c8q/d9DwWZ5F2ugUc1PuMLPGsUnphCt/cNDHu8JeBbxf1qA==",
       "dev": true,
       "optional": true
-    },
-    "astw": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/astw/-/astw-2.2.0.tgz",
-      "integrity": "sha1-e9QXhNMkk5h66yOba04cV6hzuRc=",
-      "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
-      "dependencies": {
-        "acorn": {
-          "version": "4.0.13",
-          "resolved": "https://registry.npmjs.org/acorn/-/acorn-4.0.13.tgz",
-          "integrity": "sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=",
-          "dev": true
-        }
-      }
     },
     "async": {
       "version": "2.6.0",
@@ -1443,173 +1388,6 @@
       "integrity": "sha1-EsJe/kCkXjwyPrhnWgoM5XsiNx8=",
       "dev": true
     },
-    "browser-pack": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/browser-pack/-/browser-pack-6.1.0.tgz",
-      "integrity": "sha512-erYug8XoqzU3IfcU8fUgyHqyOXqIE4tUTTQ+7mqUjQlvnXkOO6OlT9c/ZoJVHYoAaqGxr09CN53G7XIsO4KtWA==",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.8.0",
-        "defined": "1.0.0",
-        "safe-buffer": "5.1.1",
-        "through2": "2.0.3",
-        "umd": "3.0.3"
-      }
-    },
-    "browser-resolve": {
-      "version": "1.11.2",
-      "resolved": "https://registry.npmjs.org/browser-resolve/-/browser-resolve-1.11.2.tgz",
-      "integrity": "sha1-j/CbCixCFxihBRwmCzLkj0QpOM4=",
-      "dev": true,
-      "requires": {
-        "resolve": "1.1.7"
-      },
-      "dependencies": {
-        "resolve": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
-          "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        }
-      }
-    },
-    "browserify": {
-      "version": "14.5.0",
-      "resolved": "https://registry.npmjs.org/browserify/-/browserify-14.5.0.tgz",
-      "integrity": "sha512-gKfOsNQv/toWz+60nSPfYzuwSEdzvV2WdxrVPUbPD/qui44rAkB3t3muNtmmGYHqrG56FGwX9SUEQmzNLAeS7g==",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "assert": "1.4.1",
-        "browser-pack": "6.1.0",
-        "browser-resolve": "1.11.2",
-        "browserify-zlib": "0.2.0",
-        "buffer": "5.1.0",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "defined": "1.0.0",
-        "deps-sort": "2.0.0",
-        "domain-browser": "1.1.7",
-        "duplexer2": "0.1.4",
-        "events": "1.1.1",
-        "glob": "7.1.2",
-        "has": "1.0.1",
-        "htmlescape": "1.1.1",
-        "https-browserify": "1.0.0",
-        "inherits": "2.0.3",
-        "insert-module-globals": "7.0.6",
-        "labeled-stream-splicer": "2.0.1",
-        "module-deps": "4.1.1",
-        "os-browserify": "0.3.0",
-        "parents": "1.0.1",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "read-only-stream": "2.0.0",
-        "readable-stream": "2.3.6",
-        "resolve": "1.7.0",
-        "shasum": "1.0.2",
-        "shell-quote": "1.6.1",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
-        "string_decoder": "1.0.3",
-        "subarg": "1.0.0",
-        "syntax-error": "1.4.0",
-        "through2": "2.0.3",
-        "timers-browserify": "1.4.2",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "buffer": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.1.0.tgz",
-          "integrity": "sha512-YkIRgwsZwJWTnyQrsBTWefizHh+8GYj3kbL1BTiAQ/9pwpino0G7B2gp5tx/FUBqUlvtxV85KNR3mwfAtv15Yw==",
-          "dev": true,
-          "requires": {
-            "base64-js": "1.2.3",
-            "ieee754": "1.1.11"
-          }
-        },
-        "concat-stream": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
-              }
-            },
-            "string_decoder": {
-              "version": "0.10.31",
-              "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-              "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-              "dev": true
-            }
-          }
-        },
-        "domain-browser": {
-          "version": "1.1.7",
-          "resolved": "https://registry.npmjs.org/domain-browser/-/domain-browser-1.1.7.tgz",
-          "integrity": "sha1-hnqksJP6oF8d4IwG9NeyH9+GmLw=",
-          "dev": true
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "punycode": {
-          "version": "1.4.1",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-          "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
-          "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
-        },
-        "timers-browserify": {
-          "version": "1.4.2",
-          "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-1.4.2.tgz",
-          "integrity": "sha1-ycWLV1voQHN1y14kYtrO50NZ9B0=",
-          "dev": true,
-          "requires": {
-            "process": "0.11.10"
-          }
-        }
-      }
-    },
     "browserify-aes": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.2.0.tgz",
@@ -1832,12 +1610,6 @@
         "schema-utils": "0.4.5"
       }
     },
-    "cached-path-relative": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/cached-path-relative/-/cached-path-relative-1.0.1.tgz",
-      "integrity": "sha1-0JxLUoAKpMB44t2BqGmqyQ0uVOc=",
-      "dev": true
-    },
     "callsite": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/callsite/-/callsite-1.0.0.tgz",
@@ -1951,9 +1723,9 @@
       "dev": true
     },
     "circular-json": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.1.tgz",
-      "integrity": "sha512-UjgcRlTAhAkLeXmDe2wK7ktwy/tgAqxiSndTIPiFZuIPLZmzHzWMwUIe9h9m/OokypG7snxCDEuwJshGBdPvaw==",
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/circular-json/-/circular-json-0.5.3.tgz",
+      "integrity": "sha512-YlxLOimeIoQGHnMe3kbf8qIV2Bj7uXLbljMPRguNT49GmSAzooNfS9EJ91rSJKbLBOOzM5agvtx0WyechZN/Hw==",
       "dev": true
     },
     "class-utils": {
@@ -2103,26 +1875,6 @@
       "dev": true,
       "requires": {
         "lodash": "4.17.5"
-      }
-    },
-    "combine-source-map": {
-      "version": "0.8.0",
-      "resolved": "https://registry.npmjs.org/combine-source-map/-/combine-source-map-0.8.0.tgz",
-      "integrity": "sha1-pY0N8ELBhvz4IqjoAV9UUNLXmos=",
-      "dev": true,
-      "requires": {
-        "convert-source-map": "1.1.3",
-        "inline-source-map": "0.6.2",
-        "lodash.memoize": "3.0.4",
-        "source-map": "0.5.7"
-      },
-      "dependencies": {
-        "convert-source-map": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.1.3.tgz",
-          "integrity": "sha1-SCnId+n+SbMWHzvzZziI4gRpmGA=",
-          "dev": true
-        }
       }
     },
     "combined-stream": {
@@ -2785,12 +2537,6 @@
         }
       }
     },
-    "defined": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.0.tgz",
-      "integrity": "sha1-yY2bzvdWdBiOEQlpFRGZ45sfppM=",
-      "dev": true
-    },
     "degenerator": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/degenerator/-/degenerator-1.0.4.tgz",
@@ -2873,18 +2619,6 @@
       "integrity": "sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=",
       "dev": true
     },
-    "deps-sort": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/deps-sort/-/deps-sort-2.0.0.tgz",
-      "integrity": "sha1-CRckkC6EZYJg65EHSMzNGvbiH7U=",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "shasum": "1.0.2",
-        "subarg": "1.0.0",
-        "through2": "2.0.3"
-      }
-    },
     "des.js": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
@@ -2915,16 +2649,6 @@
       "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.3.tgz",
       "integrity": "sha1-ogM8CcyOFY03dI+951B4Mr1s4Sc=",
       "dev": true
-    },
-    "detective": {
-      "version": "4.7.1",
-      "resolved": "https://registry.npmjs.org/detective/-/detective-4.7.1.tgz",
-      "integrity": "sha512-H6PmeeUcZloWtdt4DAkFyzFL94arpHr3NOwwmVILFiy+9Qd4JTxxXrzfyGk/lmct2qVGBwTSwSXagqu2BxmWig==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.5.3",
-        "defined": "1.0.0"
-      }
     },
     "di": {
       "version": "0.0.1",
@@ -3068,15 +2792,6 @@
       "integrity": "sha1-ED01J/0xUo9AGIEwyEHv3XgmTlw=",
       "dev": true,
       "optional": true
-    },
-    "duplexer2": {
-      "version": "0.1.4",
-      "resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
-      "integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.6"
-      }
     },
     "duplexify": {
       "version": "3.5.4",
@@ -5421,12 +5136,6 @@
         }
       }
     },
-    "htmlescape": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/htmlescape/-/htmlescape-1.1.1.tgz",
-      "integrity": "sha1-OgPtwiFLyjtmQko+eVk0lQnLA1E=",
-      "dev": true
-    },
     "htmlparser2": {
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-3.3.0.tgz",
@@ -5725,32 +5434,6 @@
       "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
       "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
       "dev": true
-    },
-    "inline-source-map": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/inline-source-map/-/inline-source-map-0.6.2.tgz",
-      "integrity": "sha1-+Tk0ccGKedFyT4Y/o4tYY3Ct4qU=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
-    },
-    "insert-module-globals": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/insert-module-globals/-/insert-module-globals-7.0.6.tgz",
-      "integrity": "sha512-R3sidKJr3SsggqQQ5cEwQb3pWG8RNx0UnpyeiOSR6jorRIeAOzH2gkTWnNdMnyRiVbjrG047K7UCtlMkQ1Mo9w==",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "combine-source-map": "0.8.0",
-        "concat-stream": "1.6.2",
-        "is-buffer": "1.1.6",
-        "lexical-scope": "1.2.0",
-        "path-is-absolute": "1.0.1",
-        "process": "0.11.10",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
-      }
     },
     "intercept-stdout": {
       "version": "0.1.2",
@@ -6388,12 +6071,6 @@
       "integrity": "sha1-LHS27kHZPKUbe1qu6PUDYx0lKnM=",
       "dev": true
     },
-    "jsonparse": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/jsonparse/-/jsonparse-1.3.1.tgz",
-      "integrity": "sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=",
-      "dev": true
-    },
     "jsonpointer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/jsonpointer/-/jsonpointer-4.0.1.tgz",
@@ -6475,14 +6152,13 @@
       }
     },
     "karma": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.0.tgz",
-      "integrity": "sha512-K9Kjp8CldLyL9ANSUctDyxC7zH3hpqXj/K09qVf06K3T/kXaHtFZ5tQciK7OzQu68FLvI89Na510kqQ2LCbpIw==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/karma/-/karma-2.0.2.tgz",
+      "integrity": "sha1-TS25QChQpmVR+nhLAWT7CCTtjEs=",
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
         "body-parser": "1.18.2",
-        "browserify": "14.5.0",
         "chokidar": "1.7.0",
         "colors": "1.2.1",
         "combine-lists": "1.0.1",
@@ -6507,7 +6183,7 @@
         "socket.io": "2.0.4",
         "source-map": "0.6.1",
         "tmp": "0.0.33",
-        "useragent": "2.3.0"
+        "useragent": "2.2.1"
       },
       "dependencies": {
         "colors": {
@@ -6591,25 +6267,6 @@
         "is-buffer": "1.1.6"
       }
     },
-    "labeled-stream-splicer": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/labeled-stream-splicer/-/labeled-stream-splicer-2.0.1.tgz",
-      "integrity": "sha512-MC94mHZRvJ3LfykJlTUipBqenZz1pacOZEMhhQ8dMGcDHs0SBE5GbsavUXV7YtP3icBW17W0Zy1I0lfASmo9Pg==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "isarray": "2.0.4",
-        "stream-splicer": "2.0.0"
-      },
-      "dependencies": {
-        "isarray": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.4.tgz",
-          "integrity": "sha512-GMxXOiUirWg1xTKRipM0Ek07rX+ubx4nNVElTJdNLYmNO/2YrDkgJGw9CljXn+r4EWiDQg/8lsRdHyg2PJuUaA==",
-          "dev": true
-        }
-      }
-    },
     "lazy-cache": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-1.0.4.tgz",
@@ -6661,15 +6318,6 @@
       "requires": {
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2"
-      }
-    },
-    "lexical-scope": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/lexical-scope/-/lexical-scope-1.2.0.tgz",
-      "integrity": "sha1-/Ope3HBKSzqHls3KQZw6CvryLfQ=",
-      "dev": true,
-      "requires": {
-        "astw": "2.2.0"
       }
     },
     "libbase64": {
@@ -6829,12 +6477,6 @@
         "lodash.isarray": "3.0.4"
       }
     },
-    "lodash.memoize": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-3.0.4.tgz",
-      "integrity": "sha1-LcvSwofLwKVcxCMovQxzYVDVPj8=",
-      "dev": true
-    },
     "lodash.mergewith": {
       "version": "4.6.1",
       "resolved": "https://registry.npmjs.org/lodash.mergewith/-/lodash.mergewith-4.6.1.tgz",
@@ -6867,7 +6509,7 @@
       "requires": {
         "amqplib": "0.5.2",
         "axios": "0.15.3",
-        "circular-json": "0.5.1",
+        "circular-json": "0.5.3",
         "date-format": "1.2.0",
         "debug": "3.1.0",
         "hipchat-notifier": "1.1.0",
@@ -7433,70 +7075,6 @@
       "resolved": "https://registry.npmjs.org/mkpath/-/mkpath-0.1.0.tgz",
       "integrity": "sha1-dVSm+Nhxg0zJe1RisSLEwSTW3pE=",
       "dev": true
-    },
-    "module-deps": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/module-deps/-/module-deps-4.1.1.tgz",
-      "integrity": "sha1-IyFYM/HaE/1gbMuAh7RIUty4If0=",
-      "dev": true,
-      "requires": {
-        "JSONStream": "1.3.2",
-        "browser-resolve": "1.11.2",
-        "cached-path-relative": "1.0.1",
-        "concat-stream": "1.5.2",
-        "defined": "1.0.0",
-        "detective": "4.7.1",
-        "duplexer2": "0.1.4",
-        "inherits": "2.0.3",
-        "parents": "1.0.1",
-        "readable-stream": "2.3.6",
-        "resolve": "1.7.0",
-        "stream-combiner2": "1.1.1",
-        "subarg": "1.0.0",
-        "through2": "2.0.3",
-        "xtend": "4.0.1"
-      },
-      "dependencies": {
-        "concat-stream": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.5.2.tgz",
-          "integrity": "sha1-cIl4Yk2FavQaWnQd790mHadSwmY=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "readable-stream": "2.0.6",
-            "typedarray": "0.0.6"
-          },
-          "dependencies": {
-            "readable-stream": {
-              "version": "2.0.6",
-              "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.0.6.tgz",
-              "integrity": "sha1-j5A0HmilPMySh4jaz80Rs265t44=",
-              "dev": true,
-              "requires": {
-                "core-util-is": "1.0.2",
-                "inherits": "2.0.3",
-                "isarray": "1.0.0",
-                "process-nextick-args": "1.0.7",
-                "string_decoder": "0.10.31",
-                "util-deprecate": "1.0.2"
-              }
-            }
-          }
-        },
-        "process-nextick-args": {
-          "version": "1.0.7",
-          "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
-          "integrity": "sha1-FQ4gt1ZZCtP5EJPyWk8q2L/zC6M=",
-          "dev": true
-        },
-        "string_decoder": {
-          "version": "0.10.31",
-          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
-          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
-          "dev": true
-        }
-      }
     },
     "moment": {
       "version": "2.22.1",
@@ -12263,15 +11841,6 @@
         "no-case": "2.3.2"
       }
     },
-    "parents": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parents/-/parents-1.0.1.tgz",
-      "integrity": "sha1-/t1NK/GTp3dF/nHjcdc8MwfZx1E=",
-      "dev": true,
-      "requires": {
-        "path-platform": "0.11.15"
-      }
-    },
     "parse-asn1": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
@@ -12374,12 +11943,6 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.5.tgz",
       "integrity": "sha1-PBrfhx6pzWyUMbbqK9dKD/BVxME=",
-      "dev": true
-    },
-    "path-platform": {
-      "version": "0.11.15",
-      "resolved": "https://registry.npmjs.org/path-platform/-/path-platform-0.11.15.tgz",
-      "integrity": "sha1-6GQhf3TDaFDwhSt43Hv31KVyG/I=",
       "dev": true
     },
     "path-proxy": {
@@ -12639,6 +12202,11 @@
         "renderkid": "2.0.1",
         "utila": "0.4.0"
       }
+    },
+    "primeng": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/primeng/-/primeng-5.2.4.tgz",
+      "integrity": "sha512-Z/0YIyTwwKftMcblMnzpMvnwgLmx8q59C+9E72aV2nZJ98LaqkzlgE0Gwyz5w1DqiEpq/AUcnIYi7Gid54BO5w=="
     },
     "process": {
       "version": "0.11.10",
@@ -13083,15 +12651,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         }
-      }
-    },
-    "read-only-stream": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/read-only-stream/-/read-only-stream-2.0.0.tgz",
-      "integrity": "sha1-JyT9aoET1zdkrCiNQ4YnDB2/F/A=",
-      "dev": true,
-      "requires": {
-        "readable-stream": "2.3.6"
       }
     },
     "read-pkg": {
@@ -13859,27 +13418,6 @@
         }
       }
     },
-    "shasum": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/shasum/-/shasum-1.0.2.tgz",
-      "integrity": "sha1-5wEjENj0F/TetXEhUOVni4euVl8=",
-      "dev": true,
-      "requires": {
-        "json-stable-stringify": "0.0.1",
-        "sha.js": "2.4.11"
-      },
-      "dependencies": {
-        "json-stable-stringify": {
-          "version": "0.0.1",
-          "resolved": "https://registry.npmjs.org/json-stable-stringify/-/json-stable-stringify-0.0.1.tgz",
-          "integrity": "sha1-YRwj6BTbN1Un34URk9tZ3Sryf0U=",
-          "dev": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
-        }
-      }
-    },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
@@ -13894,18 +13432,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
       "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
       "dev": true
-    },
-    "shell-quote": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
-      "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
-      "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
-      }
     },
     "signal-exit": {
       "version": "3.0.2",
@@ -14485,16 +14011,6 @@
         "readable-stream": "2.3.6"
       }
     },
-    "stream-combiner2": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/stream-combiner2/-/stream-combiner2-1.1.1.tgz",
-      "integrity": "sha1-+02KFCDqNidk4hrUeAOXvry0HL4=",
-      "dev": true,
-      "requires": {
-        "duplexer2": "0.1.4",
-        "readable-stream": "2.3.6"
-      }
-    },
     "stream-each": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/stream-each/-/stream-each-1.2.2.tgz",
@@ -14523,16 +14039,6 @@
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
       "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
       "dev": true
-    },
-    "stream-splicer": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/stream-splicer/-/stream-splicer-2.0.0.tgz",
-      "integrity": "sha1-G2O+Q4oTPktnHMGTUZdgAXWRDYM=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.6"
-      }
     },
     "streamroller": {
       "version": "0.7.0",
@@ -14675,23 +14181,6 @@
         "when": "3.6.4"
       }
     },
-    "subarg": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/subarg/-/subarg-1.0.0.tgz",
-      "integrity": "sha1-9izxdYHplrSPyWVpn1TAauJouNI=",
-      "dev": true,
-      "requires": {
-        "minimist": "1.2.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        }
-      }
-    },
     "supports-color": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
@@ -14705,15 +14194,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
       "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ="
-    },
-    "syntax-error": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/syntax-error/-/syntax-error-1.4.0.tgz",
-      "integrity": "sha512-YPPlu67mdnHGTup2A8ff7BC2Pjq0e0Yp/IyTFN03zWO0RcK07uLcbi7C2KpGR2FvWbaB0+bfE27a+sBKebSo7w==",
-      "dev": true,
-      "requires": {
-        "acorn-node": "1.3.0"
-      }
     },
     "tapable": {
       "version": "0.2.8",
@@ -15198,9 +14678,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.1.tgz",
-      "integrity": "sha512-Ao/f6d/4EPLq0YwzsQz8iXflezpTkQzqAyenTiw4kCUGr1uPiFLC3+fZ+gMZz6eeI/qdRUqvC+HxIJzUAzEFdg==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.8.3.tgz",
+      "integrity": "sha512-K7g15Bb6Ra4lKf7Iq2l/I5/En+hLIHmxWZGq3D4DIRNFxMNV6j2SHSvDOqs2tGd4UvD/fJvrwopzQXjLrT7Itw==",
       "dev": true
     },
     "uglify-js": {
@@ -15272,12 +14752,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/ultron/-/ultron-1.0.2.tgz",
       "integrity": "sha1-rOEWq1V80Zc4ak6I9GhTeMiy5Po=",
-      "dev": true
-    },
-    "umd": {
-      "version": "3.0.3",
-      "resolved": "https://registry.npmjs.org/umd/-/umd-3.0.3.tgz",
-      "integrity": "sha512-4IcGSufhFshvLNcMCV80UnQVlZ5pMOC8mvNPForqwA4+lzYQuetTESLDQkeLmihq8bRcnpbQa48Wb8Lh16/xow==",
       "dev": true
     },
     "underscore": {
@@ -15500,13 +14974,21 @@
       }
     },
     "useragent": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.3.0.tgz",
-      "integrity": "sha512-4AoH4pxuSvHCjqLO04sU6U/uE65BYza8l/KKBS0b0hnUPWi+cQ2BpeTEwejCSx9SPV5/U03nniDTrWx5NrmKdw==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/useragent/-/useragent-2.2.1.tgz",
+      "integrity": "sha1-z1k+9PLRdYdei7ZY6pLhik/QbY4=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "2.2.4",
         "tmp": "0.0.33"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "2.2.4",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-2.2.4.tgz",
+          "integrity": "sha1-bGWGGb7PFAMdDQtZSxYELOTcBj0=",
+          "dev": true
+        }
       }
     },
     "util": {

--- a/gedbrowser-client/package.json
+++ b/gedbrowser-client/package.json
@@ -37,6 +37,7 @@
     "ng2-page-scroll": "^4.0.0-beta.12",
     "ngx-gallery": "^5.3.2",
     "npm": "^5.6.0",
+    "primeng": "^5.2.4",
     "rxjs": "^5.5.10",
     "web-animations-js": "^2.3.1",
     "zone.js": "^0.8.26"
@@ -47,12 +48,12 @@
     "@angular/language-service": "^5.2.10",
     "@types/jasmine": "^2.8.6",
     "@types/jasminewd2": "~2.0.3",
-    "@types/node": "^9.6.5",
+    "@types/node": "^9.6.6",
     "angular-ide": "^0.9.39",
     "codelyzer": "~4.2.1",
     "jasmine-core": "~3.1.0",
     "jasmine-spec-reporter": "~4.2.1",
-    "karma": "~2.0.0",
+    "karma": "^2.0.2",
     "karma-chrome-launcher": "~2.2.0",
     "karma-cli": "~1.0.1",
     "karma-coverage-istanbul-reporter": "^1.4.2",
@@ -61,7 +62,7 @@
     "protractor": "^5.3.1",
     "ts-node": "~5.0.1",
     "tslint": "~5.9.1",
-    "typescript": "^2.8.1",
+    "typescript": "^2.8.3",
     "ws": "^1.1.5"
   }
 }

--- a/gedbrowser-client/src/app/app.component.html
+++ b/gedbrowser-client/src/app/app.component.html
@@ -1,38 +1,17 @@
 <link href="https://fonts.googleapis.com/icon?family=Material+Icons" rel="stylesheet">
 <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" rel="stylesheet">
-<section class="mat-typography">
-<mat-menu #menu="matMenu" class="menu" yPosition="below" xPosition="before">
-  <button mat-menu-item [routerLink]="['/header']">
-    <mat-icon>description</mat-icon>
-    <span>Header</span>
-  </button>
-  <button mat-menu-item [routerLink]="['/persons']">
-    <mat-icon>people</mat-icon>
-    <span>Persons</span>
-  </button>
-  <button mat-menu-item [routerLink]="['/sources']">
-    <mat-icon>book</mat-icon>
-    <span>Sources</span>
-  </button>
-  <button mat-menu-item [routerLink]="['/submitters']">
-    <mat-icon>people_outline</mat-icon>
-    <span>Submitters</span>
-  </button>
-  <button mat-menu-item (click)="saveFile()">
-    <mat-icon>save</mat-icon>
-    <span>Save</span>
-  </button>
-</mat-menu>
 
-<mat-toolbar class="menubar" color="primary">
-<span>Gedbrowser</span>
-<span class="example-fill-remaining-space"></span>
-<button mat-icon-button [matMenuTriggerFor]="menu"><mat-icon>menu</mat-icon></button>
-</mat-toolbar>
-</section>
+<p-toolbar>
+    <div class="ui-toolbar-group-left">
+        <span>Gedbrowser</span>
+    </div>
+    <div class="ui-toolbar-group-right">
+        <p-menu #menu1 popup="popup" [model]="items"></p-menu>
+        <button type="button" pButton icon="fa fa-bars" (click)="menu1.toggle($event)"></button>
+    </div>
+</p-toolbar>
+
 
 <div class="body">
-  <section class="mat-typography">
-    <router-outlet></router-outlet>
-  </section>
+  <router-outlet></router-outlet>
 </div>

--- a/gedbrowser-client/src/app/app.component.ts
+++ b/gedbrowser-client/src/app/app.component.ts
@@ -1,17 +1,33 @@
 import {HttpResponse} from '@angular/common/http';
 import {Component} from '@angular/core';
 import {saveAs} from 'file-saver/FileSaver';
+import {MenuItem} from 'primeng/api';
 
 import {SaveService} from './services';
 
 @Component({
   selector: 'app-root',
   templateUrl: './app.component.html',
-  styleUrls: ['./app.component.css']
+  styleUrls: [
+    './app.component.css'
+  ]
 })
 export class AppComponent {
   title = 'gedbrowser';
-
+  items: MenuItem[] = [
+    {
+      label: 'Persons', icon: 'fa-users', routerLink: ['/persons']
+    },
+    {
+      label: 'Sources', icon: 'fa-book', routerLink: ['/sources']
+    },
+    {
+      label: 'Submitters', icon: 'fa-user', routerLink: ['/submitters']
+    },
+    {
+      label: 'Save', icon: 'fa-save', command: (event: Event) => { this.saveFile(); }
+    }
+  ];
   constructor(private saveService: SaveService) { }
 
   saveFile() {

--- a/gedbrowser-client/src/app/app.module.ts
+++ b/gedbrowser-client/src/app/app.module.ts
@@ -4,41 +4,17 @@ import {BrowserAnimationsModule} from '@angular/platform-browser/animations';
 import {RouterModule} from '@angular/router';
 import {HttpClientModule} from '@angular/common/http';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
-import {
-  MatAutocompleteModule,
-  MatButtonModule,
-  MatButtonToggleModule,
-  MatCardModule,
-  MatCheckboxModule,
-  MatChipsModule,
-  MatDatepickerModule,
-  MatDialogModule,
-  MatExpansionModule,
-  MatFormFieldModule,
-  MatGridListModule,
-  MatIconModule,
-  MatInputModule,
-  MatListModule,
-  MatMenuModule,
-  MatNativeDateModule,
-  MatPaginatorModule,
-  MatProgressBarModule,
-  MatProgressSpinnerModule,
-  MatRadioModule,
-  MatRippleModule,
-  MatSelectModule,
-  MatSidenavModule,
-  MatSliderModule,
-  MatSlideToggleModule,
-  MatSnackBarModule,
-  MatSortModule,
-  MatTableModule,
-  MatTabsModule,
-  MatToolbarModule,
-  MatTooltipModule,
-  MatStepperModule,
-} from '@angular/material';
 import {CdkTableModule} from '@angular/cdk/table';
+
+import {ToolbarModule} from 'primeng/toolbar';
+import {ButtonModule} from 'primeng/button';
+import {SplitButtonModule} from 'primeng/splitbutton';
+import {PanelModule} from 'primeng/panel';
+import {AccordionModule} from 'primeng/accordion';
+import {MenuModule} from 'primeng/menu';
+import {OrderListModule} from 'primeng/orderlist';
+import {TooltipModule} from 'primeng/tooltip';
+
 import {NgxGalleryModule} from 'ngx-gallery';
 import {Ng2PageScrollModule} from 'ng2-page-scroll';
 
@@ -53,7 +29,7 @@ import {
   SubmitterModule
 } from './modules';
 
-import {ComponentsModule, NewPersonDialogComponent} from './components';
+import {ComponentsModule} from './components';
 
 import {
   ServiceBase,
@@ -65,60 +41,31 @@ import {
   SaveService
 } from './services';
 
-@NgModule({
-  exports: [
-    CdkTableModule,
-    MatAutocompleteModule,
-    MatButtonModule,
-    MatButtonToggleModule,
-    MatCardModule,
-    MatCheckboxModule,
-    MatChipsModule,
-    MatStepperModule,
-    MatDatepickerModule,
-    MatDialogModule,
-    MatExpansionModule,
-    MatFormFieldModule,
-    MatGridListModule,
-    MatIconModule,
-    MatInputModule,
-    MatListModule,
-    MatMenuModule,
-    MatNativeDateModule,
-    MatPaginatorModule,
-    MatProgressBarModule,
-    MatProgressSpinnerModule,
-    MatRadioModule,
-    MatRippleModule,
-    MatSelectModule,
-    MatSidenavModule,
-    MatSliderModule,
-    MatSlideToggleModule,
-    MatSnackBarModule,
-    MatSortModule,
-    MatTableModule,
-    MatTabsModule,
-    MatToolbarModule,
-    MatTooltipModule,
-  ],
-})
-export class AppMaterialModule {}
-
 const rootRouting: ModuleWithProviders = RouterModule.forRoot([], { useHash: true });
 
 @NgModule({
   imports: [
     rootRouting,
 
-    AppMaterialModule,
-
     Ng2PageScrollModule.forRoot(),
     NgxGalleryModule,
+
     BrowserModule,
     BrowserAnimationsModule,
+    CdkTableModule,
     FormsModule,
     ReactiveFormsModule,
     HttpClientModule,
+
+    ToolbarModule,
+    ButtonModule,
+    SplitButtonModule,
+    PanelModule,
+    AccordionModule,
+    MenuModule,
+    OrderListModule,
+    TooltipModule,
+
     PersonListModule,
     PersonModule,
     SourceListModule,
@@ -128,10 +75,8 @@ const rootRouting: ModuleWithProviders = RouterModule.forRoot([], { useHash: tru
   ],
   declarations: [
     AppComponent,
-    NewPersonDialogComponent,
   ],
   entryComponents: [
-    NewPersonDialogComponent,
   ],
   providers: [
     NewPersonLinkService,

--- a/gedbrowser-client/src/app/components/attribute-dialog/attribute-dialog.component.html
+++ b/gedbrowser-client/src/app/components/attribute-dialog/attribute-dialog.component.html
@@ -1,24 +1,30 @@
 <h1 mat-dialog-title>Attribute</h1>
 <mat-dialog-content class="container">
-  <mat-form-field>
-    <mat-select placeholder="Type" [(value)]="data.type">
-      <mat-option *ngFor="let option of options" [value]="option">{{option}}</mat-option>
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Text" [(ngModel)]="data.text">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Date" [(ngModel)]="data.date">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Place" [(ngModel)]="data.place">
-  </mat-form-field>
-  <mat-form-field>
-    <textarea matInput placeholder="Note" [(ngModel)]="data.note" rows="8"></textarea>
-  </mat-form-field>
+  <p-dropdown [options]="getOptions()" [(ngModel)]="data.type" [style]="{'width':'425px'}"
+      editable="false" placeholder="Select an attribute type"></p-dropdown>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-text" type="text" size="50" pInputText [(ngModel)]="data.text">
+    <label for="float-input-text">Text</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-date" type="text" size="50" pInputText [(ngModel)]="data.date">
+    <label for="float-input-date">Date</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-place" type="text" size="50" pInputText [(ngModel)]="data.place">
+    <label for="float-input-place">Place</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <textarea id="float-input-note" pInputTextarea [(ngModel)]="data.note"
+        [rows]="8" [cols]="50" autoResize="autoResize"></textarea>
+    <label for="float-input-note">Note</label>
+  </div>
 </mat-dialog-content>
-<mat-dialog-actions>
-  <button mat-button (click)="onClickOK()" [mat-dialog-close]="data">OK</button>
-  <button mat-button (click)="onNoClick()">Cancel</button>
+<mat-dialog-actions class="custom-button-placement">
+  <p-button label="OK" icon="fa fa-fw fa-check" (click)="onClickOK();close()"></p-button>
+  <p-button label="Cancel" icon="fa fa-fw fa-close" (click)="close()" [styleClass]="'ui-button-secondary'"></p-button>
 </mat-dialog-actions>

--- a/gedbrowser-client/src/app/components/attribute-dialog/attribute-dialog.component.ts
+++ b/gedbrowser-client/src/app/components/attribute-dialog/attribute-dialog.component.ts
@@ -138,6 +138,14 @@ export class AttributeDialogComponent {
       'Will',
   ];
 
+  getOptions(): any {
+    const ret: Array<any> = new Array<any>();
+    for (const option of this.options) {
+      ret.push({ label: option, value: option });
+    }
+    return ret;
+  }
+
   constructor(public dialogRef: MatDialogRef<AttributeDialogComponent>,
     @Inject(MAT_DIALOG_DATA) public data: AttributeDialogData) {}
 
@@ -145,7 +153,7 @@ export class AttributeDialogComponent {
     this.onOK.emit(this.data);
   }
 
-  onNoClick(): void {
+  close(): void {
     this.dialogRef.close();
   }
 }

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.html
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.html
@@ -1,11 +1,9 @@
-<mat-list-item class="parent">
+<div class="parent">
   <b>{{attributeUtil.label()}}:&nbsp;</b><span *ngIf="attributeUtil.contents()"> {{attributeUtil.contents()}}<span *ngIf="attribute.attributes">,&nbsp;</span></span>
   <app-attribute-list-item-detail-list [attributes]="attribute.attributes"></app-attribute-list-item-detail-list>
   <span class="example-fill-remaining-space"></span>
   <span *ngIf="attributeUtil.editable()" class="hidden">
-    <button mat-icon-button color="primary" (click)="edit()" matTooltip="Edit attribute"><mat-icon>edit</mat-icon></button>
-    <button mat-icon-button color="primary" (click)="moveUp()" *ngIf="!attributeUtil.first()" matTooltip="Move attribute up"><mat-icon>arrow_drop_up</mat-icon></button>
-    <button mat-icon-button color="primary" (click)="moveDown()" *ngIf="!attributeUtil.last()" matTooltip="Move attribute down"><mat-icon>arrow_drop_down</mat-icon></button>
-    <button mat-icon-button color="accent" (click)="delete()" matTooltip="Delete attribute"><mat-icon>delete_forever</mat-icon></button>
+    <p-button icon="fa fa-fw fa-pencil" (onClick)="edit()" pTooltip="Edit attribute"></p-button>
+    <p-button icon="fa fa-fw fa-trash" (onClick)="delete()" pTooltip="Delete attribute" [styleClass]="'ui-button-danger'"></p-button>
   </span>
-</mat-list-item>
+</div>

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.ts
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.ts
@@ -26,8 +26,6 @@ export class AttributeListItemComponent {
 
   edit(): void {
     const config = {
-      width: '500px',
-      height: '600px',
       data: this.attributeDialogHelper.buildData(false)
     };
     const dialogRef: MatDialogRef<AttributeDialogComponent> =

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.ts
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list-item.component.ts
@@ -38,21 +38,7 @@ export class AttributeListItemComponent {
       }
     );
 
-    dialogRef.afterClosed().subscribe(() => {
-      sub.unsubscribe();
-    });
-  }
-
-  moveUp(): void {
-    const index = this.attributes.indexOf(this.attribute);
-    this.attributes.splice(index - 1, 0, this.attributes.splice(index, 1)[0]);
-    this.parent.save();
-  }
-
-  moveDown(): void {
-    const index = this.attributes.indexOf(this.attribute);
-    this.attributes.splice(index + 1, 0, this.attributes.splice(index, 1)[0]);
-    this.parent.save();
+    dialogRef.afterClosed().subscribe(() => { sub.unsubscribe(); });
   }
 
   delete(): void {

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.html
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.html
@@ -1,12 +1,25 @@
-<mat-list>
-  <app-attribute-list-item
-    *ngFor="let attribute of attributes; let i = index"
-    [attribute]="attribute"
-    [attributes]="attributes"
-    [index]="i"
-    [parent]="parent">
-  </app-attribute-list-item>
-  <mat-list-item>
-    <button mat-icon-button color="primary" (click)="createAttribute()" matTooltip="Add attribute"><mat-icon>add_circle</mat-icon></button>
-  </mat-list-item>
-</mat-list>
+<p-panel header="Attributes" [toggleable]="toggleable" [styleClass]="styleClass">
+  <p-header>
+    <span class="bump-out">
+      <p-button (click)="createAttribute()" icon="fa fa-fw fa-plus-circle"
+          [styleClass]="'ui-button-success'"
+          pTooltip="Add attribute"></p-button>
+    </span>
+  </p-header>
+  <div>
+    <p-orderList [value]="attributes" dragdrop="true" dragdropScope="attributes"
+        [responsive]="false" [listStyle]="{'height':'100%','width':'100%','border':'0'}"
+        (onReorder)="parent.save()">
+      <ng-template let-attribute let-i="index" pTemplate="item">
+        <div>
+          <app-attribute-list-item
+            [attribute]="attribute"
+            [attributes]="attributes"
+            [index]="i"
+            [parent]="parent">
+          </app-attribute-list-item>
+        </div>
+      </ng-template>
+    </p-orderList>
+  </div>
+</p-panel>

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.ts
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.ts
@@ -49,8 +49,6 @@ export class AttributeListComponent implements OnInit {
       }
     );
 
-    dialogRef.afterClosed().subscribe(() => {
-      sub.unsubscribe();
-    });
+    dialogRef.afterClosed().subscribe(() => { sub.unsubscribe(); });
   }
 }

--- a/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.ts
+++ b/gedbrowser-client/src/app/components/attribute-list/attribute-list.component.ts
@@ -16,6 +16,8 @@ import {AttributeDialogComponent} from '../attribute-dialog/attribute-dialog.com
 export class AttributeListComponent implements OnInit {
   @Input() attributes: Array<ApiAttribute>;
   @Input() parent: any;
+  @Input() toggleable = false;
+  @Input() styleClass: string;
 
   index;
   attributeDialogHelper = new AttributeDialogHelper(this);
@@ -35,8 +37,6 @@ export class AttributeListComponent implements OnInit {
     };
     const dialogRef: MatDialogRef<AttributeDialogComponent> =
       this.dialog.open(AttributeDialogComponent, {
-        width: '500px',
-        height: '600px',
         data: dataIn,
       });
 
@@ -50,7 +50,6 @@ export class AttributeListComponent implements OnInit {
     );
 
     dialogRef.afterClosed().subscribe(() => {
-      alert('Close');
       sub.unsubscribe();
     });
   }

--- a/gedbrowser-client/src/app/components/components.module.ts
+++ b/gedbrowser-client/src/app/components/components.module.ts
@@ -3,17 +3,16 @@ import {NgModule} from '@angular/core';
 import {FormsModule, ReactiveFormsModule} from '@angular/forms';
 import {HttpClientModule} from '@angular/common/http';
 import {RouterModule} from '@angular/router';
-import {
-  MatButtonModule,
-  MatDialogModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatInputModule,
-  MatListModule,
-  MatSelectModule,
-  MatToolbarModule,
-  MatTooltipModule,
-} from '@angular/material';
+import {OrderListModule} from 'primeng/orderlist';
+import {ButtonModule} from 'primeng/button';
+import {TooltipModule} from 'primeng/tooltip';
+import {InputTextModule} from 'primeng/inputtext';
+import {InputTextareaModule} from 'primeng/inputtextarea';
+import {DropdownModule} from 'primeng/dropdown';
+import {DialogModule} from 'primeng/dialog';
+import {PanelModule} from 'primeng/panel';
+
+import {MatButtonModule, MatDialogModule, MatSelectModule} from '@angular/material';
 
 import {
   AttributeListComponent,
@@ -22,9 +21,9 @@ import {
   AttributeListItemDetailListItemComponent,
 } from './attribute-list';
 
-import {
-  AttributeDialogComponent,
-} from './attribute-dialog';
+import {AttributeDialogComponent} from './attribute-dialog';
+
+import {NewPersonDialogComponent} from './new-person-dialog';
 
 @NgModule({
   imports: [
@@ -33,15 +32,18 @@ import {
     ReactiveFormsModule,
     HttpClientModule,
     RouterModule,
-    MatButtonModule,
     MatDialogModule,
-    MatFormFieldModule,
-    MatIconModule,
-    MatInputModule,
-    MatListModule,
     MatSelectModule,
-    MatToolbarModule,
-    MatTooltipModule,
+    MatButtonModule,
+
+    OrderListModule,
+    ButtonModule,
+    TooltipModule,
+    InputTextModule,
+    InputTextareaModule,
+    DropdownModule,
+    DialogModule,
+    PanelModule,
   ],
   declarations: [
     AttributeDialogComponent,
@@ -49,9 +51,11 @@ import {
     AttributeListItemComponent,
     AttributeListItemDetailListComponent,
     AttributeListItemDetailListItemComponent,
+    NewPersonDialogComponent,
   ],
   entryComponents: [
     AttributeDialogComponent,
+    NewPersonDialogComponent,
   ],
   exports: [
     AttributeDialogComponent,
@@ -59,6 +63,7 @@ import {
     AttributeListItemComponent,
     AttributeListItemDetailListComponent,
     AttributeListItemDetailListItemComponent,
+    NewPersonDialogComponent,
   ]
 })
 

--- a/gedbrowser-client/src/app/components/new-person-dialog/new-person-dialog.component.html
+++ b/gedbrowser-client/src/app/components/new-person-dialog/new-person-dialog.component.html
@@ -1,28 +1,36 @@
-<h1 mat-dialog-title>New Person</h1>
+<p-header mat-dialog-title>New Person</p-header>
 <mat-dialog-content class="container">
-  <mat-form-field>
-    <mat-select placeholder="Sex" [(value)]="data.sex">
-      <mat-option [value]="'M'">M</mat-option>
-      <mat-option [value]="'F'">F</mat-option>
-    </mat-select>
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Name" [(ngModel)]="data.name">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Birth date" [(ngModel)]="data.birthDate">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Birth place" [(ngModel)]="data.birthPlace">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Death date" [(ngModel)]="data.deathDate">
-  </mat-form-field>
-  <mat-form-field>
-    <input matInput placeholder="Death place" [(ngModel)]="data.deathPlace">
-  </mat-form-field>
+  <p-dropdown
+      [options]="[{'label': 'Select the sex', 'value': ''}, {'label': 'Male', 'value': 'M'}, {'label': 'Female', 'value': 'F'}]"
+      [(ngModel)]="data.sex" [style]="{'width':'425px'}"
+      editable="false" placeholder="Select the sex"></p-dropdown>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-name" type="text" size="50" pInputText [(ngModel)]="data.name">
+    <label for="float-input-name">Name</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-bdate" type="text" size="50" pInputText [(ngModel)]="data.birthDate">
+    <label for="float-input-bdate">Birth date</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-bplace" type="text" size="50" pInputText [(ngModel)]="data.birthPlace">
+    <label for="float-input-bplace">Birth place</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-ddate" type="text" size="50" pInputText [(ngModel)]="data.deathDate">
+    <label for="float-input-ddate">Death date</label>
+  </div>
+  <br/>
+  <div class="ui-float-label">
+    <input id="float-input-dplace" type="text" size="50" pInputText [(ngModel)]="data.deathPlace">
+    <label for="float-input-dplace">Death place</label>
+  </div>
 </mat-dialog-content>
-<mat-dialog-actions>
-  <button mat-button (click)="onClickOK()" [mat-dialog-close]="data">OK</button>
-  <button mat-button (click)="onNoClick()">Cancel</button>
+<mat-dialog-actions class="custom-button-placement">
+  <p-button label="OK" icon="fa fa-fw fa-check" (click)="onClickOK();onNoClick()"></p-button>
+  <p-button label="Cancel" icon="fa fa-fw fa-close" (click)="onNoClick()" [styleClass]="'ui-button-secondary'"></p-button>
 </mat-dialog-actions>

--- a/gedbrowser-client/src/app/components/new-person-dialog/new-person-helper.ts
+++ b/gedbrowser-client/src/app/components/new-person-dialog/new-person-helper.ts
@@ -70,8 +70,8 @@ export class NewPersonHelper {
 
   config(dataIn) {
     return {
-        width: '500px',
-        height: '600px',
+//        width: '500px',
+//        height: '600px',
         data: dataIn,
       };
   }

--- a/gedbrowser-client/src/app/modules/person-list/person-list-item.component.html
+++ b/gedbrowser-client/src/app/modules/person-list/person-list-item.component.html
@@ -1,1 +1,1 @@
-<a mat-list-item [routerLink]="['/persons', person.string]">{{person.indexName}}{{lifespanYearString()}} [{{person.string}}]</a>
+<a [routerLink]="['/persons', person.string]">{{person.indexName}}{{lifespanYearString()}} [{{person.string}}]</a>

--- a/gedbrowser-client/src/app/modules/person-list/person-list.component.html
+++ b/gedbrowser-client/src/app/modules/person-list/person-list.component.html
@@ -1,7 +1,10 @@
-<mat-card [class.mat-elevation-z4]="true">
-  <mat-card-title>Person List</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
-  <mat-list>
-    <app-person-list-item *ngFor="let p of persons" [person]="p"></app-person-list-item>
-  </mat-list>
-</mat-card>
+<p-dataView [value]="persons" [style]="{'min-width':'500px'}"  [paginator]="true" [rows]="30"
+    paginatorPosition="both" pageLinks="10" [rowsPerPageOptions]="[10, 30, 100, 10000]"
+    [alwaysShowPaginator]="false">
+  <p-header>Person List</p-header>
+  <ng-template let-person pTemplate="listItem">
+    <div class="main-list">
+      <app-person-list-item [person]="person"></app-person-list-item>
+    </div>
+  </ng-template>
+</p-dataView>

--- a/gedbrowser-client/src/app/modules/person-list/person-list.module.ts
+++ b/gedbrowser-client/src/app/modules/person-list/person-list.module.ts
@@ -1,7 +1,9 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {MatCardModule, MatDividerModule, MatListModule} from '@angular/material';
+
+import {PanelModule} from 'primeng/panel';
+import {DataViewModule} from 'primeng/dataview';
 
 import {ComponentsModule} from '../../components';
 
@@ -23,10 +25,9 @@ const personRouting: ModuleWithProviders = RouterModule.forChild([
   imports: [
     personRouting,
     CommonModule,
-    MatCardModule,
-    MatDividerModule,
-    MatListModule,
     ComponentsModule,
+    PanelModule,
+    DataViewModule,
   ],
   declarations: [
     PersonListComponent,

--- a/gedbrowser-client/src/app/modules/person/person-creator.ts
+++ b/gedbrowser-client/src/app/modules/person/person-creator.ts
@@ -18,9 +18,7 @@ export abstract class PersonCreator {
       dialogRef.componentInstance.onOK.subscribe(
         result => this.saveNewWrapper(this, result, service, ub));
 
-    dialogRef.afterClosed().subscribe(() => {
-      sub.unsubscribe();
-    });
+    dialogRef.afterClosed().subscribe(() => { sub.unsubscribe(); });
   }
 
   saveNewWrapper(that: PersonCreator,

--- a/gedbrowser-client/src/app/modules/person/person-creator.ts
+++ b/gedbrowser-client/src/app/modules/person/person-creator.ts
@@ -19,7 +19,6 @@ export abstract class PersonCreator {
         result => this.saveNewWrapper(this, result, service, ub));
 
     dialogRef.afterClosed().subscribe(() => {
-      alert('there');
       sub.unsubscribe();
     });
   }
@@ -27,7 +26,6 @@ export abstract class PersonCreator {
   saveNewWrapper(that: PersonCreator,
     dialogData: NewPersonDialogData, service: PostRelatedPerson,
     ub: UrlBuilder): void {
-    alert('here');
     that.saveNew(dialogData, service, ub);
   }
 

--- a/gedbrowser-client/src/app/modules/person/person-family-child-list.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-family-child-list.component.html
@@ -1,17 +1,25 @@
-<br/>
-<mat-divider [inset]="true"></mat-divider>
-<br/>
-<div *ngIf="children.length">
-  <mat-list>
-    <mat-list-item><span class="children label">Children:</span></mat-list-item>
-    <mat-list>
-      <app-person-family-child *ngFor="let child of children; let i = index;" [child]="child" [index]="i" [parentComponent]="parentComponent"></app-person-family-child>
-      <mat-list-item>
-        <button mat-icon-button color="primary" matTooltip="Add child" (click)="createChild()"><mat-icon>person_add</mat-icon></button>
-      </mat-list-item>
-    </mat-list>
-  </mat-list>
-</div>
-<div *ngIf="!children.length">
-  <button mat-icon-button color="primary" (click)="createChild()" matTooltip="Add child"><mat-icon>person_add</mat-icon></button>
+<div class="ui-g">
+  <div class="ui-g-1"></div>
+  <div class="ui-g-10">
+    <p-panel header="Children" styleClass="ui-panel-titlebar-success">
+      <p-header>
+        <span class="bump-out">
+          <p-button (click)="createChild()" icon="fa fa-fw fa-user-plus" pTooltip="Add child"
+              [styleClass]="'ui-button-success'"></p-button>
+        </span>
+      </p-header>
+
+      <p-orderList [value]="children" dragdrop="true" dragdropScope="children"
+          [responsive]="false" [listStyle]="{'height':'100%','width':'100%','border':'0'}"
+          (onReorder)="parent.save()">
+        <ng-template let-child let-i="index" pTemplate="item">
+          <div>
+            <app-person-family-child [child]="child" [index]="i"
+                [parent]="parent"></app-person-family-child>
+          </div>
+        </ng-template>
+      </p-orderList>
+    </p-panel>
+  </div>
+  <div class="ui-g-1"></div>
 </div>

--- a/gedbrowser-client/src/app/modules/person/person-family-child-list.component.ts
+++ b/gedbrowser-client/src/app/modules/person/person-family-child-list.component.ts
@@ -21,7 +21,7 @@ import {PersonFamilyComponent} from './person-family.component';
 export class PersonFamilyChildListComponent extends PersonCreator {
   @Input() children: Array<ApiAttribute>;
   @Input() family: ApiFamily;
-  @Input() parentComponent: PersonFamilyComponent;
+  @Input() parent: PersonFamilyComponent;
 
   constructor(public dialog: MatDialog,
     private newPersonLinkService: NewPersonLinkService,
@@ -30,7 +30,7 @@ export class PersonFamilyChildListComponent extends PersonCreator {
   }
 
   createChild(): void {
-    this.newPersonDialog2('M', 'Anonymous/' + this.parentComponent.person.surname + '/',
+    this.newPersonDialog2('M', 'Anonymous/' + this.parent.person.surname + '/',
       this.newPersonLinkService,
       new UrlBuilder('schoeller', 'families', 'children'));
   }
@@ -40,7 +40,7 @@ export class PersonFamilyChildListComponent extends PersonCreator {
   }
 
   refreshPerson(): void {
-    this.personService.getOne('schoeller', this.parentComponent.person.string).subscribe(
-      (person: any) => this.parentComponent.refreshPerson());
+    this.personService.getOne('schoeller', this.parent.person.string).subscribe(
+      (person: any) => this.parent.refreshPerson());
   }
 }

--- a/gedbrowser-client/src/app/modules/person/person-family-child.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-family-child.component.html
@@ -1,11 +1,9 @@
-<mat-list-item class="parent">
+<div class="parent">
   <span *ngIf="person">
     <a [routerLink]="['/persons', person.string]" class="name">{{person.indexName}} {{lifespanYearString()}} [{{person.string}}]</a>
   </span>
   <span class="example-fill-remaining-space"></span>
   <span class="hidden">
-    <button mat-icon-button color="primary" (click)="moveUp()" *ngIf="!first()"><mat-icon>arrow_drop_up</mat-icon></button>
-    <button mat-icon-button color="primary" (click)="moveDown()" *ngIf="!last()"><mat-icon>arrow_drop_down</mat-icon></button>
-    <button mat-icon-button color="accent"><mat-icon>delete_forever</mat-icon></button>
+    <p-button icon="fa fa-fw fa-trash" (onClick)="delete()" pTooltip="Delete attribute" [styleClass]="'ui-button-danger'"></p-button>
   </span>
-</mat-list-item>
+</div>

--- a/gedbrowser-client/src/app/modules/person/person-family-child.component.ts
+++ b/gedbrowser-client/src/app/modules/person/person-family-child.component.ts
@@ -23,7 +23,7 @@ import {PersonFamilyComponent} from './person-family.component';
 export class PersonFamilyChildComponent implements OnInit {
   @Input() child: ApiAttribute;
   @Input() index: number;
-  @Input() parentComponent: PersonFamilyComponent;
+  @Input() parent: PersonFamilyComponent;
   person: ApiPerson;
 
   constructor(
@@ -46,25 +46,25 @@ export class PersonFamilyChildComponent implements OnInit {
   }
 
   last(): boolean {
-    return this.index > this.parentComponent.family.children.length;
+    return this.index + 1 >= this.parent.family.children.length;
   }
 
   moveUp(): void {
-    this.parentComponent.family.children.splice(
+    this.parent.family.children.splice(
       this.index - 1, 0,
-      this.parentComponent.family.children.splice(this.index, 1)[0]);
-    this.parentComponent.save();
+      this.parent.family.children.splice(this.index, 1)[0]);
+    this.parent.save();
   }
 
   moveDown(): void {
-    this.parentComponent.family.children.splice(
+    this.parent.family.children.splice(
       this.index + 1, 0,
-      this.parentComponent.family.children.splice(this.index, 1)[0]);
-    this.parentComponent.save();
+      this.parent.family.children.splice(this.index, 1)[0]);
+    this.parent.save();
   }
 
   delete(): void {
-    this.parentComponent.family.children.splice(this.index, 1);
-    this.parentComponent.save();
+    this.parent.family.children.splice(this.index, 1);
+    this.parent.save();
   }
 }

--- a/gedbrowser-client/src/app/modules/person/person-family-child.component.ts
+++ b/gedbrowser-client/src/app/modules/person/person-family-child.component.ts
@@ -49,20 +49,6 @@ export class PersonFamilyChildComponent implements OnInit {
     return this.index + 1 >= this.parent.family.children.length;
   }
 
-  moveUp(): void {
-    this.parent.family.children.splice(
-      this.index - 1, 0,
-      this.parent.family.children.splice(this.index, 1)[0]);
-    this.parent.save();
-  }
-
-  moveDown(): void {
-    this.parent.family.children.splice(
-      this.index + 1, 0,
-      this.parent.family.children.splice(this.index, 1)[0]);
-    this.parent.save();
-  }
-
   delete(): void {
     this.parent.family.children.splice(this.index, 1);
     this.parent.save();

--- a/gedbrowser-client/src/app/modules/person/person-family-list.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-family-list.component.html
@@ -1,16 +1,7 @@
-<app-person-family *ngFor="let attribute of person.fams; let i = index" [string]="attribute.string" [person]="person" [index]="i"></app-person-family>
-<mat-expansion-panel [expanded]="true" [class.mat-elevation-z8]="true">
-  <button mat-icon-button [matMenuTriggerFor]="newFamilyMenu" color="primary" matTooltip="Add family"><mat-icon>group_add</mat-icon></button>
-</mat-expansion-panel>
+<app-person-family *ngFor="let attribute of person.fams; let i = index"
+    [string]="attribute.string" [person]="person" [index]="i"></app-person-family>
 
-
-<mat-menu #newFamilyMenu="matMenu" class="menu" yPosition="below" xPosition="before">
-  <button mat-menu-item (click)="createFamilyWithSpouse()">
-    <mat-icon>person_add</mat-icon>
-    <span>Add family with partner</span>
-  </button>
-  <button mat-menu-item (click)="createFamilyWithChild()">
-    <mat-icon>person_add</mat-icon>
-    <span>Add family with child</span>
-  </button>
-</mat-menu>
+<p-menu #menu popup="popup" #cm appendTo="body" [model]="items"></p-menu>
+<p-button icon="fa fa-user-plus" (click)="menu.toggle($event)" pTooltip="Add new family"
+    [styleClass]="'ui-button-success'"></p-button>
+<br/>

--- a/gedbrowser-client/src/app/modules/person/person-family-list.component.ts
+++ b/gedbrowser-client/src/app/modules/person/person-family-list.component.ts
@@ -1,5 +1,6 @@
 import {Component, Input} from '@angular/core';
 import {MatDialogRef, MatDialog} from '@angular/material';
+import {MenuItem} from 'primeng/api';
 
 import {ApiAttribute, ApiFamily, ApiPerson} from '../../models';
 import {NewPersonLinkService, PersonService, UrlBuilder} from '../../services';
@@ -21,6 +22,14 @@ import {PersonComponent} from './person.component';
 export class PersonFamilyListComponent extends PersonCreator {
   @Input() parent: PersonComponent;
   @Input() person: ApiPerson;
+  items: MenuItem[] = [
+    {
+      label: 'Add family with partner', icon: 'fa-user-plus', command: (event: Event) => { this.createFamilyWithSpouse(); }
+    },
+    {
+      label: 'Add family with child', icon: 'fa-user-plus', command: (event: Event) => { this.createFamilyWithChild(); }
+    },
+  ];
 
   constructor(public dialog: MatDialog,
     private newPersonLinkService: NewPersonLinkService,

--- a/gedbrowser-client/src/app/modules/person/person-family.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-family.component.html
@@ -1,14 +1,29 @@
-<mat-expansion-panel *ngIf="initialized" [expanded]="true" [class.mat-elevation-z8]="true">
-  <mat-expansion-panel-header>
-    <mat-panel-title>
-      <span>Family {{index+1}}</span><span *ngIf="spouse()">&nbsp; - &nbsp;</span>
-      <app-person-family-spouse *ngIf="spouse()" [attribute]="spouse()"></app-person-family-spouse>
-    </mat-panel-title>
-  </mat-expansion-panel-header>
-  <span *ngIf="!spouse()">
-    <button mat-icon-button color="primary" (click)="createSpouse()" matTooltip="Add spouse"><mat-icon>person_add</mat-icon></button>
-  </span>
-  <app-attribute-list [attributes]="family.attributes" [parent]="this"></app-attribute-list>
-  <ngx-gallery *ngIf="family.images.length" [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
-  <app-person-family-child-list [children]="family.children" [family]="family" [parentComponent]="this"></app-person-family-child-list>
-</mat-expansion-panel>
+<p-panel [toggleable]="true">
+  <p-header>
+    <span>Family {{index+1}}</span>
+    <span *ngIf="spouse()">&nbsp;-&nbsp;</span>
+    <app-person-family-spouse *ngIf="spouse()" [attribute]="spouse()"></app-person-family-spouse>
+    <span class="bump-out" *ngIf="!spouse()">
+      <p-button (click)="createSpouse()" icon="fa fa-fw fa-user-plus"
+          [styleClass]="'ui-button-success'" pTooltip="Add spouse"></p-button>
+    </span>
+  </p-header>
+  <div class="ui-g">
+    <div class="ui-g-1"></div>
+    <div class="ui-g-10">
+      <app-attribute-list [attributes]="family?.attributes" [parent]="this" [styleClass]="'ui-panel-titlebar-success'"></app-attribute-list>
+    </div>
+    <div class="ui-g-1"></div>
+  </div>
+  <div class="ui-g">
+    <div class="ui-g-1"></div>
+    <div class="ui-g-10">
+      <p-panel header="Images" styleClass="ui-panel-titlebar-success">
+        <ngx-gallery *ngIf="family?.images.length" [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
+      </p-panel>
+    </div>
+    <div class="ui-g-1"></div>
+  </div>
+  <app-person-family-child-list *ngIf="family?.children" [children]="family?.children" [family]="family" [parent]="this"></app-person-family-child-list>
+</p-panel>
+<br/>

--- a/gedbrowser-client/src/app/modules/person/person-parent-families.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-parent-families.component.html
@@ -1,4 +1,9 @@
-<app-person-parent-family *ngFor="let famcAttribute of person.famc" [attribute]="famcAttribute"></app-person-parent-family>
-<div *ngIf="!person.famc.length">
-  <button mat-icon-button color="primary" (click)="createParentFamily()" matTooltip="Add parent family"><mat-icon>group_add</mat-icon></button>
-</div>
+<p-panel header="{{parent.person.string}}: {{parent.person.indexName}}{{parent.lifespanDateString()}}">
+  <p-header>
+    <span class="bump-out" *ngIf="!person.famc.length">
+      <p-button (click)="createParentFamily()" icon="fa fa-fw fa-user-plus"
+          [styleClass]="'ui-button-success'" pTooltip="Add parent family"></p-button>
+    </span>
+  </p-header>
+  <app-person-parent-family *ngFor="let famcAttribute of person.famc" [attribute]="famcAttribute"></app-person-parent-family>
+</p-panel>

--- a/gedbrowser-client/src/app/modules/person/person-parent-family.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-parent-family.component.html
@@ -1,3 +1,8 @@
-<mat-list *ngIf="initialized">
-  <app-person-parent *ngFor="let attribute of family.spouses" [attribute]="attribute"></app-person-parent>
-</mat-list>
+<p-orderList [value]="family?.spouses" dragdrop="false"
+    [responsive]="false" [listStyle]="{'height':'100%','width':'100%','border':'0'}">
+  <ng-template let-spouse pTemplate="listItem">
+    <div class="parent-family">
+      <app-person-parent [attribute]="spouse"></app-person-parent>
+    </div>
+  </ng-template>
+</p-orderList>

--- a/gedbrowser-client/src/app/modules/person/person-parent.component.html
+++ b/gedbrowser-client/src/app/modules/person/person-parent.component.html
@@ -1,4 +1,2 @@
-<mat-list-item>
-  <b>{{label()}}:&nbsp;</b>
-  <span *ngIf="person"><a [routerLink]="['/persons', person.string]" class="name"> {{person.indexName}} {{lifespanYearString()}} [{{person.string}}]</a></span>
-</mat-list-item>
+<b>{{label()}}:&nbsp;</b>
+<span *ngIf="person"><a [routerLink]="['/persons', person.string]" class="name"> {{person.indexName}} {{lifespanYearString()}} [{{person.string}}]</a></span>

--- a/gedbrowser-client/src/app/modules/person/person.component.css
+++ b/gedbrowser-client/src/app/modules/person/person.component.css
@@ -1,1 +1,21 @@
 @import '../../app.component.css';
+
+button[icon="fa-angle-up"] {
+  display: none !important;
+}
+
+button[icon="fa-angle-down"] {
+  display: none !important;
+}
+
+button[icon="fa-angle-double-up"] {
+    display: none !important;
+}
+
+button[ng-reflect-icon="fa-angle-double-up"] {
+    display: none !important;
+}
+
+div.ui-orderlist-controls {
+    display: none !important;
+}

--- a/gedbrowser-client/src/app/modules/person/person.component.html
+++ b/gedbrowser-client/src/app/modules/person/person.component.html
@@ -1,29 +1,17 @@
-<mat-card [class.mat-elevation-z4]="true">
-  <mat-card-title>{{person.string}}: {{person.indexName}}{{lifespanDateString()}}</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
-  <br/>
-  <mat-accordion multi="true">
-     <mat-expansion-panel [expanded]="true" [class.mat-elevation-z8]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>Parents</mat-panel-title>
-      </mat-expansion-panel-header>
-      <app-person-parent-families [parent]="this" [person]="person"></app-person-parent-families>
-    </mat-expansion-panel>
-    <app-person-family-list [parent]="this" [person]="person"></app-person-family-list>
-    <mat-expansion-panel [expanded]="true" [class.mat-elevation-z8]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>Attributes</mat-panel-title>
-      </mat-expansion-panel-header>
-      <app-attribute-list [attributes]="person.attributes" [parent]="this"></app-attribute-list>
-    </mat-expansion-panel>
-    <mat-expansion-panel *ngIf="person.images.length" [expanded]="true" [class.mat-elevation-z8]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>Images</mat-panel-title>
-      </mat-expansion-panel-header>
-      <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
-    </mat-expansion-panel>
-  </mat-accordion>
-  <br/>
+<app-person-parent-families [parent]="this" [person]="person"></app-person-parent-families>
+<br/>
+<app-person-family-list [parent]="this" [person]="person"></app-person-family-list>
+<br/>
+<app-attribute-list [attributes]="person.attributes" [parent]="this" [toggleable]="true"></app-attribute-list>
+<br/>
+<p-panel header="Images" [toggleable]="true">
+  <div>
+    <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
+  </div>
+</p-panel>
+<br/>
+<p-panel [showHeader]="false">
   <div><b>{{person.refn[0].string}}:&nbsp;</b> {{person.refn[0].tail}}</div>
   <div><b>{{person.changed[0].string}}:&nbsp;</b> {{person.changed[0].attributes[0].string}}</div>
-</mat-card>
+</p-panel>
+<br/>

--- a/gedbrowser-client/src/app/modules/person/person.module.ts
+++ b/gedbrowser-client/src/app/modules/person/person.module.ts
@@ -1,19 +1,16 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {
-  MatButtonModule,
-  MatCardModule,
-  MatDividerModule,
-  MatExpansionModule,
-  MatFormFieldModule,
-  MatIconModule,
-  MatListModule,
-  MatMenuModule,
-  MatTooltipModule,
-} from '@angular/material';
 import {NgxGalleryModule} from 'ngx-gallery';
 import {Ng2PageScrollModule} from 'ng2-page-scroll';
+
+import {PanelModule} from 'primeng/panel';
+import {AccordionModule} from 'primeng/accordion';
+import {DataViewModule} from 'primeng/dataview';
+import {ButtonModule} from 'primeng/button';
+import {TooltipModule} from 'primeng/tooltip';
+import {OrderListModule} from 'primeng/orderlist';
+import {MenuModule} from 'primeng/menu';
 
 import {ComponentsModule} from '../../components';
 
@@ -41,22 +38,20 @@ const personRouting: ModuleWithProviders = RouterModule.forChild([
 /**
  * The module for a person page routing.
  */
-@NgModule({
+@NgModule( {
   imports: [
     personRouting,
     CommonModule,
-    MatButtonModule,
-    MatCardModule,
-    MatDividerModule,
-    MatExpansionModule,
-    MatFormFieldModule,
-    MatIconModule,
-    MatListModule,
-    MatMenuModule,
-    MatTooltipModule,
     NgxGalleryModule,
     Ng2PageScrollModule.forRoot(),
     ComponentsModule,
+    PanelModule,
+    AccordionModule,
+    DataViewModule,
+    ButtonModule,
+    TooltipModule,
+    OrderListModule,
+    MenuModule,
   ],
   declarations: [
     PersonComponent,
@@ -72,6 +67,6 @@ const personRouting: ModuleWithProviders = RouterModule.forChild([
   providers: [
     PersonResolver,
   ]
-})
+} )
 
 export class PersonModule {}

--- a/gedbrowser-client/src/app/modules/source-list/source-list-item.component.html
+++ b/gedbrowser-client/src/app/modules/source-list/source-list-item.component.html
@@ -1,1 +1,1 @@
-<a mat-list-item [routerLink]="['/sources', source.string]">{{source.title}} ({{source.string}})</a>
+<a [routerLink]="['/sources', source.string]">{{source.title}} ({{source.string}})</a>

--- a/gedbrowser-client/src/app/modules/source-list/source-list.component.html
+++ b/gedbrowser-client/src/app/modules/source-list/source-list.component.html
@@ -1,7 +1,10 @@
-<mat-card [class.mat-elevation-4]="true">
-  <mat-card-title>Source List</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
-  <mat-list>
-    <app-source-list-item *ngFor="let source of sources" [source]="source"></app-source-list-item>
-  </mat-list>
-</mat-card>
+<p-dataView [value]="sources" [style]="{'min-width':'500px'}" [paginator]="true" [rows]="30"
+    paginatorPosition="both" pageLinks="10" [rowsPerPageOptions]="[10, 30, 100, 10000]"
+    [alwaysShowPaginator]="false">
+  <p-header>Source List</p-header>
+  <ng-template let-source pTemplate="listItem">
+    <div class="main-list">
+      <app-source-list-item [source]="source"></app-source-list-item>
+    </div>
+  </ng-template>
+</p-dataView>

--- a/gedbrowser-client/src/app/modules/source-list/source-list.module.ts
+++ b/gedbrowser-client/src/app/modules/source-list/source-list.module.ts
@@ -1,7 +1,9 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {MatCardModule, MatDividerModule, MatListModule} from '@angular/material';
+
+import {PanelModule} from 'primeng/panel';
+import {DataViewModule} from 'primeng/dataview';
 
 import {ComponentsModule} from '../../components';
 
@@ -23,10 +25,9 @@ const sourceRouting: ModuleWithProviders = RouterModule.forChild([
   imports: [
     sourceRouting,
     CommonModule,
-    MatCardModule,
-    MatDividerModule,
-    MatListModule,
-    ComponentsModule
+    ComponentsModule,
+    PanelModule,
+    DataViewModule,
   ],
   declarations: [
     SourceListComponent,

--- a/gedbrowser-client/src/app/modules/source/source.component.html
+++ b/gedbrowser-client/src/app/modules/source/source.component.html
@@ -1,19 +1,11 @@
-<mat-card [class.mat-elevation-z4]="true">
-  <mat-card-title>{{source.string}}: {{source.title}}</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
-  <br/>
-  <mat-accordion multi="true">
-    <mat-expansion-panel [expanded]="true" [class.mat-elevation-z8]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>Attributes</mat-panel-title>
-      </mat-expansion-panel-header>
-      <app-attribute-list [attributes]="source.attributes" [parent]="this"></app-attribute-list>
-    </mat-expansion-panel>
-    <mat-expansion-panel *ngIf="source.images.length" [expanded]="true" [class.mat-elevation-z8]="true">
-      <mat-expansion-panel-header>
-        <mat-panel-title>Images</mat-panel-title>
-      </mat-expansion-panel-header>
-      <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
-    </mat-expansion-panel>
-  </mat-accordion>
-</mat-card>
+<p-panel>
+  <p-header>{{source.string}}: {{source.title}}</p-header>
+</p-panel>
+
+<p-panel header="Attributes" [toggleable]="true">
+  <app-attribute-list [attributes]="source.attributes" [parent]="this"></app-attribute-list>
+</p-panel>
+
+<p-panel header="Images" [toggleable]="true">
+  <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
+</p-panel>

--- a/gedbrowser-client/src/app/modules/source/source.module.ts
+++ b/gedbrowser-client/src/app/modules/source/source.module.ts
@@ -1,9 +1,11 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {MatCardModule, MatDividerModule, MatExpansionModule, MatListModule} from '@angular/material';
+
 import {NgxGalleryModule} from 'ngx-gallery';
 import {Ng2PageScrollModule} from 'ng2-page-scroll';
+
+import {PanelModule} from 'primeng/panel';
 
 import {ComponentsModule} from '../../components';
 
@@ -24,12 +26,10 @@ const sourceRouting: ModuleWithProviders = RouterModule.forChild([
   imports: [
     sourceRouting,
     CommonModule,
-    MatCardModule,
-    MatDividerModule,
-    MatExpansionModule,
-    MatListModule,
     NgxGalleryModule,
     Ng2PageScrollModule.forRoot(),
+
+    PanelModule,
 
     ComponentsModule,
   ],

--- a/gedbrowser-client/src/app/modules/submitter-list/submitter-list-item.component.html
+++ b/gedbrowser-client/src/app/modules/submitter-list/submitter-list-item.component.html
@@ -1,1 +1,1 @@
-<a mat-list-item [routerLink]="['/submitters', submitter.string]">{{submitter.name}} ({{submitter.string}})</a>
+<a [routerLink]="['/submitters', submitter.string]">{{submitter.name}} ({{submitter.string}})</a>

--- a/gedbrowser-client/src/app/modules/submitter-list/submitter-list.component.html
+++ b/gedbrowser-client/src/app/modules/submitter-list/submitter-list.component.html
@@ -1,7 +1,10 @@
-<mat-card [class.mat-elevation-z4]="true">
-  <mat-card-title>Submitter List</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
-  <mat-list>
-    <app-submitter-list-item *ngFor="let submitter of submitters" [submitter]="submitter"></app-submitter-list-item>
-  </mat-list>
-</mat-card>
+<p-dataView [value]="submitters" [style]="{'min-width':'500px'}" [paginator]="true" [rows]="30"
+    paginatorPosition="both" pageLinks="10" [rowsPerPageOptions]="[10, 30, 100, 10000]"
+    [alwaysShowPaginator]="false">
+  <p-header>Submitter List</p-header>
+  <ng-template let-submitter pTemplate="listItem">
+    <div class="main-list">
+      <app-submitter-list-item [submitter]="submitter"></app-submitter-list-item>
+    </div>
+  </ng-template>
+</p-dataView>

--- a/gedbrowser-client/src/app/modules/submitter-list/submitter-list.module.ts
+++ b/gedbrowser-client/src/app/modules/submitter-list/submitter-list.module.ts
@@ -1,7 +1,9 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {MatCardModule, MatDividerModule, MatListModule} from '@angular/material';
+
+import {PanelModule} from 'primeng/panel';
+import {DataViewModule} from 'primeng/dataview';
 
 import {ComponentsModule} from '../../components';
 
@@ -23,10 +25,9 @@ const submitterRouting: ModuleWithProviders = RouterModule.forChild([
   imports: [
     submitterRouting,
     CommonModule,
-    MatCardModule,
-    MatDividerModule,
-    MatListModule,
-    ComponentsModule
+    ComponentsModule,
+    PanelModule,
+    DataViewModule,
   ],
   declarations: [
     SubmitterListComponent,

--- a/gedbrowser-client/src/app/modules/submitter/submitter.component.html
+++ b/gedbrowser-client/src/app/modules/submitter/submitter.component.html
@@ -1,5 +1,4 @@
-<mat-card [class.mat-elevation-z4]="true">
-  <mat-card-title>{{submitter.string}}: {{submitter.name}}</mat-card-title>
-  <mat-divider [inset]="true"></mat-divider>
+<p-panel>
+  <p-header>{{submitter.string}}: {{submitter.name}}</p-header>
   <app-attribute-list [attributes]="submitter.attributes"></app-attribute-list>
-</mat-card>
+</p-panel>

--- a/gedbrowser-client/src/app/modules/submitter/submitter.module.ts
+++ b/gedbrowser-client/src/app/modules/submitter/submitter.module.ts
@@ -1,7 +1,7 @@
 import {ModuleWithProviders, NgModule} from '@angular/core';
 import {RouterModule} from '@angular/router';
 import {CommonModule} from '@angular/common';
-import {MatCardModule, MatDividerModule} from '@angular/material';
+import {PanelModule} from 'primeng/panel';
 
 import {ComponentsModule} from '../../components';
 
@@ -22,9 +22,8 @@ const submitterRouting: ModuleWithProviders = RouterModule.forChild([
   imports: [
     submitterRouting,
     CommonModule,
-    MatCardModule,
-    MatDividerModule,
     ComponentsModule,
+    PanelModule,
   ],
   declarations: [
     SubmitterComponent,

--- a/gedbrowser-client/src/app/utils/attribute-util.ts
+++ b/gedbrowser-client/src/app/utils/attribute-util.ts
@@ -58,6 +58,9 @@ export class AttributeUtil {
 
   lastIndex(): number {
     let index = 0;
+    if (this.parent === null || this.parent.attributes === null) {
+      return 0;
+    }
     for (const attribute of this.parent.attributes) {
       if (this.isLast(this.parent.attributes, attribute)) {
         return index;

--- a/gedbrowser-client/src/styles.css
+++ b/gedbrowser-client/src/styles.css
@@ -1,4 +1,7 @@
 @import '~@angular/material/prebuilt-themes/indigo-pink.css';
+@import '~font-awesome/css/font-awesome.min.css';
+@import '~primeng/resources/themes/start/theme.css';
+@import '~primeng/resources/primeng.min.css';
 
 .mat-sidenav-container, .mat-sidenav-content, .mat-tab-body-content {
     transform: none !important;
@@ -12,4 +15,36 @@ ngx-gallery-arrows.ngx-gallery-image-size-contain .fa {
 
 .ngx-gallery-icon {
     color: white;
+}
+
+div.ui-orderlist-controls {
+    display: none !important;
+}
+
+.ui-panel.ui-panel-titlebar-success .ui-panel-titlebar  {
+  /* Hover colors for the titlebar button in Start theme. */
+  border-color: #448dae;
+  background: #79c9ec;
+  color: #222222;
+}
+
+.mat-dialog-actions.custom-button-placement {
+  float: right;
+}
+
+.parent-family {
+  padding: 10px;
+}
+
+.main-list {
+  padding: 3px;
+}
+
+.ui-toolbar-group-left span {
+  font-size:16pt;
+  vertical-align: baseline;
+}
+
+.bump-out {
+  padding-left: 2em;
 }


### PR DESCRIPTION
Fixes #614

In addition to the change of component set, we pick up the following
improvements.

* Use drag-and-drop to reorder the items in lists
* Move the "create" buttons into the banners for their sections
* Use pagination on the potentially long lists
* Seem to have gotten better behaviors on the image handling
* Updates to npm components