### PR TITLE
more warnings

### DIFF
--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.BDDAssertions.then;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,19 +14,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings({"PMD.JUnitTestsShouldIncludeAssert", "null"})
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 public class LivingControllerTest implements MenuTestHelper {
 
     /**
@@ -55,7 +52,7 @@ public class LivingControllerTest implements MenuTestHelper {
         final HttpStatusCode status = entity.getStatus();
         then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         then(entity.getResponseBody()).contains("<title>Living - gl120368</title>")
-        .contains(getMenu("A"));
+            .contains(getMenu("A"));
     }
 
     /** */

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -2,10 +2,10 @@ package org.schoellerfamily.gedbrowser.controller.test;
 
 import static org.assertj.core.api.BDDAssertions.then;
 
+import java.net.URI;
 import java.util.List;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -16,21 +16,19 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.web.client.RestTemplate;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
-import java.net.URI;
+import org.springframework.web.client.RestTemplate;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
-@SpringBootTest(classes = { Application.class, TestConfiguration.class },
+@SpringBootTest(
+    classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert", "null" })
+@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 public class LoginControllerTest {
 
     /**


### PR DESCRIPTION
This pull request makes minor cleanup changes to the test classes for `LivingControllerTest` and `LoginControllerTest`. The changes focus on removing unnecessary imports and annotations, and improving code style consistency.

Test class cleanup and code style improvements:

* Removed the unnecessary `@ExtendWith(SpringExtension.class)` annotation and related imports from both `LivingControllerTest` and `LoginControllerTest` since they are redundant with `@SpringBootTest`. [[1]](diffhunk://#diff-6b623591566e9a95993f5a66ed10ce04667d19142464d742cc7b484b432c63b6L18-R27) [[2]](diffhunk://#diff-e979569893f25cf2090d70c049a04d4032987f0484e349ff96f8339968346fdaL19-R31)
* Cleaned up imports by removing unused or duplicate imports and reordering them for clarity in both test files. [[1]](diffhunk://#diff-6b623591566e9a95993f5a66ed10ce04667d19142464d742cc7b484b432c63b6L8) [[2]](diffhunk://#diff-e979569893f25cf2090d70c049a04d4032987f0484e349ff96f8339968346fdaR5-L8) [[3]](diffhunk://#diff-e979569893f25cf2090d70c049a04d4032987f0484e349ff96f8339968346fdaL19-R31)
* Updated the `@SuppressWarnings` annotation to remove the `"null"` warning suppression, which is no longer needed. [[1]](diffhunk://#diff-6b623591566e9a95993f5a66ed10ce04667d19142464d742cc7b484b432c63b6L18-R27) [[2]](diffhunk://#diff-e979569893f25cf2090d70c049a04d4032987f0484e349ff96f8339968346fdaL19-R31)