### PR TITLE
Fix problem populating attribute dialog

### DIFF
--- a/gedbrowserng-frontend/src/app/utils/attribute-dialog-helper.ts
+++ b/gedbrowserng-frontend/src/app/utils/attribute-dialog-helper.ts
@@ -64,17 +64,17 @@ export class AttributeDialogHelper {
   }
 
   private getByType(typeInput: string) {
-    return this.getBy(this.parent.attribute.attributes, typeInput, (attr) => attr.type.toLowerCase());
+    return this.getBy(this.parent.attribute.attributes, typeInput, (attr) => attr.type.toLowerCase(), (attr) => attr.string);
   }
 
   private getByString(stringInput: string) {
-    return this.getBy(this.parent.attribute.attributes, stringInput, (attr) => attr.string);
+    return this.getBy(this.parent.attribute.attributes, stringInput, (attr) => attr.string, (attr) => attr.tail);
   }
 
-  private getBy(attributes: Array<ApiAttribute>, input: string, getField) {
+  private getBy(attributes: Array<ApiAttribute>, input: string, getField, getValue) {
     for (const attr of attributes) {
       if (getField(attr) === input) {
-        return attr.tail;
+        return getValue(attr);
       }
     }
   }


### PR DESCRIPTION
Fixes #774

A regression was introduced in 1.3.0-M5 where certain types of
attributes didn't populate correctly because the field extractor
was changed incorrectly.

The fix will cause a method to have a warning for too many params.