### PR TITLE
Fix a bunch of warnings

### DIFF
--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/users/test/UserFacadeTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/users/test/UserFacadeTest.java
@@ -14,7 +14,6 @@ import org.schoellerfamily.gedbrowser.datamodel.users.UserRoleName;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("null")
 public class UserFacadeTest {
     /**
      * @author Dick Schoeller
@@ -24,15 +23,14 @@ public class UserFacadeTest {
         private final User user;
 
         /**
+         * Constructor.
+         *
          * @param user the user object that we are wrapping
          */
         UserFacadeImpl(final User user) {
             this.user = user;
         }
 
-        /**
-         * {@inheritDoc}
-         */
         @Override
         public User getUser() {
             return user;

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GedObjectBuilderFamilyTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GedObjectBuilderFamilyTest.java
@@ -17,7 +17,6 @@ import org.schoellerfamily.gedbrowser.datamodel.visitor.GetDateVisitor;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("null")
 public final class GedObjectBuilderFamilyTest {
     /** */
     private final GedObjectBuilder builder = new GedObjectBuilder();

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/fixture/RepositoryFixture.java
@@ -22,7 +22,6 @@ import lombok.RequiredArgsConstructor;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("null")
 @RequiredArgsConstructor
 public final class RepositoryFixture {
     /** */
@@ -73,7 +72,7 @@ public final class RepositoryFixture {
     public void clearRepository() {
         rootDocumentRepository.deleteAll();
         repositoryManager.reset();
-        MongoDatabase db = mongoTemplate.getDb();
+        final MongoDatabase db = mongoTemplate.getDb();
         db.drop();
     }
 }

--- a/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/testreader/TestDataReader.java
+++ b/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/testreader/TestDataReader.java
@@ -15,7 +15,6 @@ import lombok.RequiredArgsConstructor;
  */
 @Component
 @RequiredArgsConstructor
-@SuppressWarnings("null")
 public final class TestDataReader {
     /** */
     private final GedLineToGedObjectTransformer g2g;

--- a/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/testreader/TestResourceReader.java
+++ b/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/testreader/TestResourceReader.java
@@ -17,7 +17,6 @@ import org.schoellerfamily.gedbrowser.reader.StreamManager;
  *
  * @author Dick Schoeller
  */
-@SuppressWarnings("null")
 public final class TestResourceReader {
     /**
      * Constructor.
@@ -35,7 +34,7 @@ public final class TestResourceReader {
      */
     public static AbstractGedLine readFileTestSource(final Object caller, final String filename)
         throws IOException {
-        String shortname;
+        final String shortname;
         if (filename.charAt(0) == '/') {
             shortname = filename.substring(filename.lastIndexOf("/") + 1);
         } else {

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmissionLinkListItemRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/SubmissionLinkListItemRendererTest.java
@@ -25,7 +25,6 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { TestConfiguration.class })
-@SuppressWarnings("null")
 public final class SubmissionLinkListItemRendererTest {
     /** */
     @Autowired

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/MockMvcConfig.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/MockMvcConfig.java
@@ -19,7 +19,6 @@ import lombok.RequiredArgsConstructor;
  */
 @Configuration
 @RequiredArgsConstructor
-@SuppressWarnings("null")
 public class MockMvcConfig {
     /** */
     private final WebApplicationContext wac;
@@ -27,12 +26,8 @@ public class MockMvcConfig {
     /** */
     private final TokenAuthenticationFilter filter;
 
-//    /** */
-//    @Autowired
-//    private Environment env;
-
     /** */
-    private final int port = 8080;
+    private static final int PORT = 8080;
 
     /**
      * @return the request builder
@@ -45,7 +40,7 @@ public class MockMvcConfig {
      * @return the mock MVC
      */
     private MockMvc mockMvc() {
-        DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
+        final DefaultMockMvcBuilder builder = MockMvcBuilders.webAppContextSetup(wac);
         return builder.addFilter(filter, "", "")
                 .build();
     }
@@ -56,6 +51,6 @@ public class MockMvcConfig {
     @PostConstruct
     protected void restAssured() {
         RestAssuredMockMvc.mockMvc(mockMvc());
-        RestAssured.port = this.port;
+        RestAssured.port = PORT;
     }
 }

--- a/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/GedWriterTest.java
+++ b/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/GedWriterTest.java
@@ -9,7 +9,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 
 import org.apache.commons.io.FileUtils;
-import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -25,13 +24,14 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit.jupiter.SpringExtension;
 
+import lombok.extern.slf4j.Slf4j;
+
 /**
  * @author Dick Schoeller
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { TestConfiguration.class })
 @Slf4j
-@SuppressWarnings("null")
 public class GedWriterTest {
     /** */
     @Autowired

--- a/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/ReaderWriterTest.java
+++ b/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/ReaderWriterTest.java
@@ -21,7 +21,6 @@ import lombok.extern.slf4j.Slf4j;
  * @author Dick Schoeller
  */
 @Slf4j
-@SuppressWarnings("null")
 public class ReaderWriterTest {
     /**
      * The file name to use in the test.

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/SaveController.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/SaveController.java
@@ -48,7 +48,6 @@ public class SaveController {
      */
     @GetMapping(value = "/v1/dbs/{db}/save", produces = MediaType.TEXT_PLAIN_VALUE)
     @ResponseBody
-    @SuppressWarnings("null")
     public final ResponseEntity<String> save(@PathVariable final String db,
         final HttpServletResponse response) {
         log.info("Starting save");

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/UploadController.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/UploadController.java
@@ -65,7 +65,6 @@ public class UploadController {
         }
         log.info("in file upload: {}", originalFilename);
         storageService.store(file);
-        @SuppressWarnings("null")
         final String name = originalFilename.replaceAll("\\.ged", "");
         return readOne(name);
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/service/storage/FileSystemStorageService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/service/storage/FileSystemStorageService.java
@@ -53,7 +53,6 @@ public class FileSystemStorageService implements StorageService {
         if (ObjectUtils.isEmpty(originalFilename)) {
             throw new StorageException("Failed to store file with empty name");
         }
-        @SuppressWarnings("null")
         final String filename = StringUtils.cleanPath(originalFilename);
         if (file.isEmpty()) {
             throw new StorageException("Failed to store empty file %s".formatted(filename));

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
@@ -8,7 +8,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiNote;
@@ -22,7 +21,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -30,11 +28,10 @@ import org.springframework.web.client.RestClientException;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class NoteControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiSource;
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -29,11 +27,10 @@ import org.springframework.web.client.RestClientException;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class SourceControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
@@ -4,10 +4,10 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiPerson;
 import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
@@ -18,7 +18,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -28,13 +27,13 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { Application.class,
-    TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = { Application.class, TestConfiguration.class },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @Slf4j
 @AutoConfigureRestTestClient
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 public class SpousesControllerTest {
     /**
      * RestTestClient injected by Spring's test support.

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
@@ -4,7 +4,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
-import java.net.URISyntaxException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -139,7 +138,7 @@ public class SpousesControllerTest {
     /**
      * @param parent the parent
      * @return the child
-     * @throws URISyntaxException if there is a problem with the URL
+     * @throws RestClientException if we can't talk to rest server
      */
     private ApiPerson createChildOfParent(final ApiPerson parent) throws RestClientException {
         final String childUrl = helper.getPersonsUrl() + "/" + parent.getString() + "/children";

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiSubmission;
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -29,11 +27,11 @@ import org.springframework.web.client.RestClientException;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { Application.class,
-    TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = { Application.class, TestConfiguration.class },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class SubmissionControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
@@ -7,7 +7,6 @@ import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiSubmitter;
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -29,11 +27,11 @@ import org.springframework.web.client.RestClientException;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { Application.class,
-    TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = { Application.class, TestConfiguration.class },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class SubmitterControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadServiceTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadServiceTest.java
@@ -3,7 +3,6 @@ package org.schoellerfamily.gedbrowser.api.controller.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiHead;
 import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
@@ -17,7 +16,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.util.LinkedMultiValueMap;
@@ -26,11 +24,10 @@ import org.springframework.util.MultiValueMap;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class UploadServiceTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -10,7 +10,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -27,18 +26,17 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { Application.class,
-    TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@SpringBootTest(
+    classes = { Application.class, TestConfiguration.class },
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @Slf4j
 public class SubmissionCrudTest {
 
@@ -120,7 +118,7 @@ public class SubmissionCrudTest {
         final ApiSubmission inSubmission = ApiSubmission.builder()
             .type("submission")
             .string("")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiSubmission outSubmission = crud.createOne(helper.getDb(), inSubmission);
         then(outSubmission.getType()).isEqualTo(inSubmission.getType());
@@ -133,7 +131,7 @@ public class SubmissionCrudTest {
         final ApiSubmission inSubmission = ApiSubmission.builder()
             .type("submission")
             .string("")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiSubmission outSubmission = crud.createOne(helper.getDb(), inSubmission);
         final String id = outSubmission.getString();

--- a/geoservice/src/main/java/org/schoellerfamily/geoservice/Application.java
+++ b/geoservice/src/main/java/org/schoellerfamily/geoservice/Application.java
@@ -17,6 +17,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.Configuration;
 
 /**
  * Main module of a Spring Boot application to provide cached geocode lookups
@@ -26,6 +27,7 @@ import org.springframework.context.annotation.ComponentScan;
  */
 @ComponentScan(basePackages = { "org.schoellerfamily.geoservice" })
 @EnableAutoConfiguration
+@Configuration
 public class Application {
     /** */
     @Value("${geoservice.keyfile:/var/lib/gedbrowser/google-geocoding-key}")


### PR DESCRIPTION
This pull request focuses on cleaning up test and application code by removing unnecessary `@SuppressWarnings("null")` annotations, improving code style, and making minor refactoring for clarity and consistency. The changes primarily target test files across multiple modules, with some small improvements to variable declarations and annotation usage.

Key changes include:

**Removal of unnecessary warnings and annotation cleanup:**

* Removed `@SuppressWarnings("null")` annotations from numerous test classes, reducing clutter and improving code readability. [[1]](diffhunk://#diff-84870fca54542a8d8a656e610cf7b1f77f59ad8960dea190db50e740ac024bc6L17) [[2]](diffhunk://#diff-f96693feec998f796f70e9018690cce75b2f8be26ca273567dec2064c91a302aL20) [[3]](diffhunk://#diff-3ffdf117a0bdb4bf57944b814c0b69c4ce46b5e208e7eb1c9349b2510c54356eL25) [[4]](diffhunk://#diff-4e5f70600fe6632a9b4e2b3e413f3cc12983ed827a567fb8c7bb6e8bf3805517L18) [[5]](diffhunk://#diff-555834a961fc68f09842edb193ea45993ba2ce95ab448a7e9d44684af113001bL20) [[6]](diffhunk://#diff-b5aaa512a40e6446bab0c272b0e63d91031abb6f06e852aef6eb14798eb1498cL28) [[7]](diffhunk://#diff-f8fbe7ddd8f47598681167da17efa22c015546f80fe3599c0f108bee7e378b6aR27-L34) [[8]](diffhunk://#diff-649dab15c6aa9a297413031fbba1425ce9ef59aa4d7c97df4f64c7245ef334eaL24) [[9]](diffhunk://#diff-443491f7977862299edfbed5959b06e5061968375f6b29769eac2995abed4ef0L51) [[10]](diffhunk://#diff-1fb90208c005bb7818acbd38b0009a5107ec2f82eb6b8579f6f023ab8c8fc4c9L68) [[11]](diffhunk://#diff-ad038a7ca966a64164fd639bfc2f820b26d792ab633b0fd6d1f99d87026f19beL56) [[12]](diffhunk://#diff-059375f14bcbee451b2bd784f27a2049cb3ea47b99f39edca5a3da713248fc01L25-R34) [[13]](diffhunk://#diff-8e5b34081fcc65154cb83066304ef169603e0267ff39f53f0ccd929b33620937L24-R33) [[14]](diffhunk://#diff-84507e64cea51fcb46bf001611c6ad87caaa5de712f72fec8d688831028ef8b1L31-R36) [[15]](diffhunk://#diff-23be6c6bb31c812f2a96edcb88b3d2375b69efb9e7872c86c3eee4569f6e6e8bL24-R34) [[16]](diffhunk://#diff-2591f9a2b064a1f5e46bf58cfde1c944a921d084a87139366802a6989d3d11d9L24-R34)

**Test code improvements and refactoring:**

* Updated variable declarations to use `final` where appropriate, and improved naming consistency (e.g., `PORT` constant in `MockMvcConfig`, use of `final` for local variables). [[1]](diffhunk://#diff-3ffdf117a0bdb4bf57944b814c0b69c4ce46b5e208e7eb1c9349b2510c54356eL76-R75) [[2]](diffhunk://#diff-aa35eed6e09224eaebc620b6e0a961f4f91d464bf601b49cabd54f7171cc4453L22-R30) [[3]](diffhunk://#diff-aa35eed6e09224eaebc620b6e0a961f4f91d464bf601b49cabd54f7171cc4453L48-R43) [[4]](diffhunk://#diff-aa35eed6e09224eaebc620b6e0a961f4f91d464bf601b49cabd54f7171cc4453L59-R54) [[5]](diffhunk://#diff-555834a961fc68f09842edb193ea45993ba2ce95ab448a7e9d44684af113001bL38-R37)
* Moved the `@Slf4j` annotation to the correct location in `GedWriterTest` for proper logging. [[1]](diffhunk://#diff-f8fbe7ddd8f47598681167da17efa22c015546f80fe3599c0f108bee7e378b6aL12) [[2]](diffhunk://#diff-f8fbe7ddd8f47598681167da17efa22c015546f80fe3599c0f108bee7e378b6aR27-L34)

**JUnit and Spring test annotation updates:**

* Removed redundant or unnecessary JUnit and Spring test annotations (such as `@ExtendWith(SpringExtension.class)`) from test classes, relying on more modern Spring Boot test configurations. [[1]](diffhunk://#diff-059375f14bcbee451b2bd784f27a2049cb3ea47b99f39edca5a3da713248fc01L11) [[2]](diffhunk://#diff-8e5b34081fcc65154cb83066304ef169603e0267ff39f53f0ccd929b33620937L10) [[3]](diffhunk://#diff-84507e64cea51fcb46bf001611c6ad87caaa5de712f72fec8d688831028ef8b1R7-L10) [[4]](diffhunk://#diff-84507e64cea51fcb46bf001611c6ad87caaa5de712f72fec8d688831028ef8b1L21) [[5]](diffhunk://#diff-23be6c6bb31c812f2a96edcb88b3d2375b69efb9e7872c86c3eee4569f6e6e8bL10) [[6]](diffhunk://#diff-2591f9a2b064a1f5e46bf58cfde1c944a921d084a87139366802a6989d3d11d9L10) [[7]](diffhunk://#diff-843807a5ffef6c409b05f8833f18c49e9dd94fe3707638c53abe2a25976f359cL6)
* Cleaned up `@SuppressWarnings` lists in test classes to remove the `"null"` warning where it is no longer necessary. [[1]](diffhunk://#diff-059375f14bcbee451b2bd784f27a2049cb3ea47b99f39edca5a3da713248fc01L25-R34) [[2]](diffhunk://#diff-8e5b34081fcc65154cb83066304ef169603e0267ff39f53f0ccd929b33620937L24-R33) [[3]](diffhunk://#diff-84507e64cea51fcb46bf001611c6ad87caaa5de712f72fec8d688831028ef8b1L31-R36) [[4]](diffhunk://#diff-23be6c6bb31c812f2a96edcb88b3d2375b69efb9e7872c86c3eee4569f6e6e8bL24-R34) [[5]](diffhunk://#diff-2591f9a2b064a1f5e46bf58cfde1c944a921d084a87139366802a6989d3d11d9L24-R34)

**Minor documentation and constructor improvements:**

* Improved Javadoc comments and constructor documentation in test utility classes for clarity.

**Dependency and import cleanup:**

* Removed unused imports and organized import statements for better maintainability. [[1]](diffhunk://#diff-059375f14bcbee451b2bd784f27a2049cb3ea47b99f39edca5a3da713248fc01L11) [[2]](diffhunk://#diff-8e5b34081fcc65154cb83066304ef169603e0267ff39f53f0ccd929b33620937L10) [[3]](diffhunk://#diff-84507e64cea51fcb46bf001611c6ad87caaa5de712f72fec8d688831028ef8b1R7-L10) [[4]](diffhunk://#diff-f8fbe7ddd8f47598681167da17efa22c015546f80fe3599c0f108bee7e378b6aL12)

These changes collectively enhance code quality, readability, and maintainability across the test and supporting codebase.