### PR TITLE
Switch tests to AssertJ exception assertions

### DIFF
--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -327,11 +327,12 @@ public final class RepositoryFinderTest {
 
     @Test
     void testWithWrongGedObjectForRoot() {
-        final IllegalArgumentException e = assertThrows(IllegalArgumentException.class, () -> {
-            final GedObjectBuilder builder = new GedObjectBuilder();
-            finder.find(builder.createPerson(), "foo");
-        });
-        assertEquals("Owner must be root", e.getMessage(), "Message mismatch");
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> {
+                final GedObjectBuilder builder = new GedObjectBuilder();
+                finder.find(builder.createPerson(), "foo");
+            })
+            .withMessage("Owner must be root");
     }
 
     @Test
@@ -349,11 +350,12 @@ public final class RepositoryFinderTest {
 
     @Test
     void testFinderFindAllPersonsNotRoot() {
-        assertThrows(IllegalArgumentException.class, () -> {
-            final GedObjectBuilder builder = new GedObjectBuilder(root);
-            final Person person = builder.createPerson();
-            finder.find(person, Person.class);
-        });
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> {
+                final GedObjectBuilder builder = new GedObjectBuilder(root);
+                final Person person = builder.createPerson();
+                finder.find(person, Person.class);
+            });
     }
 
     @Test

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.util.Map;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -1,6 +1,5 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.io.IOException;
 import java.util.Map;
@@ -298,8 +298,8 @@ public final class RootRepositoryTest {
     /** */
     @Test
     void testFindByRoot() {
-        assertThrows(IllegalArgumentException.class,
-            () -> rootDocumentRepository.findByRootAndString(rootDocument, root.getString()));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> rootDocumentRepository.findByRootAndString(rootDocument, root.getString()));
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
@@ -1,8 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.assertj.core.api.BDDAssertions.then;
-import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -77,11 +76,8 @@ public class HeadCrudTest {
     @Test
     void testGetHeadBadDataSet() {
         log.info("beginning testGetHeadBadDataSet");
-        final DataSetNotFoundException e = assertThrows(
-                DataSetNotFoundException.class,
-                () -> crud.readOne("XYZZY")
-        );
-        assertEquals("Data set XYZZY not found", e.getMessage(),
-                "bad exception message");
+        assertThatExceptionOfType(DataSetNotFoundException.class)
+            .isThrownBy(() -> crud.readOne("XYZZY"))
+            .withMessage("Data set XYZZY not found");
     }
 }

--- a/geoservice-persistence/pom.xml
+++ b/geoservice-persistence/pom.xml
@@ -182,6 +182,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.springframework</groupId>
       <artifactId>spring-test</artifactId>
       <scope>test</scope>

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderTest.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.geoservice.model.builder.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 
 import java.util.Arrays;
 
@@ -203,8 +203,8 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
         final double lat = 10.00;
         final double lng = 20.00;
         final LngLatAlt northeast = new LngLatAlt(lng, lat);
-        assertThrows(IllegalArgumentException.class,
-            () -> GeoServiceBounds.createBounds("bounds", null, northeast));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> GeoServiceBounds.createBounds("bounds", null, northeast));
     }
 
     /** */
@@ -213,8 +213,8 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
         final double lat = 10.00;
         final double lng = 20.00;
         final LngLatAlt southwest = new LngLatAlt(lng, lat);
-        assertThrows(IllegalArgumentException.class,
-            () -> GeoServiceBounds.createBounds("bounds", southwest, null));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> GeoServiceBounds.createBounds("bounds", southwest, null));
     }
 
     /** */
@@ -267,8 +267,8 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
         final double lat = 10.00;
         final double lng = 20.00;
         final LngLatAlt northeast = new LngLatAlt(lng, lat);
-        assertThrows(IllegalArgumentException.class,
-            () -> GeoServiceBounds.createBounds("viewport", null, northeast));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> GeoServiceBounds.createBounds("viewport", null, northeast));
     }
 
     /** */
@@ -277,8 +277,8 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
         final double lat = 5.00;
         final double lng = 25.00;
         final LngLatAlt southwest = new LngLatAlt(lng, lat);
-        assertThrows(IllegalArgumentException.class,
-            () -> GeoServiceBounds.createBounds("viewport", southwest, null));
+        assertThatExceptionOfType(IllegalArgumentException.class)
+            .isThrownBy(() -> GeoServiceBounds.createBounds("viewport", southwest, null));
     }
 
     /** */


### PR DESCRIPTION
This pull request updates the way exception assertions are handled in test code across several modules. The main change is replacing `assertThrows` from JUnit with AssertJ's `assertThatExceptionOfType` for more expressive and readable exception assertions. Additionally, the AssertJ library is added as a test dependency where needed.

**Test assertion improvements:**

* Replaced usage of `assertThrows` with `assertThatExceptionOfType` from AssertJ in multiple test classes for clearer and more fluent exception assertions, including checks for exception messages. (`RepositoryFinderTest.java`, `RootRepositoryTest.java`, `HeadCrudTest.java`, `GeocodeResultBuilderTest.java`) [[1]](diffhunk://#diff-50039730037130c8cbe6617347323ba88ef11f7303bf57144d962fbe088c2a2aR3-L6) [[2]](diffhunk://#diff-50039730037130c8cbe6617347323ba88ef11f7303bf57144d962fbe088c2a2aL330-R335) [[3]](diffhunk://#diff-50039730037130c8cbe6617347323ba88ef11f7303bf57144d962fbe088c2a2aL352-R354) [[4]](diffhunk://#diff-ae25d8283091dba9a386ce46ded913da37130e82039afcfd9eba8b23853522d2R3-L5) [[5]](diffhunk://#diff-ae25d8283091dba9a386ce46ded913da37130e82039afcfd9eba8b23853522d2L301-R302) [[6]](diffhunk://#diff-fbb967e5394ce4921cba6db8f18f6dcbffee0f6c6f15c50f700ddc0790fb4972R3-L5) [[7]](diffhunk://#diff-fbb967e5394ce4921cba6db8f18f6dcbffee0f6c6f15c50f700ddc0790fb4972L80-R81) [[8]](diffhunk://#diff-ed3b05315bb84785b87a971dc7b656ff0defd01b76d4a5e93cf270cb3cd4cebaR3-L6) [[9]](diffhunk://#diff-ed3b05315bb84785b87a971dc7b656ff0defd01b76d4a5e93cf270cb3cd4cebaL206-R207) [[10]](diffhunk://#diff-ed3b05315bb84785b87a971dc7b656ff0defd01b76d4a5e93cf270cb3cd4cebaL216-R217) [[11]](diffhunk://#diff-ed3b05315bb84785b87a971dc7b656ff0defd01b76d4a5e93cf270cb3cd4cebaL270-R271) [[12]](diffhunk://#diff-ed3b05315bb84785b87a971dc7b656ff0defd01b76d4a5e93cf270cb3cd4cebaL280-R281)

**Dependency updates:**

* Added the AssertJ core library as a test dependency in `geoservice-persistence/pom.xml` to support the new assertion style.