### PR TITLE
Use AssertJ for testing expected exceptions

### DIFF
--- a/gedbrowser-datamodel/pom.xml
+++ b/gedbrowser-datamodel/pom.xml
@@ -73,6 +73,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/gedbrowser-datamodel/pom.xml
+++ b/gedbrowser-datamodel/pom.xml
@@ -70,6 +70,10 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
@@ -2,7 +2,7 @@ package org.schoellerfamily.gedbrowser.datamodel.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.util.Set;
 
@@ -119,12 +119,8 @@ public final class IndexTest {
     @Test
     void testGetNamesPerSurname6() {
         final Set<String> schoellerIndex = root.getIndex().getNamesPerSurname(SCHOELLER_SURNAME);
-        try {
-            schoellerIndex.add(FOO);
-            fail(SHOULD_THROW);
-        } catch (UnsupportedOperationException e) {
-            // Expected to get here
-        }
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> schoellerIndex.add(FOO));
     }
 
     @Test
@@ -145,12 +141,8 @@ public final class IndexTest {
     @Test
     void testGetSurnamesImmutable() {
         final Set<String> set = root.getIndex().getSurnames();
-        try {
-            set.add(FOO);
-            fail(SHOULD_THROW);
-        } catch (UnsupportedOperationException e) {
-            // Expected to get here.
-        }
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> set.add(FOO));
     }
 
     @Test
