### PR TITLE
Improve error handling in linking and deleting

### DIFF
--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/CrudHelper.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/CrudHelper.java
@@ -21,7 +21,8 @@ public class CrudHelper {
         if (sex(person, "F")) {
             return new ApiAttribute("wife", person.getString());
         }
-        return new ApiAttribute("spouse", person.getString());
+        // TODO This should really be "spouse" but not supported everywhere
+        return new ApiAttribute("husband", person.getString());
     }
 
     /**

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/RelationsCrud.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/RelationsCrud.java
@@ -119,9 +119,20 @@ public abstract class RelationsCrud extends CrudParams implements LinkCrud {
      */
     private ApiAttribute findFamsAttribute(final ApiFamily family,
             final ApiPerson person) {
+        final String fid = family.getString();
+        return findFamsAttribute(fid, person);
+    }
+
+
+    /**
+     * @param fid the family that should be pointed to by fams
+     * @param person the person we are searching
+     * @return the fams attribute
+     */
+    protected ApiAttribute findFamsAttribute(final String fid,
+            final ApiPerson person) {
         for (final ApiAttribute fams : person.getFams()) {
-            if (fams.getString().equals(family.getString())) {
-                person.getFams().remove(fams);
+            if (fams.getString().equals(fid)) {
                 return fams;
             }
         }
@@ -137,6 +148,16 @@ public abstract class RelationsCrud extends CrudParams implements LinkCrud {
     protected final ApiPerson crudUpdate(final String db,
             final ApiFamily newFamily, final ApiPerson... newPersons) {
         familyCrud().updateOne(db, newFamily.getString(), newFamily);
+        return crudUpdate(db, newPersons);
+    }
+
+    /**
+     * @param db the name of the db to update
+     * @param newPersons the persons linked to the family
+     * @return the person
+     */
+    protected final ApiPerson crudUpdate(final String db,
+            final ApiPerson... newPersons) {
         ApiPerson person = null;
         for (final ApiPerson newPerson : newPersons) {
             person = personCrud()


### PR DESCRIPTION
Fixes #804

2 things were occuring
* Spouses of unknown sex were mishandled. This would result in problems with
  the lists of spouses in families
* Families with problems in the lists of spouses would end up with bad
  behavior when link/unlinking, which would make things undeletable.