@@ -165,12 +157,8 @@ public final class IndexTest {
         Set<String> emptySet;
         emptySet = root.getIndex().getIdsPerName(SCHOELLER_SURNAME, null);
         assertEquals(0, emptySet.size(), "Expected empty result set");
-        try {
-            emptySet.add(FOO);
-            fail(SHOULD_THROW);
-        } catch (UnsupportedOperationException e) {
-            // Expected to get here
-        }
+        assertThatExceptionOfType(UnsupportedOperationException.class)
+            .isThrownBy(() -> emptySet.add(FOO));
     }
 
     @Test

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/test/IndexTest.java
@@ -19,11 +19,6 @@ import org.schoellerfamily.gedbrowser.datamodel.util.GedObjectBuilder;
 public final class IndexTest {
 
     /**
-     * Message if we didn't throw when we should.
-     */
-    private static final String SHOULD_THROW = "We shouldn't have gotten here";
-
-    /**
      * Dummy input line.
      */
     private static final String FOO = "FOO";

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -54,227 +54,170 @@ public final class BadLoadTest {
     @Test
     void testBadAttributeLoad() {
         final AttributeDocumentMongo ad = new AttributeDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadChildLoad() {
         final ChildDocumentMongo ad = new ChildDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadDateLoad() {
         final DateDocumentMongo ad = new DateDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadFamCLoad() {
         final FamCDocumentMongo ad = new FamCDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadFamilyLoad() {
         final FamilyDocumentMongo ad = new FamilyDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadFamSLoad() {
         final FamSDocumentMongo ad = new FamSDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadHeadLoad() {
         final HeadDocumentMongo ad = new HeadDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadHusbandLoad() {
         final HusbandDocumentMongo ad = new HusbandDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadMultimediaLoad() {
         final MultimediaDocumentMongo ad = new MultimediaDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadNameLoad() {
         final NameDocumentMongo ad = new NameDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadPersonLoad() {
         final PersonDocumentMongo ad = new PersonDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadPlaceLoad() {
         final PlaceDocumentMongo ad = new PlaceDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadRootLoad() {
         final RootDocumentMongo ad = new RootDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, attr);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, attr))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadSourceLoad() {
         final SourceDocumentMongo ad = new SourceDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadSourceLinkLoad() {
         final SourceLinkDocumentMongo ad = new SourceLinkDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadSubmitterLoad() {
         final SubmitterDocumentMongo ad = new SubmitterDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadSubmitterLinkLoad() {
         final SubmitterLinkDocumentMongo ad = new SubmitterLinkDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadTrailerLoad() {
         final TrailerDocumentMongo ad = new TrailerDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 
     /** */
     @Test
     void testBadWifeLoad() {
         final WifeDocumentMongo ad = new WifeDocumentMongo();
-        try {
-            ad.loadGedObject(toDocConverter, root);
-            fail("Expected to throw persistence exception");
-        } catch (PersistenceException e) {
-            assertEquals("Wrong type", e.getMessage(), "Expected a wrong type exception");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> ad.loadGedObject(toDocConverter, root))
+            .withMessage("Wrong type");
     }
 }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -319,12 +319,7 @@ public final class GedDocumentMongoToGedObjectConverterTest {
             }
         };
         gmd.setString("Foo");
-        GedObject ged = null;
-        try {
-            ged = toObjConverter.createGedObject(new Root(), gmd);
-            fail("Should not get here");
-        } catch (PersistenceException e) {
-            assertNull(ged, "Result should be null");
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> toObjConverter.createGedObject(new Root(), gmd));
     }
 }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -297,26 +297,16 @@ public class GedObjectToGedDocumentMongoConverterTest {
     /** */
     @Test
     void testNullCreateDocument() {
-        GedDocument<?> gmd = null;
-        try {
-            gmd = toDocConverter.createGedDocument(null);
-            fail("Should not get here");
-        } catch (PersistenceException e) {
-            assertNull(gmd, "Should be null"); // Expected
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> toDocConverter.createGedDocument(null));
     }
 
     /** */
     @Test
     void testUnexpectedCreateDocument() {
         final GedObject ged = createGedObject();
-        GedDocument<?> gmd = null;
-        try {
-            gmd = toDocConverter.createGedDocument(ged);
-            fail("Should not get here");
-        } catch (PersistenceException e) {
-            assertNull(gmd, "Should be null"); // Expected
-        }
+        assertThatExceptionOfType(PersistenceException.class)
+            .isThrownBy(() -> toDocConverter.createGedDocument(ged));
     }
 
     /**

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.loader.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.Iterator;
 import java.util.Map;
@@ -145,9 +145,9 @@ public class GedDocumentFileLoaderTest {
      * Check that the repository is empty.
      */
     private void assertRepositoryEmpty() {
-        for (final RootDocument doc : findAll()) {
-            fail("should not have found document " + doc.getDbName());
-        }
+        final Iterable<RootDocumentMongo> allDocs = findAll();
+        assertThatExceptionOfType(java.util.NoSuchElementException.class)
+            .isThrownBy(() -> allDocs.iterator().next());
     }
 
     /**

--- a/gedbrowser-writer/pom.xml
+++ b/gedbrowser-writer/pom.xml
@@ -84,6 +84,10 @@
       <artifactId>junit-jupiter-params</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+    </dependency>
   </dependencies>
 
   <reporting>

--- a/gedbrowser-writer/pom.xml
+++ b/gedbrowser-writer/pom.xml
@@ -87,6 +87,7 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
+++ b/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.writer.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.schoellerfamily.gedbrowser.datamodel.users.User;
@@ -31,12 +31,9 @@ public class UsersWriterTest {
 
     @Test
     void testNull() {
-        try {
-            writeUserFile(null);
-            fail("Should throw null pointer exception");
-        } catch (NullPointerException e) {
-            assertNull(e.getMessage(), "Should be a null message");
-        }
+        assertThatExceptionOfType(NullPointerException.class)
+            .isThrownBy(() -> writeUserFile(null))
+            .withMessage(null);
     }
 
     @Test

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -22,20 +21,18 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
-public class FamilyCrudTest {
+class FamilyCrudTest {
 
     /** */
     @Autowired
@@ -54,7 +51,7 @@ public class FamilyCrudTest {
 
     /** */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         crud = new FamilyCrud(loader, toDocConverter, repositoryManager);
     }
 
@@ -116,13 +113,9 @@ public class FamilyCrudTest {
     @Test
     void testGetFamiliesMiniSchoellerXyzzy() {
         log.info("Beginning testGetFamiliesMiniSchoellerXyzzy");
-        try {
-            final ApiFamily family = crud.readOne("mini-schoeller", "Xyzzy");
-            fail("The family should not be found: " + family.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object Xyzzy of type family not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("mini-schoeller", "Xyzzy"))
+            .withMessage("Object Xyzzy of type family not found");
     }
 
     /** */
@@ -161,38 +154,27 @@ public class FamilyCrudTest {
         final String id = outFamily.getString();
         final ApiFamily deletedFamily = crud.deleteOne("gl120368", id);
         then(deletedFamily.getString()).isEqualTo(id);
-        try {
-            final ApiFamily family = crud.readOne("gl120368", id);
-            fail("The family should not be found: " + family.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + id + " of type family not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("gl120368", id))
+            .withMessage("Object " + id + " of type family not found");
     }
 
     /** */
     @Test
     void testDeleteFamilyNotFound() {
         log.info("Beginning testDeleteFamilyNotFound");
-        try {
-            final ApiFamily family = crud.deleteOne("gl120368", "XXXXXXX");
-            fail("The family should not be found: " + family.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXXXX of type family not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne("gl120368", "XXXXXXX"))
+            .withMessage("Object XXXXXXX of type family not found");
     }
 
     /** */
     @Test
     void testDeleteFamilyDatabaseNotFound() {
         log.info("Beginning testDeleteFamilyDatabaseNotFound");
-        try {
-            final ApiFamily family = crud.deleteOne("XYZZY", "SUBM1");
-            fail("The family should not be found: " + family.getString());
-        } catch (DataSetNotFoundException e) {
-            assertEquals("Data set XYZZY not found", e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne("XYZZY", "SUBM1"))
+            .withMessage("Data set XYZZY not found");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -149,13 +149,9 @@ public class NoteCrudTest {
     @Test
     void testReadNotesGl120368Xyzzy() {
         log.info("Beginning testReadNotesGl120368N1932");
-        try {
-            final ApiNote resNote = crud.readOne(helper.getDb(), "Xyzzy");
-            fail("The note should not be found: " + resNote.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object Xyzzy of type note not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), "Xyzzy"))
+            .withMessage("Object Xyzzy of type note not found");
     }
 
     /** */
@@ -185,38 +181,27 @@ public class NoteCrudTest {
         final ApiNote resNote = crud.createOne(helper.getDb(), reqNote);
         final String id = resNote.getString();
         final ApiNote deletedNote = crud.deleteOne(helper.getDb(), id);
-        try {
-            final ApiNote foundNote = crud.readOne(helper.getDb(), deletedNote.getString());
-            fail("should not have found note " + foundNote.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + id + " of type note not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), deletedNote.getString()))
+            .withMessage("Object " + id + " of type note not found");
     }
 
     /** */
     @Test
     void testDeleteNoteNotFound() {
         log.info("Beginning testDeleteNoteNotFound");
-        try {
-            final ApiNote foundNote = crud.readOne(helper.getDb(), "XXXXXXX");
-            fail("should not have found note " + foundNote.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXXXX of type note not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), "XXXXXXX"))
+            .withMessage("Object XXXXXXX of type note not found");
     }
 
     /** */
     @Test
     void testDeleteNoteDatabaseNotFound() {
         log.info("Beginning testDeleteNoteDatabaseNotFound");
-        try {
-            final ApiNote foundNote = crud.readOne("XYZZY", "N1");
-            fail("should not have found note " + foundNote.getString());
-        } catch (DataSetNotFoundException e) {
-            assertEquals("Data set XYZZY not found", e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("XYZZY", "N1"))
+            .withMessage("Data set XYZZY not found");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
@@ -113,13 +113,9 @@ public class PersonCrudTest {
     @Test
     void testGetPersonsMiniSchoellerXyzzy() {
         log.info("Beginning testGetPersonsMiniSchoellerXyzzy");
-        try {
-            crud.readOne("mini-schoeller", "Xyzzy");
-            fail("should not have found person " + "Xyzzy in data set mini-schoeller");
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object Xyzzy of type person not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("mini-schoeller", "Xyzzy"))
+            .withMessage("Object Xyzzy of type person not found");
     }
 
     /** */
@@ -186,13 +182,9 @@ public class PersonCrudTest {
         crud.readOne(helper.getDb(), id);
         final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), id);
         then(deletedPerson.getString()).isEqualTo(id);
-        try {
-            crud.readOne(helper.getDb(), id);
-            fail("should not have found person " + id + " in data set " + helper.getDb());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + id + " of type person not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), id))
+            .withMessage("Object " + id + " of type person not found");
     }
 
     /** */
@@ -215,13 +207,9 @@ public class PersonCrudTest {
         then(readPerson.getString()).isEqualTo(id);
         ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), id);
         then(deletedPerson.getString()).isEqualTo(id);
-        try {
-            crud.readOne(helper.getDb(), id);
-            fail("should not have found person " + id + " in data set " + helper.getDb());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + id + " of type person not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), id))
+            .withMessage("Object " + id + " of type person not found");
         final ApiFamily readFamily = familyCrud.readOne(helper.getDb(), fam);
         then(readFamily.getSpouses().size()).isEqualTo(1);
         then(readFamily.getSpouses().get(0).getString()).isEqualTo(gotP2.getString());
@@ -245,13 +233,9 @@ public class PersonCrudTest {
         then(gotP2.getFamss().get(0).getString()).isEqualTo(fam);
         final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), childId);
         then(deletedPerson.getString()).isEqualTo(childId);
-        try {
-            crud.readOne(helper.getDb(), childId);
-            fail("should not have found person " + childId + " in data set " + helper.getDb());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + childId + " of type person not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), childId))
+            .withMessage("Object " + childId + " of type person not found");
         final ApiFamily readFamily = familyCrud.readOne(helper.getDb(), fam);
         then(readFamily.getChildren().size()).isEqualTo(0);
     }
@@ -260,13 +244,9 @@ public class PersonCrudTest {
     @Test
     void testDeletePersonNotFound() {
         log.info("Beginning testDeletePersonNotFound");
-        try {
-            crud.deleteOne(helper.getDb(), "XXXXXXX");
-            fail("should not have found person XXXXXXX in data set " + helper.getDb());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXXXX of type person not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne(helper.getDb(), "XXXXXXX"))
+            .withMessage("Object XXXXXXX of type person not found");
     }
 
     /** */
@@ -274,12 +254,9 @@ public class PersonCrudTest {
     void testDeletePersonDatabaseNotFound() {
         log.info("Beginning testDeletePersonDatabaseNotFound");
         log.info("Beginning testDeletePersonNotFound");
-        try {
-            crud.deleteOne("XYZZY", "XXXXXXX");
-            fail("should not have found data set " + "XYZZY while looking for person XXXXXXX");
-        } catch (DataSetNotFoundException e) {
-            assertEquals("Data set XYZZY not found", e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne("XYZZY", "XXXXXXX"))
+            .withMessage("Data set XYZZY not found");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
@@ -135,13 +135,9 @@ public class SourceCrudTest {
     @Test
     void testReadSourcesMiniSchoellerXyzzy() {
         log.info("Beginning testReadSourcesMiniSchoellerXyzzy");
-        try {
-            final ApiSource source = crud.readOne("mini-schoeller", "Xyzzy");
-            fail("The source should not be found: " + source.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object Xyzzy of type source not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("mini-schoeller", "Xyzzy"))
+            .withMessage("Object Xyzzy of type source not found");
     }
 
     /** */
@@ -172,39 +168,27 @@ public class SourceCrudTest {
         final String id = resSource.getString();
         final ApiSource deletedSource = crud.deleteOne(helper.getDb(), id);
 
-        try {
-            final ApiSource foundSource = crud.readOne("mini-schoeller", deletedSource.getString());
-            fail("The source should not be found: " + foundSource.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object " + deletedSource.getString() + " of type source not found",
-                e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("mini-schoeller", deletedSource.getString()))
+            .withMessage("Object " + deletedSource.getString() + " of type source not found");
     }
 
     /** */
     @Test
     void testDeleteSourceNotFound() {
         log.info("Beginning testDeleteSourceNotFound");
-        try {
-            final ApiSource deletedSource = crud.deleteOne(helper.getDb(), "XXXXXXX");
-            fail("The source should not be found: " + deletedSource.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXXXX of type source not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne(helper.getDb(), "XXXXXXX"))
+            .withMessage("Object XXXXXXX of type source not found");
     }
 
     /** */
     @Test
     void testDeleteSubmitterDatabaseNotFound() {
         log.info("Beginning testDeleteSubmitterDatabaseNotFound");
-        try {
-            final ApiSource deletedSource = crud.deleteOne("XYZZY", "S1");
-            fail("The dataset XYZZY should not be found," + " while looking for source "
-                + deletedSource.getString());
-        } catch (DataSetNotFoundException e) {
-            assertEquals("Data set XYZZY not found", e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne("XYZZY", "S1"))
+            .withMessage("Data set XYZZY not found");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -156,13 +156,9 @@ public final class SpouseCrudTest {
         final ApiPerson gotP1 = helper.getPerson(p1);
         then(gotP1.getFamss().size()).isEqualTo(1);
 
-        try {
-            crud.unlinkSpouseInFamily(helper.getDb(), fam, "XXXXX");
-            fail("Should have thrown");
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXX of type person not found", e.getMessage(),
-                "exception message mismatch");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.unlinkSpouseInFamily(helper.getDb(), fam, "XXXXX"))
+            .withMessage("Object XXXXX of type person not found");
     }
 
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -102,13 +102,9 @@ public class SubmissionCrudTest {
     @Test
     void testGetSubmissionsGl120368Xyzzy() {
         log.info("Beginning testGetSubmissionsGl120368Xyzzy");
-        try {
-            final ApiSubmission submission = crud.readOne(helper.getDb(), "Xyzzy");
-            fail("The submission should not be found: " + submission.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object Xyzzy of type submission not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.readOne(helper.getDb(), "Xyzzy"))
+            .withMessage("Object Xyzzy of type submission not found");
     }
 
     /** */
@@ -144,25 +140,18 @@ public class SubmissionCrudTest {
     @Test
     void testDeleteSubmissionNotFound() {
         log.info("Beginning testDeleteSubmissionNotFound");
-        try {
-            final ApiSubmission submission = crud.deleteOne(helper.getDb(), "XXXXXXX");
-            fail("The submission should not be found: " + submission.getString());
-        } catch (ObjectNotFoundException e) {
-            assertEquals("Object XXXXXXX of type submission not found", e.getMessage(),
-                "Mismatched message");
-        }
+        assertThatExceptionOfType(ObjectNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne(helper.getDb(), "XXXXXXX"))
+            .withMessage("Object XXXXXXX of type submission not found");
     }
 
     /** */
     @Test
     void testDeleteSubmissionDatabaseNotFound() {
         log.info("Beginning testDeleteSubmissionDatabaseNotFound");
-        try {
-            crud.deleteOne("XYZZY", "SUBM1");
-            fail("The dataset should not be found: XYZZY, when getting SUBM1");
-        } catch (DataSetNotFoundException e) {
-            assertEquals("Data set XYZZY not found", e.getMessage(), "Mismatched message");
-        }
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.deleteOne("XYZZY", "SUBM1"))
+            .withMessage("Data set XYZZY not found");
     }
 
     /** */

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderToBackupTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderToBackupTest.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.geoservice.model.builder.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.fail;
 
 import org.junit.jupiter.api.Test;
 import org.schoellerfamily.geoservice.model.GeoServiceItem;
@@ -166,12 +166,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry = new Geometry();
         gr.geometry.bounds = new Bounds();
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("should have thrown an illegal argument exception: " + bgci);
-        } catch (IllegalArgumentException e) {
-            // Expect to throw.
-        }
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */
@@ -184,13 +180,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         final double lng = 20.00;
         gr.geometry.bounds.northeast = new LatLng(lat, lng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("Should have thrown illegal argument exception: " + bgci);
-        } catch (IllegalArgumentException e) {
-            // Should have thrown
-        }
-
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */
@@ -203,12 +194,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         final double lng = 20.00;
         gr.geometry.bounds.southwest = new LatLng(lat, lng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("Should have thrown illegal argument exception: " + bgci);
-        } catch (IllegalArgumentException e) {
-            // Should have thrown
-        }
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */
@@ -246,12 +233,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry = new Geometry();
         gr.geometry.viewport = new Bounds();
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("should have thrown an illegal argument exception" + bgci);
-        } catch (IllegalArgumentException e) {
-            // Expect to throw.
-        }
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */
@@ -264,13 +247,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         final double lng = 20.00;
         gr.geometry.viewport.northeast = new LatLng(lat, lng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("should have thrown an illegal argument exception" + bgci);
-        } catch (IllegalArgumentException e) {
-            // Expect to throw.
-        }
-
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */
@@ -283,12 +261,8 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         final double lng = 25.00;
         gr.geometry.viewport.southwest = new LatLng(lat, lng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
-        try {
-            final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-            fail("should have thrown an illegal argument exception" + bgci);
-        } catch (IllegalArgumentException e) {
-            // Expect to throw.
-        }
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> builder.toGeoServiceItem(gci));
     }
 
     /** */


### PR DESCRIPTION
This pull request refactors exception assertion logic in test cases throughout the codebase by replacing manual try-catch blocks and `fail()` calls with AssertJ's fluent `assertThatExceptionOfType` assertions. Additionally, it introduces the AssertJ library as a test dependency where needed. These changes improve test readability and consistency.

Test assertion modernization:

* Replaced manual exception handling in various test classes (such as `IndexTest`, `BadLoadTest`, `GedDocumentMongoToGedObjectConverterTest`, `GedObjectToGedDocumentMongoConverterTest`, `GedDocumentFileLoaderTest`, `UsersWriterTest`, and `FamilyCrudTest`) with AssertJ's `assertThatExceptionOfType` for clearer and more concise exception assertions. [[1]](diffhunk://#diff-610af760e82615c107d63877f8aceb0712b8fddd11228511902c0a12ce02c41eL122-R123) [[2]](diffhunk://#diff-610af760e82615c107d63877f8aceb0712b8fddd11228511902c0a12ce02c41eL148-R145) [[3]](diffhunk://#diff-610af760e82615c107d63877f8aceb0712b8fddd11228511902c0a12ce02c41eL168-R161) [[4]](diffhunk://#diff-9d638531fe68eaae272fcb054d2fe4ea09c15eb352d9ecb79ddccf50238731abL57-R221) [[5]](diffhunk://#diff-b64d3ff41c5215e2dae2d18a01d8a9b1c3955d3d107fa9ac57ae3ad48d8c1655L322-R323) [[6]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L300-R309) [[7]](diffhunk://#diff-04b78bc78c1c744970d16e563cb71200ead4df698047b25d54df8ddb603396a5L148-R150) [[8]](diffhunk://#diff-d3eea6db6ec6ff14e9610241f6509069fe3195b1341998aa1620b6600a17778aL34-R36) [[9]](diffhunk://#diff-46cf9baed6e34fb3ece5780eb0643d5895e3d0c92ed1e30c4c56757aaf816e48L3-L11)

Dependency updates:

* Added the `assertj-core` dependency to the `gedbrowser-datamodel` and `gedbrowser-writer` Maven `pom.xml` files to support AssertJ assertions in tests. [[1]](diffhunk://#diff-96a2bf4438eb3e6f8c28cf707f05fc4d1b1bb70050ccb73a3340d3eb10eb1631R73-R76) [[2]](diffhunk://#diff-e30c69604edefbf3de25421488ebfbd353a873e630e76833fba435806df6d81eR87-R90)

Test import cleanup:

* Removed unused `fail` imports and added `assertThatExceptionOfType` imports in affected test files to match the new assertion style. [[1]](diffhunk://#diff-610af760e82615c107d63877f8aceb0712b8fddd11228511902c0a12ce02c41eL5-R5) [[2]](diffhunk://#diff-9d638531fe68eaae272fcb054d2fe4ea09c15eb352d9ecb79ddccf50238731abR3-L4) [[3]](diffhunk://#diff-b64d3ff41c5215e2dae2d18a01d8a9b1c3955d3d107fa9ac57ae3ad48d8c1655R3-L5) [[4]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21R3-L6) [[5]](diffhunk://#diff-04b78bc78c1c744970d16e563cb71200ead4df698047b25d54df8ddb603396a5R3-L5) [[6]](diffhunk://#diff-d3eea6db6ec6ff14e9610241f6509069fe3195b1341998aa1620b6600a17778aR3-L5) [[7]](diffhunk://#diff-46cf9baed6e34fb3ece5780eb0643d5895e3d0c92ed1e30c4c56757aaf816e48L3-L11)