### PR TITLE
Modernize test suite with AssertJ fluent assertions

### DIFF
--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
@@ -1,7 +1,6 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
@@ -2,7 +2,6 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
@@ -2,7 +2,6 @@ package org.schoellerfamily.gedbrowser.persistence.mongo.domain.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.Test;
@@ -69,7 +68,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 @SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects" })
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
-public class GedObjectToGedDocumentMongoConverterTest {
+class GedObjectToGedDocumentMongoConverterTest {
     /** */
     @Autowired
     private transient GedObjectToGedDocumentMongoConverter toDocConverter;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -299,7 +299,8 @@ public final class RootRepositoryTest {
     @Test
     void testFindByRoot() {
         assertThatExceptionOfType(IllegalArgumentException.class)
-            .isThrownBy(() -> rootDocumentRepository.findByRootAndString(rootDocument, root.getString()));
+            .isThrownBy(() -> rootDocumentRepository
+                .findByRootAndString(rootDocument, root.getString()));
     }
 
     /** */

--- a/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
+++ b/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
@@ -2,7 +2,6 @@ package org.schoellerfamily.gedbrowser.writer.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertNull;
 
 import org.junit.jupiter.api.Test;
 import org.schoellerfamily.gedbrowser.datamodel.users.User;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -5,8 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -22,13 +20,11 @@ import org.springframework.test.web.servlet.client.RestTestClient;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class HeadControllerTest implements MenuTestHelper {
+class HeadControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.
      */

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -52,8 +52,8 @@ public class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("<title>Header - gl120368</title>")
             .contains("File:</span> C:\\Users\\Phil\\Documents\\W0803.GED")
             .contains("GEDCOM:</span> 5.5, LINEAGE-LINKED")
@@ -76,8 +76,8 @@ public class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("<title>Header - mini-schoeller</title>")
             .contains("Submitter:</span> <a class=\"name\""
                     + " href=\"submitter?db=mini-schoeller&amp;"
@@ -98,7 +98,7 @@ public class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,20 +14,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class IndexControllerTest implements MenuTestHelper {
+class IndexControllerTest implements MenuTestHelper {
     /**
      * Template for building surname index URLs.
      */
@@ -86,7 +82,7 @@ public class IndexControllerTest implements MenuTestHelper {
     /** */
     @Test
     void testIndexControllerBadDataSet() {
-        String url = URL_TEMPLATE.formatted(port, "XYZZY", "A");
+        final String url = URL_TEMPLATE.formatted(port, "XYZZY", "A");
         final EntityExchangeResult<String> entity = restTestClient.get()
             .uri(URI.create(url))
             .exchange()
@@ -100,7 +96,7 @@ public class IndexControllerTest implements MenuTestHelper {
     /** */
     @Test
     void testIndexControllerLetter() {
-        String url = URL_TEMPLATE.formatted(port, "gl120368", "q");
+        final String url = URL_TEMPLATE.formatted(port, "gl120368", "q");
         final EntityExchangeResult<String> entity = restTestClient.get()
             .uri(URI.create(url))
             .exchange()

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -57,8 +57,8 @@ public class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Index - C - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Index - C - gl120368</title>")
             .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
                 + " class=\"name\">[?]</a>   </span>")
             .contains("<li id=\"I2508\"><a href=\"person?db=gl120368&amp;id=")
@@ -75,8 +75,8 @@ public class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Index - B - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Index - B - gl120368</title>")
             .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
                 + " class=\"name\">[?]</a>   </span>")
             .contains("<li id=\"I2561\"><a href=\"person?db=gl120368&amp;id=")
@@ -93,8 +93,8 @@ public class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -107,8 +107,8 @@ public class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Index - q - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Index - q - gl120368</title>")
             .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
                 + " class=\"name\">[?]</a>   </span>")
             .doesNotContain("<li><a href=\"person?db=gl120368&amp;id=")

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -25,7 +25,7 @@ import org.springframework.test.web.servlet.client.RestTestClient;
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
 @SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
-public class LivingControllerTest implements MenuTestHelper {
+class LivingControllerTest implements MenuTestHelper {
 
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -50,8 +50,8 @@ public class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Living - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Living - gl120368</title>")
             .contains(getMenu("A"));
     }
 
@@ -64,7 +64,7 @@ public class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import java.util.List;
@@ -54,8 +54,8 @@ public class LoginControllerTest {
         final ResponseEntity<String> entity =
                 restTemplate.getForEntity(url, String.class);
 
-        then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        then(entity.getBody()).contains("<title>Login to GedBrowser</title>")
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).contains("<title>Login to GedBrowser</title>")
             .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
                     + refererUrl + "\"/>");
     }
@@ -71,8 +71,8 @@ public class LoginControllerTest {
         final ResponseEntity<String> entity =
                 restTemplate.getForEntity(url, String.class);
 
-        then(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        then(entity.getBody()).contains("<title>Login to GedBrowser</title>")
+        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getBody()).contains("<title>Login to GedBrowser</title>")
             .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
                     + refererUrl + "\"/>");
     }
@@ -88,8 +88,8 @@ public class LoginControllerTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
             .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
                     + refererUrl + "\"/>");
     }
@@ -105,8 +105,8 @@ public class LoginControllerTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
             .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
                     + refererUrl + "\"/>");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -29,7 +29,7 @@ import org.springframework.web.client.RestTemplate;
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
 @SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
-public class LoginControllerTest {
+class LoginControllerTest {
 
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -51,8 +51,8 @@ public class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>_P_CCINFO 1-1319 - N1 - gl120368")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>_P_CCINFO 1-1319 - N1 - gl120368")
             .contains(getMenu("A"));
     }
 
@@ -65,8 +65,8 @@ public class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -78,7 +78,7 @@ public class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Note XYZZY not found").contains(getMenu("A"));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Note XYZZY not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,20 +14,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
-public class NoteControllerTest implements MenuTestHelper {
+class NoteControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.
      */
@@ -79,6 +75,7 @@ public class NoteControllerTest implements MenuTestHelper {
 
         final HttpStatusCode status = entity.getStatus();
         assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Note XYZZY not found").contains(getMenu("A"));
+        assertThat(entity.getResponseBody())
+            .contains("Note XYZZY not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -52,8 +52,8 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Living  - I4 - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Living  - I4 - gl120368</title>")
             .contains(getMenu("?#?"));
     }
 
@@ -67,8 +67,8 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
                 + "1951) - I9 - gl120368</title>")
             .contains(getMenu("W#Williams"));
@@ -83,8 +83,8 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -96,7 +96,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Person not found").contains(getMenu("A"));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Person not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,19 +14,16 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class PersonControllerTest implements MenuTestHelper {
 
     /**
@@ -60,7 +56,7 @@ public class PersonControllerTest implements MenuTestHelper {
     /** */
     @Test
     void testPersonControllerI9() {
-        String url = "http://localhost:" + port + "/gedbrowser/person?db=gl120368&id=I9";
+        final String url = "http://localhost:" + port + "/gedbrowser/person?db=gl120368&id=I9";
         final EntityExchangeResult<String> entity = restTestClient.get()
             .uri(URI.create(url))
             .exchange()

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -15,19 +14,16 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class PlaceIndexControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -51,8 +51,8 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Places - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Places - gl120368</title>")
             .contains(getMenu("A"));
     }
 
@@ -65,7 +65,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -67,8 +67,8 @@ public class SaveControllerTest {
                 .exchange()
                 .returnResult(String.class);
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("0 HEAD")
             .contains("1 SOUR FAMILY_HISTORIAN")
             .contains("2 VERS 3.1")
@@ -104,8 +104,8 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
 
         // Turn off anonymous admin.
         users.remove(user);
@@ -122,8 +122,8 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("Sorry, you aren't authorized to do that!");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -5,31 +5,27 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
-import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.schoellerfamily.gedbrowser.datamodel.users.UserImpl;
 import org.schoellerfamily.gedbrowser.datamodel.users.Users;
+import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTestClient;
-import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
-import org.springframework.test.web.servlet.client.EntityExchangeResult;
-import org.springframework.test.web.servlet.client.RestTestClient;
+import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.client.EntityExchangeResult;
+import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SaveControllerTest {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -51,8 +51,8 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>File (merged):"
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>File (merged):"
             + " C:\\Users\\Phil\\Downloads\\butcher\\butcher.GED" + " - S33750 - gl120368")
             .contains(getMenu("A"));
     }
@@ -66,8 +66,8 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -79,8 +79,8 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final String responseBody = entity.getResponseBody();
-        then(responseBody).contains("Source not found").contains(getMenu("A"));
+        assertThat(responseBody).contains("Source not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -52,8 +52,8 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Sources - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Sources - gl120368</title>")
             .contains("Sources for dataset: gl120368</h2>")
             .contains("href=\"source?db=gl120368&amp;id=S2050\" class=\"name\""
                     + " id=\"source-S2050\">Parish records (S2050)")
@@ -73,7 +73,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -51,8 +51,8 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>B1 - gl120368").contains(getMenu("A"));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>B1 - gl120368").contains(getMenu("A"));
     }
 
     /** */
@@ -65,8 +65,8 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -79,7 +79,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Submission not found").contains(getMenu("A"));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Submission not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -51,8 +51,8 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Phil Williams - U1 - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Phil Williams - U1 - gl120368</title>")
             .contains("Name:</span> Phil Williams")
             .contains(getMenu("A"));
     }
@@ -67,8 +67,8 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Arthur PUNCHARD - U2 - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Arthur PUNCHARD - U2 - gl120368</title>")
             .contains("Name:</span> Arthur PUNCHARD")
             .contains("Changed:</span> 24 MAR 2007")
             .contains(getMenu("A"));
@@ -84,8 +84,8 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody())
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody())
             .contains("<title>Created by FamilySearch (TM) Internet"
                 + " Genealogy Service - U4 - gl120368</title>")
             .contains("Name:</span> Created by FamilySearch")
@@ -103,8 +103,8 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 
     /** */
@@ -117,7 +117,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Submitter not found").contains(getMenu("A"));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Submitter not found").contains(getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 
@@ -52,8 +52,8 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("<title>Submitters - gl120368</title>")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("<title>Submitters - gl120368</title>")
             .contains("Submitters for dataset: gl120368</h2>")
             .contains("href=\"submitter?db=gl120368&amp;id=U1\">Phil Williams")
             .contains("href=\"submitter?db=gl120368&amp;id=U3\"> ")
@@ -82,7 +82,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/test/ApplicationTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/test/ApplicationTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -56,7 +56,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(String.class);
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
     }
 
     /** */
@@ -68,7 +68,7 @@ public class ApplicationTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
     }
 
     /** */
@@ -80,8 +80,8 @@ public class ApplicationTest {
                 .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("Reloaded");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("Reloaded");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ChildrenControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ChildrenControllerTest.java
@@ -7,7 +7,6 @@ import java.net.URI;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiFamily;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiPerson;
@@ -21,7 +20,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -31,14 +29,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @Slf4j
 @AutoConfigureRestTestClient
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
-public class ChildrenControllerTest {
+class ChildrenControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */
@@ -58,7 +54,7 @@ public class ChildrenControllerTest {
      * Set up some base objects.
      */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         helper = new ControllerTestHelper(port, restTestClient);
     }
 
@@ -84,7 +80,7 @@ public class ChildrenControllerTest {
         final ApiPerson parent = helper.createPerson();
 
         final ApiPerson child = createChildOfParent(parent);
-        String famID = child.getFamcs().get(0).getString();
+        final String famID = child.getFamcs().get(0).getString();
         log.info("famc: {}", famID);
 
         final ApiPerson secondChild = helper.createPerson();
@@ -167,8 +163,8 @@ public class ChildrenControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        final ApiPerson child = childEntity.getResponseBody();
-        return child;
+        assertThat(childEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        return childEntity.getResponseBody();
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ChildrenControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ChildrenControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -125,10 +125,10 @@ public class ChildrenControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson gotChild = childEntity.getResponseBody();
-        then(gotChild.getString()).isEqualTo(child.getString());
-        then(gotChild.getFamcs().size()).isEqualTo(1);
+        assertThat(gotChild.getString()).isEqualTo(child.getString());
+        assertThat(gotChild.getFamcs().size()).isEqualTo(1);
         final ApiPerson gotParent = helper.getPerson(parent);
-        then(gotParent.getFamss().size()).isEqualTo(1);
+        assertThat(gotParent.getFamss().size()).isEqualTo(1);
         assertEquals(gotParent.getFamss().get(0).getString(),
             gotChild.getFamcs().get(0).getString(), "check ids");
     }
@@ -167,7 +167,7 @@ public class ChildrenControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
         return child;
     }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
@@ -46,15 +46,12 @@ class FamilyControllerTest {
     private int port;
 
     /** */
-    private ControllerTestHelper helper;
-
-    /** */
     private HttpHeaders headers;
 
     /** */
     @BeforeEach
     void setUp() {
-        helper = new ControllerTestHelper(port, restTestClient);
+        final ControllerTestHelper helper = new ControllerTestHelper(port, restTestClient);
         headers = helper.getHeaders();
     }
 
@@ -89,8 +86,11 @@ class FamilyControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
-            "\"string\" : \"Marriage\"", "\"type\" : \"date\"", "\"string\" : \"27 MAY 1984\"",
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"",
+            "\"string\" : \"F1\"",
+            "\"string\" : \"Marriage\"",
+            "\"type\" : \"date\"",
+            "\"string\" : \"27 MAY 1984\"",
             "\"string\" : \"Temple Emanu-el, Providence, Providence County, Rhode Island, USA\"",
             "\"tail\" : \"The ceremony performed by Rabbi Wayne"
                 + " Franklin and Cantor Ivan\\nPerlman.  The best man and"
@@ -112,7 +112,8 @@ class FamilyControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1593\"",
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"",
+            "\"string\" : \"F1593\"",
             "\"attributes\" : [ {", "\"type\" : \"sourcelink\"", "\"string\" : \"S33723\"",
             "\"type\" : \"attribute\"", "\"string\" : \"Note\"", "\"attributes\" : [ ]",
             "\"tail\" : \"Record originated in...\"");
@@ -130,8 +131,10 @@ class FamilyControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
-            "\"string\" : \"Marriage\"", "\"string\" : \"27 MAY 1984\"",
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"",
+            "\"string\" : \"F1\"",
+            "\"string\" : \"Marriage\"",
+            "\"string\" : \"27 MAY 1984\"",
             "\"string\" : \"Temple Emanu-el, Providence, Providence County, Rhode Island, USA\"",
             "\"tail\" : \"The ceremony performed by Rabbi Wayne"
                 + " Franklin and Cantor Ivan\\nPerlman.  The best man and"
@@ -152,7 +155,8 @@ class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     @Test
@@ -185,8 +189,7 @@ class FamilyControllerTest {
             .exchange()
             .returnResult(ApiFamily.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        final ApiFamily resBody = entity.getResponseBody();
-        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getResponseBody().getType()).isEqualTo(reqBody.getType());
     }
 
     /** */
@@ -203,7 +206,8 @@ class FamilyControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiFamily.class);
-        assertThat(familyEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(familyEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new family.
         final ApiFamily resBody = familyEntity.getResponseBody();
         final String id = resBody.getString();
@@ -214,13 +218,15 @@ class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiFamily.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiFamily> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
@@ -288,18 +294,19 @@ class FamilyControllerTest {
             .body(req.getBody())
             .exchange()
             .returnResult(ApiFamily.class);
-        final ApiFamily familyPostResponse = entity.getResponseBody();
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(familyPostResponse.getType()).isEqualTo(familyRequest.getType());
-        assertThat(familyPostResponse.getAttributes().size()).isEqualTo(1);
-        assertThat(familyPostResponse.getChildren().size()).isEqualTo(1);
+        assertThat(entity.getResponseBody().getType()).isEqualTo(familyRequest.getType());
+        assertThat(entity.getResponseBody().getAttributes().size()).isEqualTo(1);
+        assertThat(entity.getResponseBody().getChildren().size()).isEqualTo(1);
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")
             .string("Note")
             .tail("this is a note")
             .build();
-        final ApiFamily familyPutRequest = familyPostResponse.toBuilder().attribute(aNote).build();
+        final ApiFamily familyPutRequest = entity.getResponseBody().toBuilder()
+            .attribute(aNote)
+            .build();
         assertThat(familyPutRequest.getAttributes().size()).isEqualTo(2);
         final EntityExchangeResult<ApiFamily> putResponseEntity = restTestClient.put()
             .uri(URI.create(url + "/" + familyPutRequest.getString()))
@@ -310,7 +317,8 @@ class FamilyControllerTest {
         final ApiFamily familyPutResponse = putResponseEntity.getResponseBody();
         final List<ApiAttribute> attributesPutResponse = familyPutResponse.getAttributes();
         log.info("Attribute list size: {}", attributesPutResponse.size());
-        assertThat(attributesPutResponse.size()).isEqualTo(2);
+        assertThat(attributesPutResponse.size())
+            .isEqualTo(2);
         for (final ApiAttribute a : attributesPutResponse) {
             log.info("attribute: {} {} {}", a.getType(), a.getString(), a.getTail());
         }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -72,8 +72,8 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
             "\"attributes\" : [ ]", "\"images\" : [ ]");
     }
 
@@ -88,8 +88,8 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
             "\"string\" : \"Marriage\"", "\"type\" : \"date\"", "\"string\" : \"27 MAY 1984\"",
             "\"string\" : \"Temple Emanu-el, Providence, Providence County, Rhode Island, USA\"",
             "\"tail\" : \"The ceremony performed by Rabbi Wayne"
@@ -111,8 +111,8 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1593\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1593\"",
             "\"attributes\" : [ {", "\"type\" : \"sourcelink\"", "\"string\" : \"S33723\"",
             "\"type\" : \"attribute\"", "\"string\" : \"Note\"", "\"attributes\" : [ ]",
             "\"tail\" : \"Record originated in...\"");
@@ -129,8 +129,8 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
             "\"string\" : \"Marriage\"", "\"string\" : \"27 MAY 1984\"",
             "\"string\" : \"Temple Emanu-el, Providence, Providence County, Rhode Island, USA\"",
             "\"tail\" : \"The ceremony performed by Rabbi Wayne"
@@ -152,7 +152,7 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -169,8 +169,8 @@ public class FamilyControllerTest {
             .exchange()
             .returnResult(ApiFamily.class);
         final ApiFamily resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
     /**
@@ -190,9 +190,9 @@ public class FamilyControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiFamily.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiFamily resBody = entity.getResponseBody();
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
     /** */
@@ -209,7 +209,7 @@ public class FamilyControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiFamily.class);
-        then(familyEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(familyEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new family.
         final ApiFamily resBody = familyEntity.getResponseBody();
         final String id = resBody.getString();
@@ -220,19 +220,19 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiFamily.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiFamily> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiFamily.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -246,14 +246,14 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiFamily.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -266,14 +266,14 @@ public class FamilyControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiFamily.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -295,10 +295,10 @@ public class FamilyControllerTest {
             .exchange()
             .returnResult(ApiFamily.class);
         final ApiFamily familyPostResponse = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(familyPostResponse.getType()).isEqualTo(familyRequest.getType());
-        then(familyPostResponse.getAttributes().size()).isEqualTo(1);
-        then(familyPostResponse.getChildren().size()).isEqualTo(1);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(familyPostResponse.getType()).isEqualTo(familyRequest.getType());
+        assertThat(familyPostResponse.getAttributes().size()).isEqualTo(1);
+        assertThat(familyPostResponse.getChildren().size()).isEqualTo(1);
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")
@@ -306,7 +306,7 @@ public class FamilyControllerTest {
             .tail("this is a note")
             .build();
         final ApiFamily familyPutRequest = familyPostResponse.toBuilder().attribute(aNote).build();
-        then(familyPutRequest.getAttributes().size()).isEqualTo(2);
+        assertThat(familyPutRequest.getAttributes().size()).isEqualTo(2);
         final EntityExchangeResult<ApiFamily> putResponseEntity = restTestClient.put()
             .uri(URI.create(url + "/" + familyPutRequest.getString()))
             .headers(h -> h.addAll(headers))
@@ -316,7 +316,7 @@ public class FamilyControllerTest {
         final ApiFamily familyPutResponse = putResponseEntity.getResponseBody();
         final List<ApiAttribute> attributesPutResponse = familyPutResponse.getAttributes();
         log.info("Attribute list size: {}", attributesPutResponse.size());
-        then(attributesPutResponse.size()).isEqualTo(2);
+        assertThat(attributesPutResponse.size()).isEqualTo(2);
         for (final ApiAttribute a : attributesPutResponse) {
             log.info("attribute: {} {} {}", a.getType(), a.getString(), a.getTail());
         }
@@ -337,10 +337,10 @@ public class FamilyControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /** */
@@ -357,10 +357,10 @@ public class FamilyControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /** */
@@ -377,10 +377,10 @@ public class FamilyControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /** */
@@ -397,10 +397,10 @@ public class FamilyControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/FamilyControllerTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiFamily;
@@ -24,7 +23,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
@@ -33,14 +31,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @Slf4j
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
-public class FamilyControllerTest {
+class FamilyControllerTest {
     /** */
     @Autowired
     private RestTestClient restTestClient;
@@ -73,8 +69,12 @@ public class FamilyControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"family\"", "\"string\" : \"F1\"",
-            "\"attributes\" : [ ]", "\"images\" : [ ]");
+        assertThat(entity.getResponseBody())
+            .contains(
+                "\"type\" : \"family\"",
+                "\"string\" : \"F1\"",
+                "\"attributes\" : [ ]",
+                "\"images\" : [ ]");
     }
 
     /** */
@@ -155,9 +155,6 @@ public class FamilyControllerTest {
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
-    /**
-     * @throws RestClientException if we can't talk to rest server
-     */
     @Test
     void testCreateFamiliesSimple() {
         final String url = "http://localhost:" + port + "/gedbrowserng/v1/dbs/gl120368/families";
@@ -173,9 +170,6 @@ public class FamilyControllerTest {
         assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
-    /**
-     * @throws RestClientException if we can't talk to rest server
-     */
     @Test
     void testCreateFamiliesWithMarriage() {
         final String url = "http://localhost:" + port + "/gedbrowserng/v1/dbs/gl120368/families";

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
@@ -3,7 +3,6 @@ package org.schoellerfamily.gedbrowser.api.controller.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,20 +12,17 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @AutoConfigureRestTestClient
-public class HeadControllerTest {
+class HeadControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */
@@ -50,7 +46,9 @@ public class HeadControllerTest {
 
         final HttpStatusCode status = entity.getStatus();
         assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
+        assertThat(entity.getResponseBody())
+            .contains("\"type\" : \"head\"",
+            "\"string\" : \"Header\"",
             "3C8079D5-1C5A-4473-8939-6631E48D01BB");
     }
 
@@ -64,8 +62,10 @@ public class HeadControllerTest {
             .returnResult(String.class);
 
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
-            "\"tail\" : \"TMG\"");
+        assertThat(entity.getResponseBody())
+            .contains("\"type\" : \"head\"",
+                "\"string\" : \"Header\"",
+                "\"tail\" : \"TMG\"");
     }
 
     /** */
@@ -77,8 +77,12 @@ public class HeadControllerTest {
             .returnResult(String.class);
 
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("  \"cause\" : null", "  \"stackTrace\" : [ ]",
-            "  \"datasetName\" : \"XYZZY\"", "  \"message\" : \"Data set XYZZY not found\"",
-            "  \"suppressed\" : [ ]", "  \"localizedMessage\" : \"Data set XYZZY not found\"");
+        assertThat(entity.getResponseBody())
+            .contains("  \"cause\" : null",
+                "  \"stackTrace\" : [ ]",
+                "  \"datasetName\" : \"XYZZY\"",
+                "  \"message\" : \"Data set XYZZY not found\"",
+                "  \"suppressed\" : [ ]",
+                "  \"localizedMessage\" : \"Data set XYZZY not found\"");
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,8 +49,8 @@ public class HeadControllerTest {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
             "3C8079D5-1C5A-4473-8939-6631E48D01BB");
     }
 
@@ -63,8 +63,8 @@ public class HeadControllerTest {
             .exchange()
             .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"head\"", "\"string\" : \"Header\"",
             "\"tail\" : \"TMG\"");
     }
 
@@ -76,8 +76,8 @@ public class HeadControllerTest {
             .exchange()
             .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("  \"cause\" : null", "  \"stackTrace\" : [ ]",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("  \"cause\" : null", "  \"stackTrace\" : [ ]",
             "  \"datasetName\" : \"XYZZY\"", "  \"message\" : \"Data set XYZZY not found\"",
             "  \"suppressed\" : [ ]", "  \"localizedMessage\" : \"Data set XYZZY not found\"");
     }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/HeadControllerTest.java
@@ -76,7 +76,8 @@ class HeadControllerTest {
             .exchange()
             .returnResult(String.class);
 
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         assertThat(entity.getResponseBody())
             .contains("  \"cause\" : null",
                 "  \"stackTrace\" : [ ]",

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -61,8 +61,8 @@ public class NoteControllerTest {
             + "  \"string\" : \"N2\",\n" + "  \"attributes\" : [ ],\n"
             + "  \"tail\" : \"_P_CCINFO 1-1319\"\n" + "}, {\n";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -82,8 +82,8 @@ public class NoteControllerTest {
             + " Thurston alias Amass of Debenham Butcher was\\n"
             + "baptised by George Smalley vicar on 23/3/1828.\"\n" + "}";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -105,8 +105,8 @@ public class NoteControllerTest {
             + "    } ],\n" + "    \"tail\" : \"\"\n" + "  } ],\n"
             + "  \"tail\" : \"_P_CCINFO 1-1319\"\n" + "}";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -152,8 +152,8 @@ public class NoteControllerTest {
             + " April 1926), and has issue (see GREAT BRITAIN - Almanach"
             + " de Gotha 1998; 1999; 2000).\"\n" + "}";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -166,7 +166,7 @@ public class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -185,8 +185,8 @@ public class NoteControllerTest {
             .exchange()
             .returnResult(ApiNote.class);
         final ApiNote resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getTail()).isEqualTo(reqBody.getTail());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getTail()).isEqualTo(reqBody.getTail());
     }
 
     /**
@@ -212,7 +212,7 @@ public class NoteControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiNote.class);
-        then(noteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(noteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiNote resBody = noteEntity.getResponseBody();
         final String id = resBody.getString();
 
@@ -222,18 +222,18 @@ public class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiNote.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiNote> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiNote.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -252,13 +252,13 @@ public class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiNote.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -276,13 +276,13 @@ public class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiNote.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -310,8 +310,8 @@ public class NoteControllerTest {
             .exchange()
             .returnResult(ApiNote.class);
         final ApiNote resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
@@ -222,12 +222,14 @@ class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiNote.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiNote> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/NoteControllerTest.java
@@ -31,9 +31,8 @@ import org.springframework.web.client.RestClientException;
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
-public class NoteControllerTest {
+class NoteControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */
@@ -166,7 +165,8 @@ public class NoteControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
@@ -84,7 +84,8 @@ class ParentsControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         return childEntity.getResponseBody();
     }
 

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -88,7 +88,7 @@ public class ParentsControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         return childEntity.getResponseBody();
     }
 
@@ -100,10 +100,10 @@ public class ParentsControllerTest {
         final ApiPerson parent = helper.createPerson();
         final ApiPerson child = helper.createPerson();
         final ApiPerson gotParent = linkParentOfChild(parent, child);
-        then(gotParent.getString()).isEqualTo(parent.getString());
-        then(gotParent.getFamss().size()).isEqualTo(1);
+        assertThat(gotParent.getString()).isEqualTo(parent.getString());
+        assertThat(gotParent.getFamss().size()).isEqualTo(1);
         final ApiPerson gotChild = helper.getPerson(child);
-        then(gotParent.getFamss().size()).isEqualTo(1);
+        assertThat(gotParent.getFamss().size()).isEqualTo(1);
         assertEquals(gotParent.getFamss().get(0).getString(),
             gotChild.getFamcs().get(0).getString(), "check ids");
     }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/ParentsControllerTest.java
@@ -7,7 +7,6 @@ import java.net.URI;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiPerson;
 import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
@@ -18,7 +17,6 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -28,14 +26,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 @AutoConfigureRestTestClient
-public class ParentsControllerTest {
+class ParentsControllerTest {
 
     /**
      * RestTestClient injected by Spring's test support.
@@ -120,7 +116,6 @@ public class ParentsControllerTest {
             .body(parent)
             .exchange()
             .returnResult(ApiPerson.class);
-        final ApiPerson gotParent = parentEntity.getResponseBody();
-        return gotParent;
+        return parentEntity.getResponseBody();
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
@@ -8,7 +8,6 @@ import java.util.Optional;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiAttribute;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiPerson;
@@ -23,7 +22,6 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 import org.springframework.web.client.RestClientException;
@@ -33,14 +31,12 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @Slf4j
 @AutoConfigureRestTestClient
-public final class PersonControllerTest {
+class PersonControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */
@@ -565,7 +561,7 @@ public final class PersonControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         assertEquals(aNote,
-            java.util.Optional.ofNullable(putResponseEntity.getResponseBody())
+            Optional.ofNullable(putResponseEntity.getResponseBody())
                 .map(b -> b.getAttributes().get(2))
                 .orElse(null),
             "attribute should be present");

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -76,8 +76,8 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I1\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I1\"",
             "\"attributes\" : [ {", "\"type\" : \"name\"", "\"string\" : \"Living /Williams/\"",
             "\"attributes\" : [ ]", "\"tail\" : \"\"");
     }
@@ -93,8 +93,8 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I6\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I6\"",
             "\"attributes\" : [ {", "\"type\" : \"name\"",
             "\"string\" : \"Reginald Amass /Williams/\"", "\"attributes\" : [ ]",
             "\"tail\" : \"\"");
@@ -112,8 +112,8 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(Optional.ofNullable(entity.getResponseBody()).orElse("")).contains(
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(Optional.ofNullable(entity.getResponseBody()).orElse("")).contains(
             "\"type\" : \"person\"", "\"string\" : \"I1\"", "\"attributes\" : [ {",
             "\"type\" : \"name\"", "\"string\" : \"Melissa Robinson/Schoeller/\"",
             "\"attributes\" : [ {");
@@ -129,8 +129,8 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I7\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I7\"",
             "\"attributes\" : [ {", "\"type\" : \"name\"", "\"string\" : \"Arnold/Robinson/\"",
             "\"attributes\" : [ ]", "\"tail\" : \"\"");
     }
@@ -147,8 +147,8 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I2\"",
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I2\"",
             "\"attributes\" : [ {", "\"type\" : \"name\"",
             "\"string\" : \"Richard John/Schoeller/\"", "\"attributes\" : [ ]", "\"tail\" : \"\"");
     }
@@ -163,7 +163,7 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -179,11 +179,11 @@ public final class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson resBody = entity.getResponseBody();
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -200,10 +200,10 @@ public final class PersonControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -268,7 +268,7 @@ public final class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -279,19 +279,19 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -312,7 +312,7 @@ public final class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -323,13 +323,13 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(helper.userLogin(port, restTestClient)))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.FORBIDDEN.value()));
     }
 
@@ -351,7 +351,7 @@ public final class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -365,7 +365,7 @@ public final class PersonControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
 
         final String fam = child.getFamcs().get(0).getString();
@@ -384,9 +384,9 @@ public final class PersonControllerTest {
             .body(personReq.getBody())
             .exchange()
             .returnResult(ApiPerson.class);
-        then(pe.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(pe.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson gotP2 = pe.getResponseBody();
-        then(fam).isEqualTo(gotP2.getFamss().get(0).getString());
+        assertThat(fam).isEqualTo(gotP2.getFamss().get(0).getString());
 
         final String deleteUrl = url + "/" + id;
         final EntityExchangeResult<ApiPerson> preDeleteEntity = restTestClient.get()
@@ -395,20 +395,20 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -430,7 +430,7 @@ public final class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
 
@@ -442,7 +442,7 @@ public final class PersonControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
 
         final String fam = child.getFamcs().get(0).getString();
@@ -461,9 +461,9 @@ public final class PersonControllerTest {
             .body(personReq.getBody())
             .exchange()
             .returnResult(ApiPerson.class);
-        then(pe.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(pe.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson gotP2 = pe.getResponseBody();
-        then(fam).isEqualTo(gotP2.getFamss().get(0).getString());
+        assertThat(fam).isEqualTo(gotP2.getFamss().get(0).getString());
 
         final String deleteUrl = url + "/" + childId;
         final EntityExchangeResult<ApiPerson> preDeleteEntity = restTestClient.get()
@@ -471,19 +471,19 @@ public final class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> entityAfterDelete = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        then(entityAfterDelete.getStatus())
+        assertThat(entityAfterDelete.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -500,14 +500,14 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -523,14 +523,14 @@ public final class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -548,8 +548,8 @@ public final class PersonControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")
@@ -590,10 +590,10 @@ public final class PersonControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -615,10 +615,10 @@ public final class PersonControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -640,10 +640,10 @@ public final class PersonControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -665,10 +665,10 @@ public final class PersonControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 
     /**
@@ -690,9 +690,9 @@ public final class PersonControllerTest {
             .returnResult(ApiPerson.class);
 
         final ApiPerson resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
-        then(resBody.getSurname()).isEqualTo(reqBody.getSurname());
-        then(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(resBody.getSurname()).isEqualTo(reqBody.getSurname());
+        assertThat(resBody.getIndexName()).isEqualTo(reqBody.getIndexName());
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/PersonControllerTest.java
@@ -73,8 +73,10 @@ class PersonControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I1\"",
-            "\"attributes\" : [ {", "\"type\" : \"name\"", "\"string\" : \"Living /Williams/\"",
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"",
+            "\"string\" : \"I1\"",
+            "\"attributes\" : [ {", "\"type\" : \"name\"",
+            "\"string\" : \"Living /Williams/\"",
             "\"attributes\" : [ ]", "\"tail\" : \"\"");
     }
 
@@ -90,9 +92,11 @@ class PersonControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I6\"",
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"",
+            "\"string\" : \"I6\"",
             "\"attributes\" : [ {", "\"type\" : \"name\"",
-            "\"string\" : \"Reginald Amass /Williams/\"", "\"attributes\" : [ ]",
+            "\"string\" : \"Reginald Amass /Williams/\"",
+            "\"attributes\" : [ ]",
             "\"tail\" : \"\"");
     }
 
@@ -110,8 +114,11 @@ class PersonControllerTest {
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         assertThat(Optional.ofNullable(entity.getResponseBody()).orElse("")).contains(
-            "\"type\" : \"person\"", "\"string\" : \"I1\"", "\"attributes\" : [ {",
-            "\"type\" : \"name\"", "\"string\" : \"Melissa Robinson/Schoeller/\"",
+            "\"type\" : \"person\"",
+            "\"string\" : \"I1\"",
+            "\"attributes\" : [ {",
+            "\"type\" : \"name\"",
+            "\"string\" : \"Melissa Robinson/Schoeller/\"",
             "\"attributes\" : [ {");
     }
 
@@ -126,9 +133,13 @@ class PersonControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I7\"",
-            "\"attributes\" : [ {", "\"type\" : \"name\"", "\"string\" : \"Arnold/Robinson/\"",
-            "\"attributes\" : [ ]", "\"tail\" : \"\"");
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"",
+            "\"string\" : \"I7\"",
+            "\"attributes\" : [ {",
+            "\"type\" : \"name\"",
+            "\"string\" : \"Arnold/Robinson/\"",
+            "\"attributes\" : [ ]",
+            "\"tail\" : \"\"");
     }
 
     /**
@@ -144,9 +155,13 @@ class PersonControllerTest {
             .exchange()
             .returnResult(String.class);
         assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"", "\"string\" : \"I2\"",
-            "\"attributes\" : [ {", "\"type\" : \"name\"",
-            "\"string\" : \"Richard John/Schoeller/\"", "\"attributes\" : [ ]", "\"tail\" : \"\"");
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"person\"",
+            "\"string\" : \"I2\"",
+            "\"attributes\" : [ {",
+            "\"type\" : \"name\"",
+            "\"string\" : \"Richard John/Schoeller/\"",
+            "\"attributes\" : [ ]",
+            "\"tail\" : \"\"");
     }
 
     /** */
@@ -159,7 +174,8 @@ class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -264,7 +280,8 @@ class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -275,13 +292,15 @@ class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
@@ -308,7 +327,8 @@ class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -319,7 +339,8 @@ class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(helper.userLogin(port, restTestClient)))
@@ -347,7 +368,8 @@ class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
         final String id = resBody.getString();
@@ -361,7 +383,8 @@ class PersonControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
 
         final String fam = child.getFamcs().get(0).getString();
@@ -391,13 +414,15 @@ class PersonControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
@@ -426,7 +451,8 @@ class PersonControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(personEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(personEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new person.
         final ApiPerson resBody = personEntity.getResponseBody();
 
@@ -438,7 +464,8 @@ class PersonControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
 
         final String fam = child.getFamcs().get(0).getString();
@@ -467,13 +494,15 @@ class PersonControllerTest {
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiPerson> entityAfterDelete = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .headers(h -> h.addAll(headers))

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SaveControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SaveControllerTest.java
@@ -3,7 +3,6 @@ package org.schoellerfamily.gedbrowser.api.controller.test;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,18 +12,15 @@ import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @AutoConfigureRestTestClient
 public class SaveControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SaveControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SaveControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,8 +49,8 @@ public class SaveControllerTest {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("0 HEAD")
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("0 HEAD")
             .contains("1 SOUR FAMILY_HISTORIAN")
             .contains("2 VERS 3.1")
             .contains("2 NAME Family Historian")
@@ -73,7 +73,7 @@ public class SaveControllerTest {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        then(entity.getResponseBody()).contains("Data set xyzzy not found");
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getResponseBody()).contains("Data set xyzzy not found");
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
@@ -32,7 +32,7 @@ import org.springframework.web.client.RestClientException;
 @TestPropertySource(properties = { "management.port=0" })
 @SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
-public class SourceControllerTest {
+class SourceControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
@@ -139,7 +139,8 @@ class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -189,7 +190,8 @@ class SourceControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiSource.class);
-        assertThat(sourceEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(sourceEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new source.
         final ApiSource resBody = sourceEntity.getResponseBody();
         final String id = resBody.getString();
@@ -200,12 +202,14 @@ class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSource.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiSource> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)
@@ -264,9 +268,6 @@ class SourceControllerTest {
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
-    /**
-     * @throws RestClientException if we can't talk to rest server
-     */
     @Test
     void testUpdateSourceWithNote() throws RestClientException {
         final String url = "http://localhost:" + port + "/gedbrowserng/v1/dbs/gl120368/sources";

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SourceControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -73,8 +73,8 @@ public class SourceControllerTest {
             + "      } ],\n" + "      \"tail\" : \"\"\n" + "    } ],\n" + "    \"tail\" : \"\"\n"
             + "  } ],\n" + "  \"images\" : [ ],\n" + "  \"title\" : \"1841 England Census\"\n"
             + "}, {";
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -99,8 +99,8 @@ public class SourceControllerTest {
             + "    \"tail\" : \"We have the original of this document\"\n" + "  } ],\n"
             + "  \"images\" : [ ],\n" + "  \"title\" : \"Schoeller, Melissa Robinson,"
             + " birth certificate\"\n" + "}, {";
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -125,8 +125,8 @@ public class SourceControllerTest {
             + "    \"tail\" : \"We have the original of this document\"\n" + "  } ],\n"
             + "  \"images\" : [ ],\n" + "  \"title\" : \"Schoeller, Melissa Robinson, birth"
             + " certificate\"\n" + "}";
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).isEqualTo(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).isEqualTo(bodyFragment);
     }
 
     /** */
@@ -139,7 +139,7 @@ public class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(String.class);
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -162,8 +162,8 @@ public class SourceControllerTest {
             .exchange()
             .returnResult(ApiSource.class);
         final ApiSource resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
     /**
@@ -189,7 +189,7 @@ public class SourceControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiSource.class);
-        then(sourceEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(sourceEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new source.
         final ApiSource resBody = sourceEntity.getResponseBody();
         final String id = resBody.getString();
@@ -200,18 +200,18 @@ public class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSource.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiSource> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSource.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -230,13 +230,13 @@ public class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSource.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -254,13 +254,13 @@ public class SourceControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSource.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -287,8 +287,8 @@ public class SourceControllerTest {
             .exchange()
             .returnResult(ApiSource.class);
         final ApiSource resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -71,10 +71,10 @@ public class SpousesControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson gotP1 = parentEntity.getResponseBody();
-        then(gotP1.getString()).isEqualTo(p1.getString());
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1.getString()).isEqualTo(p1.getString());
+        assertThat(gotP1.getFamss().size()).isEqualTo(1);
         final ApiPerson gotP2 = helper.getPerson(p2);
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2.getFamss().size()).isEqualTo(1);
         assertEquals(gotP1.getFamss().get(0).getString(), gotP2.getFamss().get(0).getString(),
             "check ids");
     }
@@ -96,10 +96,10 @@ public class SpousesControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson gotP2 = personEntity.getResponseBody();
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2.getString()).isEqualTo(p2.getString());
+        assertThat(gotP2.getFamss().size()).isEqualTo(1);
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1.getFamss().size()).isEqualTo(1);
         assertEquals(gotP1.getFamss().get(0).getString(), gotP2.getFamss().get(0).getString(),
             "check ids");
     }
@@ -121,17 +121,17 @@ public class SpousesControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         final ApiPerson gotP2 = personEntity.getResponseBody();
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2.getString()).isEqualTo(p2.getString());
+        assertThat(gotP2.getFamss().size()).isEqualTo(1);
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1.getFamss().size()).isEqualTo(1);
 
         restTestClient.delete()
             .uri(URI.create(helper.getFamiliesUrl() + "/" + fam + "/spouses/" + gotP1.getString()))
             .exchange();
         final ApiPerson gotP1again = helper.getPerson(gotP1);
         final ApiPerson gotP2again = helper.getPerson(gotP2);
-        then(gotP1again.getFamss().size()).isEqualTo(0);
+        assertThat(gotP1again.getFamss().size()).isEqualTo(0);
         assertEquals(gotP2again.getFamss().get(0).getString(), fam, "check ids");
     }
 
@@ -150,7 +150,7 @@ public class SpousesControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        then(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final ApiPerson child = childEntity.getResponseBody();
         return child;
     }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
@@ -149,7 +149,8 @@ class SpousesControllerTest {
             .body(childReqBody)
             .exchange()
             .returnResult(ApiPerson.class);
-        assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(childEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         return childEntity.getResponseBody();
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SpousesControllerTest.java
@@ -32,8 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @TestPropertySource(properties = { "management.port=0" })
 @Slf4j
 @AutoConfigureRestTestClient
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
-public class SpousesControllerTest {
+class SpousesControllerTest {
     /**
      * RestTestClient injected by Spring's test support.
      */
@@ -151,7 +150,6 @@ public class SpousesControllerTest {
             .exchange()
             .returnResult(ApiPerson.class);
         assertThat(childEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        final ApiPerson child = childEntity.getResponseBody();
-        return child;
+        return childEntity.getResponseBody();
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
@@ -111,7 +111,8 @@ public class SubmissionControllerTest {
             .exchange()
             .returnResult(String.class);
 
-        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -136,9 +137,6 @@ public class SubmissionControllerTest {
         assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
-    /**
-     * @throws RestClientException if we can't talk to rest server
-     */
     @Test
     void testDeleteSubmission() throws RestClientException {
         final HttpHeaders headers = new HttpHeaders();
@@ -155,7 +153,8 @@ public class SubmissionControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiSubmission.class);
-        assertThat(submissionEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(submissionEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new submission.
         final ApiSubmission resBody = submissionEntity.getResponseBody();
         final String id = resBody.getString();
@@ -166,12 +165,14 @@ public class SubmissionControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmission.class);
-        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus())
+            .isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiSubmission> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -61,8 +61,8 @@ public class SubmissionControllerTest {
             + "    \"string\" : \"Generations of descendants\",\n" + "    \"attributes\" : [ ],\n"
             + "    \"tail\" : \"2\"\n" + "  } ]\n" + "}";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -77,8 +77,8 @@ public class SubmissionControllerTest {
             .returnResult(String.class);
         final String bodyFragment = "[ ]";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).startsWith(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).startsWith(bodyFragment);
     }
 
     /** */
@@ -97,8 +97,8 @@ public class SubmissionControllerTest {
             + "    \"string\" : \"Generations of descendants\",\n" + "    \"attributes\" : [ ],\n"
             + "    \"tail\" : \"2\"\n" + "  } ]\n" + "}";
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).isEqualTo(bodyFragment);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).isEqualTo(bodyFragment);
     }
 
     /** */
@@ -112,7 +112,7 @@ public class SubmissionControllerTest {
             .exchange()
             .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -133,8 +133,8 @@ public class SubmissionControllerTest {
         final ApiSubmission resBody = entity.getResponseBody();
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
     /**
@@ -156,7 +156,7 @@ public class SubmissionControllerTest {
             .body(reqBody)
             .exchange()
             .returnResult(ApiSubmission.class);
-        then(submissionEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(submissionEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new submission.
         final ApiSubmission resBody = submissionEntity.getResponseBody();
         final String id = resBody.getString();
@@ -167,18 +167,18 @@ public class SubmissionControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmission.class);
-        then(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(preDeleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(deleteEntity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiSubmission> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmission.class);
-        then(postDeleteEntity.getStatus())
+        assertThat(postDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -197,13 +197,13 @@ public class SubmissionControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmission.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -222,13 +222,13 @@ public class SubmissionControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmission.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -258,8 +258,8 @@ public class SubmissionControllerTest {
             .exchange()
             .returnResult(ApiSubmission.class);
         final ApiSubmission resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmissionControllerTest.java
@@ -31,7 +31,6 @@ import org.springframework.web.client.RestClientException;
     classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class SubmissionControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
@@ -31,7 +31,6 @@ import org.springframework.web.client.RestClientException;
     classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class SubmitterControllerTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
@@ -56,8 +56,10 @@ public class SubmitterControllerTest {
             .returnResult(String.class);
         final HttpStatusCode status = entity.getStatus();
         assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("\"type\" : \"submitter\"", "\"string\" : \"U1\"",
-            "\"string\" : \"Phil Williams\"", "\"name\" : \"Phil Williams\"");
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"submitter\"",
+            "\"string\" : \"U1\"",
+            "\"string\" : \"Phil Williams\"",
+            "\"name\" : \"Phil Williams\"");
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/SubmitterControllerTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.controller.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
@@ -56,8 +56,8 @@ public class SubmitterControllerTest {
             .exchange()
             .returnResult(String.class);
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).contains("\"type\" : \"submitter\"", "\"string\" : \"U1\"",
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).contains("\"type\" : \"submitter\"", "\"string\" : \"U1\"",
             "\"string\" : \"Phil Williams\"", "\"name\" : \"Phil Williams\"");
     }
 
@@ -77,8 +77,8 @@ public class SubmitterControllerTest {
             + "    \"tail\" : \"\"\n" + "  } ],\n" + "  \"name\" : \"Phil Williams\"\n" + "}";
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(entity.getResponseBody()).isEqualTo(bodyFragment);
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(entity.getResponseBody()).isEqualTo(bodyFragment);
     }
 
     /** */
@@ -93,7 +93,7 @@ public class SubmitterControllerTest {
             .returnResult(String.class);
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -114,8 +114,8 @@ public class SubmitterControllerTest {
         final ApiSubmitter resBody = entity.getResponseBody();
 
         final HttpStatusCode status = entity.getStatus();
-        then(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
     }
 
     /**
@@ -139,7 +139,7 @@ public class SubmitterControllerTest {
             .returnResult(ApiSubmitter.class);
 
         final HttpStatusCode status1 = submitterEntity.getStatus();
-        then(status1).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(status1).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         // Capture information about new submitter.
         final ApiSubmitter resBody = submitterEntity.getResponseBody();
         final String id = resBody.getString();
@@ -152,21 +152,21 @@ public class SubmitterControllerTest {
             .returnResult(ApiSubmitter.class);
 
         final HttpStatusCode status2 = preDeleteEntity.getStatus();
-        then(status2).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(status2).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(deleteUrl))
             .exchange()
             .returnResult(String.class);
 
         final HttpStatusCode status3 = deleteEntity.getStatus();
-        then(status3).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(status3).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
         final EntityExchangeResult<ApiSubmitter> postDeleteEntity = restTestClient.get()
             .uri(URI.create(deleteUrl))
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmitter.class);
         final HttpStatusCode status4 = postDeleteEntity.getStatus();
-        then(status4).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
+        assertThat(status4).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
     /**
@@ -184,13 +184,13 @@ public class SubmitterControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmitter.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -209,13 +209,13 @@ public class SubmitterControllerTest {
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .returnResult(ApiSubmitter.class);
-        then(preDeleteEntity.getStatus())
+        assertThat(preDeleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
         final EntityExchangeResult<String> deleteEntity = restTestClient.delete()
             .uri(URI.create(url))
             .exchange()
             .returnResult(String.class);
-        then(deleteEntity.getStatus())
+        assertThat(deleteEntity.getStatus())
             .isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
     }
 
@@ -241,8 +241,8 @@ public class SubmitterControllerTest {
             .exchange()
             .returnResult(ApiSubmitter.class);
         final ApiSubmitter resBody = entity.getResponseBody();
-        then(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        then(resBody.getType()).isEqualTo(reqBody.getType());
+        assertThat(entity.getStatus()).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
+        assertThat(resBody.getType()).isEqualTo(reqBody.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadControllerTest.java
@@ -42,20 +42,20 @@ public class UploadControllerTest {
     private MockMvc mockMvc;
 
     /** */
-    private StorageService service = mock(FileSystemStorageService.class);
+    private final StorageService service = mock(FileSystemStorageService.class);
 
     /** */
-    private GedObjectFileLoader loader = mock(GedObjectFileLoader.class);
+    private final GedObjectFileLoader loader = mock(GedObjectFileLoader.class);
 
     /** */
-    private GedObjectToGedDocumentMongoConverter toDocConverter = mock(
+    private final GedObjectToGedDocumentMongoConverter toDocConverter = mock(
         GedObjectToGedDocumentMongoConverter.class);
 
     /** */
-    private RepositoryManagerMongo repositoryManager = mock(RepositoryManagerMongo.class);
+    private final RepositoryManagerMongo repositoryManager = mock(RepositoryManagerMongo.class);
 
     /** */
-    private UploadController controller = spy(
+    private final UploadController controller = spy(
         new UploadController(loader, toDocConverter, repositoryManager, service));
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadControllerTest.java
@@ -60,7 +60,7 @@ public class UploadControllerTest {
 
     /** */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         mockMvc = MockMvcBuilders.standaloneSetup(controller).build();
         is = controller.getClass().getClassLoader().getResourceAsStream("mini-schoeller.ged");
     }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadServiceTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/UploadServiceTest.java
@@ -27,7 +27,6 @@ import org.springframework.util.MultiValueMap;
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @AutoConfigureRestTestClient
 public class UploadServiceTest {
     /**

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
@@ -76,7 +76,7 @@ class ChildCrudTest {
         log.info("Beginning testLinkChildInFamily");
         final ApiPerson parent = helper.createPerson();
         final ApiPerson child = createChildOfParent(parent);
-        String famID = child.getFamcs().get(0).getString();
+        final String famID = child.getFamcs().get(0).getString();
         log.info("famc: {}", famID);
 
         final ApiPerson secondChild = helper.createPerson();
@@ -94,17 +94,15 @@ class ChildCrudTest {
         final ApiPerson child = helper.createPerson();
         final ApiPerson gotChild = crud.linkChild(helper.getDb(),
                 parent.getString(), child);
-        
+
         assertThat(gotChild)
             .returns(child.getString(), c -> c.getString())
             .returns(1, c -> c.getFamcs().size());
-        
+
         final ApiPerson gotParent = helper.getPerson(parent);
         assertThat(gotParent)
-            .returns(1, p -> p.getFamss().size());
-        
-        assertEquals(gotParent.getFamss().get(0).getString(),
-                gotChild.getFamcs().get(0).getString(), "check ids");
+            .returns(1, p -> p.getFamss().size())
+            .returns(gotChild.getFamcs().get(0).getString(), p -> p.getFamss().get(0).getString());
     }
 
     /** */
@@ -151,7 +149,7 @@ class ChildCrudTest {
         final ApiPerson reqPerson = helper.createAlexander();
         final ApiPerson resPerson =
                 crud.createChildInFamily(helper.getDb(), "F4", reqPerson);
-        
+
         assertThat(resPerson)
             .returns(reqPerson.getType(), p -> p.getType())
             .returns(reqPerson.getSurname(), p -> p.getSurname())
@@ -166,7 +164,7 @@ class ChildCrudTest {
         final ApiPerson reqChild = helper.createAlexander();
         final ApiPerson resChild = crud.createChild("mini-schoeller", "I9",
                 reqChild);
-        
+
         assertThat(resChild)
             .returns(reqChild.getType(), c -> c.getType())
             .returns(reqChild.getSurname(), c -> c.getSurname())
@@ -180,7 +178,7 @@ class ChildCrudTest {
         final ApiPerson reqChild = helper.createAlexandra();
         final ApiPerson resChild = crud.createChild("mini-schoeller", "I10",
                 reqChild);
-        
+
         assertThat(resChild)
             .returns(reqChild.getType(), c -> c.getType())
             .returns(reqChild.getSurname(), c -> c.getSurname())

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.crud.ChildCrud;
 import org.schoellerfamily.gedbrowser.api.crud.FamilyCrud;
@@ -19,20 +18,18 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
-public class ChildCrudTest {
+class ChildCrudTest {
 
     /** */
     @Autowired
@@ -54,7 +51,7 @@ public class ChildCrudTest {
 
     /** */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         helper = new CrudTestHelper(
                 new PersonCrud(loader, toDocConverter, repositoryManager),
                 new FamilyCrud(loader, toDocConverter, repositoryManager));

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ChildCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -97,10 +97,15 @@ public class ChildCrudTest {
         final ApiPerson child = helper.createPerson();
         final ApiPerson gotChild = crud.linkChild(helper.getDb(),
                 parent.getString(), child);
-        then(gotChild.getString()).isEqualTo(child.getString());
-        then(gotChild.getFamcs().size()).isEqualTo(1);
+        
+        assertThat(gotChild)
+            .returns(child.getString(), c -> c.getString())
+            .returns(1, c -> c.getFamcs().size());
+        
         final ApiPerson gotParent = helper.getPerson(parent);
-        then(gotParent.getFamss().size()).isEqualTo(1);
+        assertThat(gotParent)
+            .returns(1, p -> p.getFamss().size());
+        
         assertEquals(gotParent.getFamss().get(0).getString(),
                 gotChild.getFamcs().get(0).getString(), "check ids");
     }
@@ -135,10 +140,11 @@ public class ChildCrudTest {
         final ApiPerson resPerson =
                 crud.createChildInFamily(helper.getDb(), "F1", reqPerson);
 
-        then(resPerson.getType()).isEqualTo(reqPerson.getType());
-        then(resPerson.getSurname()).isEqualTo(reqPerson.getSurname());
-        then(resPerson.getIndexName()).isEqualTo(reqPerson.getIndexName());
-        then(resPerson.getFamcs().get(0).getString()).isEqualTo("F1");
+        assertThat(resPerson)
+            .returns(reqPerson.getType(), p -> p.getType())
+            .returns(reqPerson.getSurname(), p -> p.getSurname())
+            .returns(reqPerson.getIndexName(), p -> p.getIndexName())
+            .returns("F1", p -> p.getFamcs().get(0).getString());
     }
 
     /** */
@@ -148,10 +154,12 @@ public class ChildCrudTest {
         final ApiPerson reqPerson = helper.createAlexander();
         final ApiPerson resPerson =
                 crud.createChildInFamily(helper.getDb(), "F4", reqPerson);
-        then(resPerson.getType()).isEqualTo(reqPerson.getType());
-        then(resPerson.getSurname()).isEqualTo(reqPerson.getSurname());
-        then(resPerson.getIndexName()).isEqualTo(reqPerson.getIndexName());
-        then(resPerson.getFamcs().get(0).getString()).isEqualTo("F4");
+        
+        assertThat(resPerson)
+            .returns(reqPerson.getType(), p -> p.getType())
+            .returns(reqPerson.getSurname(), p -> p.getSurname())
+            .returns(reqPerson.getIndexName(), p -> p.getIndexName())
+            .returns("F4", p -> p.getFamcs().get(0).getString());
     }
 
     /** */
@@ -161,9 +169,11 @@ public class ChildCrudTest {
         final ApiPerson reqChild = helper.createAlexander();
         final ApiPerson resChild = crud.createChild("mini-schoeller", "I9",
                 reqChild);
-        then(resChild.getType()).isEqualTo(reqChild.getType());
-        then(resChild.getSurname()).isEqualTo(reqChild.getSurname());
-        then(resChild.getIndexName()).isEqualTo(reqChild.getIndexName());
+        
+        assertThat(resChild)
+            .returns(reqChild.getType(), c -> c.getType())
+            .returns(reqChild.getSurname(), c -> c.getSurname())
+            .returns(reqChild.getIndexName(), c -> c.getIndexName());
     }
 
     /** */
@@ -173,8 +183,10 @@ public class ChildCrudTest {
         final ApiPerson reqChild = helper.createAlexandra();
         final ApiPerson resChild = crud.createChild("mini-schoeller", "I10",
                 reqChild);
-        then(resChild.getType()).isEqualTo(reqChild.getType());
-        then(resChild.getSurname()).isEqualTo(reqChild.getSurname());
-        then(resChild.getIndexName()).isEqualTo(reqChild.getIndexName());
+        
+        assertThat(resChild)
+            .returns(reqChild.getType(), c -> c.getType())
+            .returns(reqChild.getSurname(), c -> c.getSurname())
+            .returns(reqChild.getIndexName(), c -> c.getIndexName());
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
@@ -165,7 +165,7 @@ class FamilyCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testDeleteFamily() {
         log.info("Beginning testDeleteFamily");
         final ApiFamily inFamily = ApiFamily.builder().type("family").string("").build();
@@ -200,7 +200,7 @@ class FamilyCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testUpdateFamilyWithNote() {
         log.info("Beginning testUpdateFamilyWithNote");
         final List<ApiAttribute> attributes = List

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -61,9 +61,11 @@ class FamilyCrudTest {
         log.info("Beginning testGetFamiliesGl120368");
         final List<ApiFamily> list = crud.readAll("gl120368");
         final ApiFamily firstFamily = list.get(0);
-        then(firstFamily.getString()).isEqualTo("F1");
-        then(firstFamily.getAttributes()).isEmpty();
-        then(firstFamily.getImages()).isEmpty();
+
+        assertThat(firstFamily)
+            .returns("F1", f -> f.getString())
+            .returns(true, f -> f.getAttributes().isEmpty())
+            .returns(true, f -> f.getImages().isEmpty());
     }
 
     /** */
@@ -72,11 +74,12 @@ class FamilyCrudTest {
         log.info("Beginning testGetFamiliesMiniSchoeller");
         final List<ApiFamily> list = crud.readAll("mini-schoeller");
         final ApiFamily firstFamily = list.get(0);
-        then(firstFamily.getString()).isEqualTo("F1");
-        final ApiAttribute firstAttribute = firstFamily.getAttributes().get(0);
-        then(firstAttribute.getString()).isEqualTo("Marriage");
-        then(firstAttribute.getAttributes().get(0).getType()).isEqualTo("date");
-        then(firstAttribute.getAttributes().get(0).getString()).isEqualTo("27 MAY 1984");
+
+        assertThat(firstFamily)
+            .returns("F1", f -> f.getString())
+            .returns("Marriage", f -> f.getAttributes().get(0).getString())
+            .returns("date", f -> f.getAttributes().get(0).getAttributes().get(0).getType())
+            .returns("27 MAY 1984", f -> f.getAttributes().get(0).getAttributes().get(0).getString());
     }
 
     /** */
@@ -84,10 +87,11 @@ class FamilyCrudTest {
     void testGetFamiliesGl120368F1593() {
         log.info("Beginning testGetFamiliesGl120368F1593");
         final ApiFamily family = crud.readOne("gl120368", "F1593");
-        then(family.getString()).isEqualTo("F1593");
-        final ApiAttribute firstAttribute = family.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("sourcelink");
-        then(firstAttribute.getString()).isEqualTo("S33723");
+
+        assertThat(family)
+            .returns("F1593", f -> f.getString())
+            .returns("sourcelink", f -> f.getAttributes().get(0).getType())
+            .returns("S33723", f -> f.getAttributes().get(0).getString());
     }
 
     /** */
@@ -95,18 +99,24 @@ class FamilyCrudTest {
     void testGetFamiliesMiniSchoellerF1() {
         log.info("Beginning testGetFamiliesMiniSchoellerF1");
         final ApiFamily family = crud.readOne("mini-schoeller", "F1");
-        then(family.getString()).isEqualTo("F1");
-        final ApiAttribute firstAttribute = family.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("attribute");
-        then(firstAttribute.getString()).isEqualTo("Marriage");
-        then(firstAttribute.getAttributes().get(0).getType()).isEqualTo("date");
-        then(firstAttribute.getAttributes().get(0).getString()).isEqualTo("27 MAY 1984");
-        then(firstAttribute.getAttributes().get(1).getType()).isEqualTo("place");
-        then(firstAttribute.getAttributes().get(1).getString()).startsWith("Temple Emanu-el");
-        then(firstAttribute.getAttributes().get(2).getType()).isEqualTo("attribute");
-        then(firstAttribute.getAttributes().get(2).getString()).isEqualTo("Note");
-        then(firstAttribute.getAttributes().get(2).getTail()).contains("Wayne Franklin",
-            "Dale Matcovitch", "Carol Robinson Sacerdote");
+
+        assertThat(family)
+            .returns("F1", f -> f.getString())
+            .returns("attribute", f -> f.getAttributes().get(0).getType())
+            .returns("Marriage", f -> f.getAttributes().get(0).getString())
+            .returns("date", f -> f.getAttributes().get(0).getAttributes().get(0).getType())
+            .returns("27 MAY 1984", f -> f.getAttributes().get(0).getAttributes().get(0).getString())
+            .returns("place", f -> f.getAttributes().get(0).getAttributes().get(1).getType())
+            .returns(true, f -> f.getAttributes().get(0).getAttributes().get(1).getString()
+                .startsWith("Temple Emanu-el"))
+            .returns("attribute", f -> f.getAttributes().get(0).getAttributes().get(2).getType())
+            .returns("Note", f -> f.getAttributes().get(0).getAttributes().get(2).getString())
+            .returns(true, f -> f.getAttributes().get(0).getAttributes().get(2).getTail()
+                .contains("Wayne Franklin"))
+            .returns(true, f -> f.getAttributes().get(0).getAttributes().get(2).getTail()
+                .contains("Dale Matcovitch"))
+            .returns(true, f -> f.getAttributes().get(0).getAttributes().get(2).getTail()
+                .contains("Carol Robinson Sacerdote"));
     }
 
     /** */
@@ -124,9 +134,11 @@ class FamilyCrudTest {
         log.info("Beginning testCreateFamiliesSimple");
         final ApiFamily inFamily = ApiFamily.builder().type("family").string("").build();
         final ApiFamily outFamily = crud.createOne("gl120368", inFamily);
-        then(outFamily.getType()).isEqualTo("family");
-        then(outFamily.getAttributes()).isEmpty();
-        then(outFamily.getString()).startsWith("F");
+
+        assertThat(outFamily)
+            .returns("family", f -> f.getType())
+            .returns(true, f -> f.getAttributes().isEmpty())
+            .returns(true, f -> f.getString().startsWith("F"));
     }
 
     /** */
@@ -136,13 +148,18 @@ class FamilyCrudTest {
         final ApiFamily inFamily = ApiFamily.builder()
             .type("family")
             .string("")
-            .attributes(List
-                .of(ApiAttribute.builder().type("attribute").string("Marriage").tail("").build()))
+            .attributes(List.of(ApiAttribute.builder()
+                .type("attribute")
+                .string("Marriage")
+                .tail("")
+                .build()))
             .build();
         final ApiFamily outFamily = crud.createOne("gl120368", inFamily);
-        then(outFamily.getType()).isEqualTo("family");
-        then(outFamily.getString()).startsWith("F");
-        then(outFamily.getAttributes().get(0).getString()).isEqualTo("Marriage");
+
+        assertThat(outFamily)
+            .returns("family", f -> f.getType())
+            .returns(true, f -> f.getString().startsWith("F"))
+            .returns("Marriage", f -> f.getAttributes().get(0).getString());
     }
 
     /** */
@@ -153,7 +170,9 @@ class FamilyCrudTest {
         final ApiFamily outFamily = crud.createOne("gl120368", inFamily);
         final String id = outFamily.getString();
         final ApiFamily deletedFamily = crud.deleteOne("gl120368", id);
-        then(deletedFamily.getString()).isEqualTo(id);
+
+        assertThat(deletedFamily)
+            .returns(id, f -> f.getString());
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.readOne("gl120368", id))
             .withMessage("Object " + id + " of type family not found");
@@ -187,26 +206,32 @@ class FamilyCrudTest {
             .type("family")
             .string("")
             .attributes(attributes)
-            .children(List.of(ApiAttribute.builder().type("child").string("I1").build()))
+            .children(List.of(ApiAttribute.builder()
+                .type("child")
+                .string("I1")
+                .build()))
             .build();
         final ApiFamily familyPostResponse = crud.createOne("gl120368", inFamily);
-        then(familyPostResponse.getType()).isEqualTo(inFamily.getType());
-        then(familyPostResponse.getAttributes().size()).isEqualTo(1);
-        then(familyPostResponse.getChildren().size()).isEqualTo(1);
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")
             .string("Note")
             .tail("this is a note")
             .build();
         final ApiFamily forPut = familyPostResponse.toBuilder().attribute(aNote).build();
-        then(forPut.getAttributes().size()).isEqualTo(2);
         final ApiFamily familyPutResponse = crud.updateOne("gl120368", forPut.getString(), forPut);
         final List<ApiAttribute> attributesPutResponse = familyPutResponse.getAttributes();
         log.info("Attribute list size: {}", attributesPutResponse.size());
-        then(attributesPutResponse.size()).isEqualTo(2);
         for (final ApiAttribute a : attributesPutResponse) {
             log.info("attribute: {} {} {}", a.getType(), a.getString(), a.getTail());
         }
+
+        assertThat(familyPostResponse)
+            .returns(inFamily.getType(), f -> f.getType())
+            .returns(1, f -> f.getAttributes().size())
+            .returns(1, f -> f.getChildren().size());
+        assertThat(forPut)
+            .returns(2, f -> f.getAttributes().size());
+        assertThat(attributesPutResponse).hasSize(2);
         assertEquals(aNote, attributesPutResponse.get(1), "attribute should be present");
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/FamilyCrudTest.java
@@ -30,7 +30,6 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 class FamilyCrudTest {
 
@@ -79,7 +78,8 @@ class FamilyCrudTest {
             .returns("F1", f -> f.getString())
             .returns("Marriage", f -> f.getAttributes().get(0).getString())
             .returns("date", f -> f.getAttributes().get(0).getAttributes().get(0).getType())
-            .returns("27 MAY 1984", f -> f.getAttributes().get(0).getAttributes().get(0).getString());
+            .returns("27 MAY 1984",
+                f -> f.getAttributes().get(0).getAttributes().get(0).getString());
     }
 
     /** */
@@ -105,7 +105,8 @@ class FamilyCrudTest {
             .returns("attribute", f -> f.getAttributes().get(0).getType())
             .returns("Marriage", f -> f.getAttributes().get(0).getString())
             .returns("date", f -> f.getAttributes().get(0).getAttributes().get(0).getType())
-            .returns("27 MAY 1984", f -> f.getAttributes().get(0).getAttributes().get(0).getString())
+            .returns("27 MAY 1984",
+                f -> f.getAttributes().get(0).getAttributes().get(0).getString())
             .returns("place", f -> f.getAttributes().get(0).getAttributes().get(1).getType())
             .returns(true, f -> f.getAttributes().get(0).getAttributes().get(1).getString()
                 .startsWith("Temple Emanu-el"))
@@ -164,6 +165,7 @@ class FamilyCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testDeleteFamily() {
         log.info("Beginning testDeleteFamily");
         final ApiFamily inFamily = ApiFamily.builder().type("family").string("").build();
@@ -198,6 +200,7 @@ class FamilyCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testUpdateFamilyWithNote() {
         log.info("Beginning testUpdateFamilyWithNote");
         final List<ApiAttribute> attributes = List

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -59,8 +59,9 @@ public class HeadCrudTest {
     void testGetHeadGl120368() {
         log.info("beginning testGetHeadGl120368");
         final ApiHead head = crud.readOne("gl120368");
-        then(head.getType()).isEqualTo("head");
-        then(head.getString()).isEqualTo("Header");
+        assertThat(head)
+            .returns("head", o -> o.getType())
+            .returns("Header", o -> o.getString());
     }
 
     /** */
@@ -68,8 +69,9 @@ public class HeadCrudTest {
     void testGetHeadMiniSchoeller() {
         log.info("beginning testGetHeadMiniSchoeller");
         final ApiHead head = crud.readOne("mini-schoeller");
-        then(head.getType()).isEqualTo("head");
-        then(head.getString()).isEqualTo("Header");
+        assertThat(head)
+            .returns("head", o -> o.getType())
+            .returns("Header", o -> o.getString());
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/HeadCrudTest.java
@@ -5,30 +5,26 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
-import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.crud.HeadCrud;
 import org.schoellerfamily.gedbrowser.api.datamodel.ApiHead;
 import org.schoellerfamily.gedbrowser.api.loader.GedObjectFileLoader;
+import org.schoellerfamily.gedbrowser.api.test.TestConfiguration;
 import org.schoellerfamily.gedbrowser.persistence.mongo.gedconvert.GedObjectToGedDocumentMongoConverter;
 import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryManagerMongo;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 public class HeadCrudTest {
 

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
@@ -167,7 +167,7 @@ public class NoteCrudTest {
             .type("note")
             .string("")
             .tail("testing")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiNote resNote = crud.createOne(helper.getDb(), reqNote);
         assertThat(resNote).returns(reqNote.getTail(), o -> o.getTail());
@@ -181,7 +181,7 @@ public class NoteCrudTest {
             .type("note")
             .string("")
             .tail("this is a note")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiNote resNote = crud.createOne(helper.getDb(), reqNote);
         final String id = resNote.getString();
@@ -236,7 +236,7 @@ public class NoteCrudTest {
             .type("attribute")
             .string("Note")
             .tail("this is a note")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build(), updatedNote.getAttributes().get(1), "attribute should be present");
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -24,18 +23,15 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 public class NoteCrudTest {
 

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/NoteCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -70,10 +70,12 @@ public class NoteCrudTest {
     void testReadNotesGl120368() {
         log.info("Beginning testReadNotesGl120368");
         final List<ApiNote> list = crud.readAll(helper.getDb());
-        then(list.get(0).getString()).isEqualTo("N1");
-        then(list.get(0).getTail()).isEqualTo("_P_CCINFO 1-1319");
-        then(list.get(1).getString()).isEqualTo("N2");
-        then(list.get(1).getTail()).isEqualTo("_P_CCINFO 1-1319");
+        assertThat(list.get(0))
+            .returns("N1", o -> o.getString())
+            .returns("_P_CCINFO 1-1319", o -> o.getTail());
+        assertThat(list.get(1))
+            .returns("N2", o -> o.getString())
+            .returns("_P_CCINFO 1-1319", o -> o.getTail());
     }
 
     /** */
@@ -81,14 +83,14 @@ public class NoteCrudTest {
     void testReadNotesGl120368N13() {
         log.info("Beginning testReadNotesGl120368N13");
         final ApiNote resNote = crud.readOne(helper.getDb(), "N13");
-        then(resNote.getString()).isEqualTo("N13");
+        assertThat(resNote).returns("N13", o -> o.getString());
         final String expected = "_P_CCINFO 1-1319\n"
             + "Suffolk County Record Office, Parish Register, St Mary"
             + " Magdalene, Debenham, Suffolk, England, Baptisms 1813-\n"
             + "1864 (FB47/D1/10), Samuel son of William Amass & Marianne"
             + " Thurston alias Amass of Debenham Butcher was\n"
             + "baptised by George Smalley vicar on 23/3/1828.";
-        then(resNote.getTail()).isEqualTo(expected);
+        assertThat(resNote).returns(expected, o -> o.getTail());
     }
 
     /** */
@@ -96,13 +98,16 @@ public class NoteCrudTest {
     void testReadNotesGl120368N66() {
         log.info("Beginning testReadNotesGl120368N66");
         final ApiNote resNote = crud.readOne(helper.getDb(), "N66");
-        then(resNote.getString()).isEqualTo("N66");
-        then(resNote.getTail()).isEqualTo("_P_CCINFO 1-1319");
+        assertThat(resNote)
+            .returns("N66", o -> o.getString())
+            .returns("_P_CCINFO 1-1319", o -> o.getTail());
         final ApiAttribute changed = resNote.getAttributes().get(0);
-        then(changed.getType()).isEqualTo("attribute");
-        then(changed.getString()).isEqualTo("Changed");
-        then(changed.getAttributes().get(0).getType()).isEqualTo("date");
-        then(changed.getAttributes().get(0).getString()).isEqualTo("22 APR 2007");
+        assertThat(changed)
+            .returns("attribute", o -> o.getType())
+            .returns("Changed", o -> o.getString());
+        assertThat(changed.getAttributes().get(0))
+            .returns("date", o -> o.getType())
+            .returns("22 APR 2007", o -> o.getString());
     }
 
     /** */
@@ -110,7 +115,7 @@ public class NoteCrudTest {
     void testReadNotesGl120368N1932() {
         log.info("Beginning testReadNotesGl120368N1932");
         final ApiNote resNote = crud.readOne(helper.getDb(), "N1932");
-        then(resNote.getString()).isEqualTo("N1932");
+        assertThat(resNote).returns("N1932", o -> o.getString());
         final String expected = "Prince Philip, born at Mon Repos, Corfu 10"
             + " June 1921, renounced his rights to the throne of Greece"
             + " and was naturalised in Great Britain taking the surname of"
@@ -127,22 +132,26 @@ public class NoteCrudTest {
             + " and Northern Ireland (born at 17 Bruton St, London W1 21"
             + " April 1926), and has issue (see GREAT BRITAIN - Almanach"
             + " de Gotha 1998; 1999; 2000).";
-        then(resNote.getTail()).isEqualTo(expected);
+        assertThat(resNote).returns(expected, o -> o.getTail());
         final List<ApiAttribute> attributes = resNote.getAttributes();
-        then(attributes.get(0).getType()).isEqualTo("sourcelink");
-        then(attributes.get(0).getString()).isEqualTo("S33734");
-        then(attributes.get(0).getAttributes().get(0).getString()).isEqualTo("Note");
-        then(attributes.get(0).getAttributes().get(0).getTail())
-            .isEqualTo("Record originated in...");
-        then(attributes.get(1).getType()).isEqualTo("sourcelink");
-        then(attributes.get(1).getString()).isEqualTo("S33716");
-        then(attributes.get(1).getAttributes().get(0).getString()).isEqualTo("Note");
-        then(attributes.get(1).getAttributes().get(0).getTail())
-            .isEqualTo("Record originated in...");
-        then(attributes.get(2).getType()).isEqualTo("attribute");
-        then(attributes.get(2).getString()).isEqualTo("Changed");
-        then(attributes.get(2).getAttributes().get(0).getType()).isEqualTo("date");
-        then(attributes.get(2).getAttributes().get(0).getString()).isEqualTo("8 MAR 2008");
+        assertThat(attributes.get(0))
+            .returns("sourcelink", o -> o.getType())
+            .returns("S33734", o -> o.getString());
+        assertThat(attributes.get(0).getAttributes().get(0))
+            .returns("Note", o -> o.getString())
+            .returns("Record originated in...", o -> o.getTail());
+        assertThat(attributes.get(1))
+            .returns("sourcelink", o -> o.getType())
+            .returns("S33716", o -> o.getString());
+        assertThat(attributes.get(1).getAttributes().get(0))
+            .returns("Note", o -> o.getString())
+            .returns("Record originated in...", o -> o.getTail());
+        assertThat(attributes.get(2))
+            .returns("attribute", o -> o.getType())
+            .returns("Changed", o -> o.getString());
+        assertThat(attributes.get(2).getAttributes().get(0))
+            .returns("date", o -> o.getType())
+            .returns("8 MAR 2008", o -> o.getString());
     }
 
     /** */
@@ -165,7 +174,7 @@ public class NoteCrudTest {
             .attributes(java.util.List.of())
             .build();
         final ApiNote resNote = crud.createOne(helper.getDb(), reqNote);
-        then(resNote.getTail()).isEqualTo(reqNote.getTail());
+        assertThat(resNote).returns(reqNote.getTail(), o -> o.getTail());
     }
 
     /** */
@@ -216,7 +225,7 @@ public class NoteCrudTest {
             .tail("Top level note")
             .build();
         final ApiNote resNote = crud.createOne(helper.getDb(), reqNote);
-        then(resNote.getType()).isEqualTo(reqNote.getType());
+        assertThat(resNote).returns(reqNote.getType(), o -> o.getType());
 
         final ApiNote modNote = resNote.toBuilder()
             .attribute(ApiAttribute.builder()

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ParentCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ParentCrudTest.java
@@ -5,7 +5,6 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.crud.FamilyCrud;
 import org.schoellerfamily.gedbrowser.api.crud.ParentCrud;
@@ -18,18 +17,15 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 public class ParentCrudTest {
 
@@ -55,7 +51,7 @@ public class ParentCrudTest {
      * Set up some base objects.
      */
     @BeforeEach
-    public void setUp() {
+    void setUp() {
         helper = new CrudTestHelper(new PersonCrud(loader, toDocConverter, repositoryManager),
             new FamilyCrud(loader, toDocConverter, repositoryManager));
         crud = new ParentCrud(loader, toDocConverter, repositoryManager);
@@ -71,7 +67,8 @@ public class ParentCrudTest {
         final ApiPerson gotChild = helper.getPerson(child);
         log.info("famc: {}", gotChild.getFamcs().get(0).getString());
 
-        assertThat(parent.getFamss().get(0).getString()).isEqualTo(gotChild.getFamcs().get(0).getString());
+        assertThat(parent.getFamss().get(0).getString())
+            .isEqualTo(gotChild.getFamcs().get(0).getString());
     }
 
     /** */

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ParentCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ParentCrudTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -71,8 +71,7 @@ public class ParentCrudTest {
         final ApiPerson gotChild = helper.getPerson(child);
         log.info("famc: {}", gotChild.getFamcs().get(0).getString());
 
-        assertEquals(gotChild.getFamcs().get(0).getString(), parent.getFamss().get(0).getString(),
-            "Child should be in family");
+        assertThat(parent.getFamss().get(0).getString()).isEqualTo(gotChild.getFamcs().get(0).getString());
     }
 
     /** */
@@ -81,10 +80,11 @@ public class ParentCrudTest {
         final ApiPerson inParent = helper.createPerson();
         final ApiPerson child = helper.createPerson();
         final ApiPerson outParent = crud.linkParent(helper.getDb(), child.getString(), inParent);
-        then(outParent.getString()).isEqualTo(inParent.getString());
-        then(outParent.getFamss().size()).isEqualTo(1);
+        assertThat(outParent)
+            .returns(inParent.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotChild = helper.getPerson(child);
-        then(outParent.getFamss().size()).isEqualTo(1);
+        assertThat(outParent).returns(1, o -> o.getFamss().size());
         assertEquals(outParent.getFamss().get(0).getString(),
             gotChild.getFamcs().get(0).getString(), "check ids");
     }
@@ -95,9 +95,10 @@ public class ParentCrudTest {
         log.info("Beginning testGetPersonsMiniSchoellerI2AddParent");
         final ApiPerson reqParent = helper.createAlexander();
         final ApiPerson resParent = crud.createParent("mini-schoeller", "I1", reqParent);
-        then(resParent.getType()).isEqualTo(reqParent.getType());
-        then(resParent.getSurname()).isEqualTo(reqParent.getSurname());
-        then(resParent.getIndexName()).isEqualTo(reqParent.getIndexName());
+        assertThat(resParent)
+            .returns(reqParent.getType(), o -> o.getType())
+            .returns(reqParent.getSurname(), o -> o.getSurname())
+            .returns(reqParent.getIndexName(), o -> o.getIndexName());
     }
 
     /** */
@@ -106,8 +107,9 @@ public class ParentCrudTest {
         log.info("Beginning testGetPersonsMiniSchoellerI2AddParent2");
         final ApiPerson reqParent = helper.createAlexandra();
         final ApiPerson resParent = crud.createParent("mini-schoeller", "I2", reqParent);
-        then(resParent.getType()).isEqualTo(reqParent.getType());
-        then(resParent.getSurname()).isEqualTo(reqParent.getSurname());
-        then(resParent.getIndexName()).isEqualTo(reqParent.getIndexName());
+        assertThat(resParent)
+            .returns(reqParent.getType(), o -> o.getType())
+            .returns(reqParent.getSurname(), o -> o.getSurname())
+            .returns(reqParent.getIndexName(), o -> o.getIndexName());
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
@@ -177,7 +177,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testDeletePerson() {
         log.info("Beginning testDeletePerson");
         final ApiPerson reqPerson = createRJS();
@@ -231,7 +231,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testDeleteChildLinkedPerson() {
         log.info("Beginning testDeleteChildLinkedPerson");
         final ApiPerson reqPerson = createRJS();
@@ -264,7 +264,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testDeletePersonNotFound() {
         log.info("Beginning testDeletePersonNotFound");
         assertThatExceptionOfType(ObjectNotFoundException.class)
@@ -283,7 +283,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testUpdatePersonWithNote() {
         log.info("Beginning testUpdatePersonWithNote");
         final ApiPerson reqPerson = createRJS();

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
@@ -76,14 +76,12 @@ public class PersonCrudTest {
         log.info("Beginning testReadSourcesGl120368");
         final List<ApiPerson> list = crud.readAll(helper.getDb());
         final ApiPerson firstPerson = list.get(0);
-        final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
 
         assertThat(firstPerson)
-            .returns("I1", p -> p.getString());
-        assertThat(firstAttribute)
-            .returns("name", a -> a.getType())
-            .returns("Living /Williams/", a -> a.getString())
-            .returns(true, a -> a.getTail().isEmpty());
+            .returns("I1", p -> p.getString())
+            .returns("name", p -> p.getAttributes().get(0).getType())
+            .returns("Living /Williams/", p -> p.getAttributes().get(0).getString())
+            .returns(true, p -> p.getAttributes().get(0).getTail().isEmpty());
     }
 
     /** */
@@ -92,14 +90,12 @@ public class PersonCrudTest {
         log.info("Beginning testGetPersonsMiniSchoeller");
         final List<ApiPerson> list = crud.readAll("mini-schoeller");
         final ApiPerson firstPerson = list.get(0);
-        final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
 
         assertThat(firstPerson)
-            .returns("I1", p -> p.getString());
-        assertThat(firstAttribute)
-            .returns("name", a -> a.getType())
-            .returns("Melissa Robinson/Schoeller/", a -> a.getString())
-            .returns(true, a -> a.getTail().isEmpty());
+            .returns("I1", p -> p.getString())
+            .returns("name", p -> p.getAttributes().get(0).getType())
+            .returns("Melissa Robinson/Schoeller/", p -> p.getAttributes().get(0).getString())
+            .returns(true, p -> p.getAttributes().get(0).getTail().isEmpty());
     }
 
     /** */
@@ -107,14 +103,12 @@ public class PersonCrudTest {
     void testGetPersonsMiniSchoellerI2() {
         log.info("Beginning testGetPersonsMiniSchoellerI2");
         final ApiPerson firstPerson = crud.readOne("mini-schoeller", "I2");
-        final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
 
         assertThat(firstPerson)
-            .returns("I2", p -> p.getString());
-        assertThat(firstAttribute)
-            .returns("name", a -> a.getType())
-            .returns("Richard John/Schoeller/", a -> a.getString())
-            .returns(true, a -> a.getTail().isEmpty());
+            .returns("I2", p -> p.getString())
+            .returns("name", p -> p.getAttributes().get(0).getType())
+            .returns("Richard John/Schoeller/", p -> p.getAttributes().get(0).getString())
+            .returns(true, p -> p.getAttributes().get(0).getTail().isEmpty());
     }
 
     /** */
@@ -296,7 +290,8 @@ public class PersonCrudTest {
         final ApiPersonBuilder<?, ?> resPerson = crud.createOne(helper.getDb(), reqPerson)
             .toBuilder();
         
-        assertThat(resPerson.getType()).isEqualTo(reqPerson.getType());
+        assertThat(resPerson)
+            .returns(reqPerson.getType(), o -> o.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -34,7 +34,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
@@ -77,11 +76,14 @@ public class PersonCrudTest {
         log.info("Beginning testReadSourcesGl120368");
         final List<ApiPerson> list = crud.readAll(helper.getDb());
         final ApiPerson firstPerson = list.get(0);
-        then(firstPerson.getString()).isEqualTo("I1");
         final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("name");
-        then(firstAttribute.getString()).isEqualTo("Living /Williams/");
-        then(firstAttribute.getTail()).isEmpty();
+
+        assertThat(firstPerson)
+            .returns("I1", p -> p.getString());
+        assertThat(firstAttribute)
+            .returns("name", a -> a.getType())
+            .returns("Living /Williams/", a -> a.getString())
+            .returns(true, a -> a.getTail().isEmpty());
     }
 
     /** */
@@ -90,11 +92,14 @@ public class PersonCrudTest {
         log.info("Beginning testGetPersonsMiniSchoeller");
         final List<ApiPerson> list = crud.readAll("mini-schoeller");
         final ApiPerson firstPerson = list.get(0);
-        then(firstPerson.getString()).isEqualTo("I1");
         final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("name");
-        then(firstAttribute.getString()).isEqualTo("Melissa Robinson/Schoeller/");
-        then(firstAttribute.getTail()).isEmpty();
+
+        assertThat(firstPerson)
+            .returns("I1", p -> p.getString());
+        assertThat(firstAttribute)
+            .returns("name", a -> a.getType())
+            .returns("Melissa Robinson/Schoeller/", a -> a.getString())
+            .returns(true, a -> a.getTail().isEmpty());
     }
 
     /** */
@@ -102,11 +107,14 @@ public class PersonCrudTest {
     void testGetPersonsMiniSchoellerI2() {
         log.info("Beginning testGetPersonsMiniSchoellerI2");
         final ApiPerson firstPerson = crud.readOne("mini-schoeller", "I2");
-        then(firstPerson.getString()).isEqualTo("I2");
         final ApiAttribute firstAttribute = firstPerson.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("name");
-        then(firstAttribute.getString()).isEqualTo("Richard John/Schoeller/");
-        then(firstAttribute.getTail()).isEmpty();
+
+        assertThat(firstPerson)
+            .returns("I2", p -> p.getString());
+        assertThat(firstAttribute)
+            .returns("name", a -> a.getType())
+            .returns("Richard John/Schoeller/", a -> a.getString())
+            .returns(true, a -> a.getTail().isEmpty());
     }
 
     /** */
@@ -129,10 +137,12 @@ public class PersonCrudTest {
             .indexName("")
             .build();
         final ApiPerson resPerson = crud.createOne(helper.getDb(), reqPerson);
-        then(resPerson.getType()).isEqualTo(reqPerson.getType());
-        then(resPerson.getSurname()).isEqualTo(reqPerson.getSurname());
-        then(resPerson.getIndexName()).isEqualTo(reqPerson.getIndexName());
-        then(resPerson.getString()).isNotEmpty();
+
+        assertThat(resPerson)
+            .returns(reqPerson.getType(), p -> p.getType())
+            .returns(reqPerson.getSurname(), p -> p.getSurname())
+            .returns(reqPerson.getIndexName(), p -> p.getIndexName())
+            .returns(true, p -> !p.getString().isEmpty());
     }
 
     /** */
@@ -141,10 +151,12 @@ public class PersonCrudTest {
         log.info("Beginning testCreatePersonsWithName");
         final ApiPerson reqPerson = createRJS();
         final ApiPerson resPerson = crud.createOne(helper.getDb(), reqPerson);
-        then(resPerson.getType()).isEqualTo(reqPerson.getType());
-        then(resPerson.getSurname()).isEqualTo(reqPerson.getSurname());
-        then(resPerson.getIndexName()).isEqualTo(reqPerson.getIndexName());
-        then(resPerson.getString()).isNotEmpty();
+
+        assertThat(resPerson)
+            .returns(reqPerson.getType(), p -> p.getType())
+            .returns(reqPerson.getSurname(), p -> p.getSurname())
+            .returns(reqPerson.getIndexName(), p -> p.getIndexName())
+            .returns(true, p -> !p.getString().isEmpty());
     }
 
     /**
@@ -158,17 +170,17 @@ public class PersonCrudTest {
                 .type("name")
                 .string("Richard/Schoeller/")
                 .tail("")
-                .attributes(java.util.List.of())
+                .attributes(List.of())
                 .build())
             .attribute(ApiAttribute.builder()
                 .type("attribute")
                 .string("Sex")
                 .tail("M")
-                .attributes(java.util.List.of())
+                .attributes(List.of())
                 .build())
             .surname("Schoeller")
             .indexName("Schoeller, Richard")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
     }
 
@@ -181,7 +193,9 @@ public class PersonCrudTest {
         final String id = resPerson.getString();
         crud.readOne(helper.getDb(), id);
         final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), id);
-        then(deletedPerson.getString()).isEqualTo(id);
+
+        assertThat(deletedPerson)
+            .returns(id, p -> p.getString());
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.readOne(helper.getDb(), id))
             .withMessage("Object " + id + " of type person not found");
@@ -201,18 +215,26 @@ public class PersonCrudTest {
         final ApiPerson p2 = helper.createAlexandra();
         final SpouseCrud spouseCrud = new SpouseCrud(loader, toDocConverter, repositoryManager);
         final ApiPerson gotP2 = spouseCrud.createSpouseInFamily(helper.getDb(), fam, p2);
-        then(fam).isEqualTo(gotP2.getFamss().get(0).getString());
 
-        ApiPerson readPerson = crud.readOne(helper.getDb(), id);
-        then(readPerson.getString()).isEqualTo(id);
-        ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), id);
-        then(deletedPerson.getString()).isEqualTo(id);
+        assertThat(gotP2)
+            .returns(fam, p -> p.getFamss().get(0).getString());
+
+        final ApiPerson readPerson = crud.readOne(helper.getDb(), id);
+        assertThat(readPerson)
+            .returns(id, p -> p.getString());
+
+        final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), id);
+        assertThat(deletedPerson)
+            .returns(id, p -> p.getString());
+
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.readOne(helper.getDb(), id))
             .withMessage("Object " + id + " of type person not found");
+
         final ApiFamily readFamily = familyCrud.readOne(helper.getDb(), fam);
-        then(readFamily.getSpouses().size()).isEqualTo(1);
-        then(readFamily.getSpouses().get(0).getString()).isEqualTo(gotP2.getString());
+        assertThat(readFamily)
+            .returns(1, f -> f.getSpouses().size())
+            .returns(gotP2.getString(), f -> f.getSpouses().get(0).getString());
     }
 
     /** */
@@ -230,14 +252,21 @@ public class PersonCrudTest {
         final ApiPerson p2 = helper.createAlexandra();
         final SpouseCrud spouseCrud = new SpouseCrud(loader, toDocConverter, repositoryManager);
         final ApiPerson gotP2 = spouseCrud.createSpouseInFamily(helper.getDb(), fam, p2);
-        then(gotP2.getFamss().get(0).getString()).isEqualTo(fam);
+        
+        assertThat(gotP2)
+            .returns(fam, p -> p.getFamss().get(0).getString());
+        
         final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), childId);
-        then(deletedPerson.getString()).isEqualTo(childId);
+        assertThat(deletedPerson)
+            .returns(childId, p -> p.getString());
+        
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.readOne(helper.getDb(), childId))
             .withMessage("Object " + childId + " of type person not found");
+        
         final ApiFamily readFamily = familyCrud.readOne(helper.getDb(), fam);
-        then(readFamily.getChildren().size()).isEqualTo(0);
+        assertThat(readFamily)
+            .returns(0, f -> f.getChildren().size());
     }
 
     /** */
@@ -266,7 +295,8 @@ public class PersonCrudTest {
         final ApiPerson reqPerson = createRJS();
         final ApiPersonBuilder<?, ?> resPerson = crud.createOne(helper.getDb(), reqPerson)
             .toBuilder();
-        then(resPerson.getType()).isEqualTo(reqPerson.getType());
+        
+        assertThat(resPerson.getType()).isEqualTo(reqPerson.getType());
 
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/PersonCrudTest.java
@@ -8,7 +8,6 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -27,7 +26,6 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
@@ -37,7 +35,6 @@ import lombok.extern.slf4j.Slf4j;
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 public class PersonCrudTest {
 
@@ -73,7 +70,7 @@ public class PersonCrudTest {
     /** */
     @Test
     void testGetPersonsGl120368() {
-        log.info("Beginning testReadSourcesGl120368");
+        log.info("Beginning testGetPersonsGl120368");
         final List<ApiPerson> list = crud.readAll(helper.getDb());
         final ApiPerson firstPerson = list.get(0);
 
@@ -180,6 +177,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testDeletePerson() {
         log.info("Beginning testDeletePerson");
         final ApiPerson reqPerson = createRJS();
@@ -233,6 +231,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testDeleteChildLinkedPerson() {
         log.info("Beginning testDeleteChildLinkedPerson");
         final ApiPerson reqPerson = createRJS();
@@ -246,18 +245,18 @@ public class PersonCrudTest {
         final ApiPerson p2 = helper.createAlexandra();
         final SpouseCrud spouseCrud = new SpouseCrud(loader, toDocConverter, repositoryManager);
         final ApiPerson gotP2 = spouseCrud.createSpouseInFamily(helper.getDb(), fam, p2);
-        
+
         assertThat(gotP2)
             .returns(fam, p -> p.getFamss().get(0).getString());
-        
+
         final ApiPerson deletedPerson = crud.deleteOne(helper.getDb(), childId);
         assertThat(deletedPerson)
             .returns(childId, p -> p.getString());
-        
+
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.readOne(helper.getDb(), childId))
             .withMessage("Object " + childId + " of type person not found");
-        
+
         final ApiFamily readFamily = familyCrud.readOne(helper.getDb(), fam);
         assertThat(readFamily)
             .returns(0, f -> f.getChildren().size());
@@ -265,6 +264,7 @@ public class PersonCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testDeletePersonNotFound() {
         log.info("Beginning testDeletePersonNotFound");
         assertThatExceptionOfType(ObjectNotFoundException.class)
@@ -276,7 +276,6 @@ public class PersonCrudTest {
     @Test
     void testDeletePersonDatabaseNotFound() {
         log.info("Beginning testDeletePersonDatabaseNotFound");
-        log.info("Beginning testDeletePersonNotFound");
         assertThatExceptionOfType(DataSetNotFoundException.class)
             .isThrownBy(() -> crud.deleteOne("XYZZY", "XXXXXXX"))
             .withMessage("Data set XYZZY not found");
@@ -284,12 +283,13 @@ public class PersonCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testUpdatePersonWithNote() {
         log.info("Beginning testUpdatePersonWithNote");
         final ApiPerson reqPerson = createRJS();
         final ApiPersonBuilder<?, ?> resPerson = crud.createOne(helper.getDb(), reqPerson)
             .toBuilder();
-        
+
         assertThat(resPerson)
             .returns(reqPerson.getType(), o -> o.getType());
 

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
@@ -72,20 +72,23 @@ public class SourceCrudTest {
         log.info("Beginning testReadSourcesGl120368");
         final List<ApiSource> list = crud.readAll(helper.getDb());
         final ApiSource firstSource = list.get(0);
-        then(firstSource.getString()).isEqualTo("S1688");
-        then(firstSource.getImages()).isEmpty();
-        then(firstSource.getTitle()).isEqualTo("1841 England Census");
+        assertThat(firstSource)
+            .returns("S1688", o -> o.getString())
+            .returns(true, o -> o.getImages().isEmpty())
+            .returns("1841 England Census", o -> o.getTitle());
         final List<ApiAttribute> attributes = firstSource.getAttributes();
-        then(attributes.get(0).getType()).isEqualTo("attribute");
-        then(attributes.get(0).getString()).isEqualTo("Author");
-        then(attributes.get(0).getTail()).isEqualTo("Ancestry.com");
-        then(attributes.get(1).getType()).isEqualTo("attribute");
-        then(attributes.get(1).getString()).isEqualTo("Title");
-        then(attributes.get(1).getTail()).isEqualTo("1841 England Census");
-        then(attributes.get(2).getType()).isEqualTo("attribute");
-        then(attributes.get(2).getString()).isEqualTo("Published");
-        then(attributes.get(2).getTail())
-            .isEqualTo("Provo, UT, USA: The Generations Network, Inc., 2006");
+        assertThat(attributes.get(0))
+            .returns("attribute", o -> o.getType())
+            .returns("Author", o -> o.getString())
+            .returns("Ancestry.com", o -> o.getTail());
+        assertThat(attributes.get(1))
+            .returns("attribute", o -> o.getType())
+            .returns("Title", o -> o.getString())
+            .returns("1841 England Census", o -> o.getTail());
+        assertThat(attributes.get(2))
+            .returns("attribute", o -> o.getType())
+            .returns("Published", o -> o.getString())
+            .returns("Provo, UT, USA: The Generations Network, Inc., 2006", o -> o.getTail());
     }
 
     /** */
@@ -94,20 +97,23 @@ public class SourceCrudTest {
         log.info("Beginning testReadSourcesMiniSchoeller");
         final List<ApiSource> list = crud.readAll("mini-schoeller");
         final ApiSource firstSource = list.get(0);
-        then(firstSource.getString()).isEqualTo("S2");
-        then(firstSource.getImages()).isEmpty();
-        then(firstSource.getTitle()).isEqualTo("Schoeller, Melissa Robinson, birth certificate");
+        assertThat(firstSource)
+            .returns("S2", o -> o.getString())
+            .returns(true, o -> o.getImages().isEmpty())
+            .returns("Schoeller, Melissa Robinson, birth certificate", o -> o.getTitle());
         final List<ApiAttribute> attributes = firstSource.getAttributes();
-        then(attributes.get(0).getType()).isEqualTo("attribute");
-        then(attributes.get(0).getString()).isEqualTo("Title");
-        then(attributes.get(0).getTail())
-            .isEqualTo("Schoeller, Melissa Robinson, birth certificate");
-        then(attributes.get(1).getType()).isEqualTo("attribute");
-        then(attributes.get(1).getString()).isEqualTo("Abbreviation");
-        then(attributes.get(1).getTail()).isEqualTo("SchoellerMelissaBirthCert");
-        then(attributes.get(2).getType()).isEqualTo("attribute");
-        then(attributes.get(2).getString()).isEqualTo("Note");
-        then(attributes.get(2).getTail()).isEqualTo("We have the original of this document");
+        assertThat(attributes.get(0))
+            .returns("attribute", o -> o.getType())
+            .returns("Title", o -> o.getString())
+            .returns("Schoeller, Melissa Robinson, birth certificate", o -> o.getTail());
+        assertThat(attributes.get(1))
+            .returns("attribute", o -> o.getType())
+            .returns("Abbreviation", o -> o.getString())
+            .returns("SchoellerMelissaBirthCert", o -> o.getTail());
+        assertThat(attributes.get(2))
+            .returns("attribute", o -> o.getType())
+            .returns("Note", o -> o.getString())
+            .returns("We have the original of this document", o -> o.getTail());
     }
 
     /** */
@@ -115,20 +121,23 @@ public class SourceCrudTest {
     void testReadSourcesMiniSchoellerS2() {
         log.info("Beginning testReadSourcesMiniSchoellerS2");
         final ApiSource firstSource = crud.readOne("mini-schoeller", "S2");
-        then(firstSource.getString()).isEqualTo("S2");
-        then(firstSource.getImages()).isEmpty();
-        then(firstSource.getTitle()).isEqualTo("Schoeller, Melissa Robinson, birth certificate");
+        assertThat(firstSource)
+            .returns("S2", o -> o.getString())
+            .returns(true, o -> o.getImages().isEmpty())
+            .returns("Schoeller, Melissa Robinson, birth certificate", o -> o.getTitle());
         final List<ApiAttribute> attributes = firstSource.getAttributes();
-        then(attributes.get(0).getType()).isEqualTo("attribute");
-        then(attributes.get(0).getString()).isEqualTo("Title");
-        then(attributes.get(0).getTail())
-            .isEqualTo("Schoeller, Melissa Robinson, birth certificate");
-        then(attributes.get(1).getType()).isEqualTo("attribute");
-        then(attributes.get(1).getString()).isEqualTo("Abbreviation");
-        then(attributes.get(1).getTail()).isEqualTo("SchoellerMelissaBirthCert");
-        then(attributes.get(2).getType()).isEqualTo("attribute");
-        then(attributes.get(2).getString()).isEqualTo("Note");
-        then(attributes.get(2).getTail()).isEqualTo("We have the original of this document");
+        assertThat(attributes.get(0))
+            .returns("attribute", o -> o.getType())
+            .returns("Title", o -> o.getString())
+            .returns("Schoeller, Melissa Robinson, birth certificate", o -> o.getTail());
+        assertThat(attributes.get(1))
+            .returns("attribute", o -> o.getType())
+            .returns("Abbreviation", o -> o.getString())
+            .returns("SchoellerMelissaBirthCert", o -> o.getTail());
+        assertThat(attributes.get(2))
+            .returns("attribute", o -> o.getType())
+            .returns("Note", o -> o.getString())
+            .returns("We have the original of this document", o -> o.getTail());
     }
 
     /** */
@@ -151,7 +160,7 @@ public class SourceCrudTest {
             .attributes(java.util.List.of())
             .build();
         final ApiSource newSource = crud.createOne(helper.getDb(), inSource);
-        then(newSource.getType()).isEqualTo(inSource.getType());
+        assertThat(newSource).returns(inSource.getType(), o -> o.getType());
     }
 
     /** */
@@ -218,6 +227,6 @@ public class SourceCrudTest {
         newSource.attribute(aNote);
         final ApiSource updatedSource = crud.updateOne(helper.getDb(), newSource.getString(),
             newSource.build());
-        assertEquals(aNote, updatedSource.getAttributes().get(1), "attribute should be present");
+        assertThat(updatedSource.getAttributes().get(1)).isEqualTo(aNote);
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SourceCrudTest.java
@@ -2,13 +2,11 @@ package org.schoellerfamily.gedbrowser.api.crud.test;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -25,14 +23,12 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
@@ -157,7 +153,7 @@ public class SourceCrudTest {
             .type("source")
             .string("")
             .title("Unknown")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiSource newSource = crud.createOne(helper.getDb(), inSource);
         assertThat(newSource).returns(inSource.getType(), o -> o.getType());
@@ -171,7 +167,7 @@ public class SourceCrudTest {
             .type("source")
             .string("")
             .title("Unknown")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build();
         final ApiSource resSource = crud.createOne(helper.getDb(), reqSource);
         final String id = resSource.getString();
@@ -208,7 +204,7 @@ public class SourceCrudTest {
             .type("attribute")
             .string("Note")
             .tail("first note")
-            .attributes(java.util.List.of())
+            .attributes(List.of())
             .build());
         final ApiSource inSource = ApiSource.builder()
             .type("source")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.api.Application;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
 import org.schoellerfamily.gedbrowser.api.crud.ChildCrud;
@@ -23,18 +22,15 @@ import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryMan
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import lombok.extern.slf4j.Slf4j;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 @Slf4j
 public final class SpouseCrudTest {
 
@@ -68,7 +64,7 @@ public final class SpouseCrudTest {
         log.info("Beginning testLinkSpouse");
         final ApiPerson p1 = helper.createPerson();
         final ApiPerson p2 = helper.createPerson();
-        ApiPerson gotP1 = crud.linkSpouse(helper.getDb(), p2.getString(), p1);
+        final ApiPerson gotP1 = crud.linkSpouse(helper.getDb(), p2.getString(), p1);
         assertThat(gotP1)
             .returns(p1.getString(), o -> o.getString())
             .returns(1, o -> o.getFamss().size());

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SpouseCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -69,10 +69,11 @@ public final class SpouseCrudTest {
         final ApiPerson p1 = helper.createPerson();
         final ApiPerson p2 = helper.createPerson();
         ApiPerson gotP1 = crud.linkSpouse(helper.getDb(), p2.getString(), p1);
-        then(gotP1.getString()).isEqualTo(p1.getString());
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1)
+            .returns(p1.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotP2 = helper.getPerson(p2);
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2).returns(1, o -> o.getFamss().size());
         assertEquals(gotP1.getFamss().get(0).getString(), gotP2.getFamss().get(0).getString(),
             "check ids");
     }
@@ -86,10 +87,11 @@ public final class SpouseCrudTest {
 
         final ApiPerson p2 = helper.createPerson();
         final ApiPerson gotP2 = crud.linkSpouseInFamily(helper.getDb(), fam, p2);
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2)
+            .returns(p2.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1).returns(1, o -> o.getFamss().size());
         assertEquals(gotP1.getFamss().get(0).getString(), gotP2.getFamss().get(0).getString(),
             "check ids");
     }
@@ -103,15 +105,16 @@ public final class SpouseCrudTest {
 
         final ApiPerson p2 = helper.createPerson();
         final ApiPerson gotP2 = crud.linkSpouseInFamily(helper.getDb(), fam, p2);
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2)
+            .returns(p2.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1).returns(1, o -> o.getFamss().size());
 
         crud.unlinkSpouseInFamily(helper.getDb(), fam, gotP1.getString());
         final ApiPerson gotP1again = helper.getPerson(gotP1);
         final ApiPerson gotP2again = helper.getPerson(gotP2);
-        then(gotP1again.getFamss().size()).isEqualTo(0);
+        assertThat(gotP1again).returns(0, o -> o.getFamss().size());
         assertEquals(gotP2again.getFamss().get(0).getString(), fam, "check ids");
     }
 
@@ -124,10 +127,11 @@ public final class SpouseCrudTest {
 
         final ApiPerson p2 = helper.createPerson();
         final ApiPerson gotP2 = crud.linkSpouseInFamily(helper.getDb(), fam, p2);
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2)
+            .returns(p2.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1).returns(1, o -> o.getFamss().size());
 
         final ApiPerson p1back = crud.unlinkSpouseInFamily(helper.getDb(), "XXXXX",
             gotP1.getString());
@@ -151,10 +155,11 @@ public final class SpouseCrudTest {
 
         final ApiPerson p2 = helper.createPerson();
         final ApiPerson gotP2 = crud.linkSpouseInFamily(helper.getDb(), fam, p2);
-        then(gotP2.getString()).isEqualTo(p2.getString());
-        then(gotP2.getFamss().size()).isEqualTo(1);
+        assertThat(gotP2)
+            .returns(p2.getString(), o -> o.getString())
+            .returns(1, o -> o.getFamss().size());
         final ApiPerson gotP1 = helper.getPerson(p1);
-        then(gotP1.getFamss().size()).isEqualTo(1);
+        assertThat(gotP1).returns(1, o -> o.getFamss().size());
 
         assertThatExceptionOfType(ObjectNotFoundException.class)
             .isThrownBy(() -> crud.unlinkSpouseInFamily(helper.getDb(), fam, "XXXXX"))
@@ -176,10 +181,11 @@ public final class SpouseCrudTest {
         log.info("Beginning testCreateSpouseInFamily");
         final ApiPerson reqSpouse = helper.createAlexandra();
         final ApiPerson resSpouse = crud.createSpouseInFamily(helper.getDb(), "F1", reqSpouse);
-        then(resSpouse.getType()).isEqualTo(reqSpouse.getType());
-        then(resSpouse.getSurname()).isEqualTo(reqSpouse.getSurname());
-        then(resSpouse.getIndexName()).isEqualTo(reqSpouse.getIndexName());
-        then(resSpouse.getFamss().get(0).getString()).isEqualTo("F1");
+        assertThat(resSpouse)
+            .returns(reqSpouse.getType(), o -> o.getType())
+            .returns(reqSpouse.getSurname(), o -> o.getSurname())
+            .returns(reqSpouse.getIndexName(), o -> o.getIndexName())
+            .returns("F1", o -> o.getFamss().get(0).getString());
     }
 
     @Test
@@ -187,10 +193,11 @@ public final class SpouseCrudTest {
         log.info("Beginning testCreateSpouseInFamily2");
         final ApiPerson reqSpouse = helper.createAlexander();
         final ApiPerson resSpouse = crud.createSpouseInFamily(helper.getDb(), "F2", reqSpouse);
-        then(resSpouse.getType()).isEqualTo(reqSpouse.getType());
-        then(resSpouse.getSurname()).isEqualTo(reqSpouse.getSurname());
-        then(resSpouse.getIndexName()).isEqualTo(reqSpouse.getIndexName());
-        then(resSpouse.getFamss().get(0).getString()).isEqualTo("F2");
+        assertThat(resSpouse)
+            .returns(reqSpouse.getType(), o -> o.getType())
+            .returns(reqSpouse.getSurname(), o -> o.getSurname())
+            .returns(reqSpouse.getIndexName(), o -> o.getIndexName())
+            .returns("F2", o -> o.getFamss().get(0).getString());
     }
 
     @Test
@@ -198,8 +205,9 @@ public final class SpouseCrudTest {
         log.info("Beginning testGetPersonsMiniSchoellerI2AddSpouse");
         final ApiPerson reqSpouse = helper.createAlexander();
         final ApiPerson resSpouse = crud.createSpouse("mini-schoeller", "I1", reqSpouse);
-        then(resSpouse.getType()).isEqualTo(reqSpouse.getType());
-        then(resSpouse.getSurname()).isEqualTo(reqSpouse.getSurname());
-        then(resSpouse.getIndexName()).isEqualTo(reqSpouse.getIndexName());
+        assertThat(resSpouse)
+            .returns(reqSpouse.getType(), o -> o.getType())
+            .returns(reqSpouse.getSurname(), o -> o.getSurname())
+            .returns(reqSpouse.getIndexName(), o -> o.getIndexName());
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -157,7 +157,7 @@ public class SubmissionCrudTest {
 
     /** */
     @Test
-    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
+    @SuppressWarnings({ "PMD.UnitTestContainsTooManyAsserts" })
     void testUpdateSubmissionWithNote() {
         log.info("Beginning testUpdateSubmissionWithNote");
         final ApiSubmission inSubmission = ApiSubmission.builder()

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -36,7 +36,6 @@ import lombok.extern.slf4j.Slf4j;
     classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 @Slf4j
 public class SubmissionCrudTest {
 
@@ -158,6 +157,7 @@ public class SubmissionCrudTest {
 
     /** */
     @Test
+    @SuppressWarnings({ "PMD:UnitTestContainsTooManyAsserts" })
     void testUpdateSubmissionWithNote() {
         log.info("Beginning testUpdateSubmissionWithNote");
         final ApiSubmission inSubmission = ApiSubmission.builder()

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -1,7 +1,7 @@
 package org.schoellerfamily.gedbrowser.api.crud.test;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
-import static org.assertj.core.api.BDDAssertions.then;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -72,11 +72,12 @@ public class SubmissionCrudTest {
         log.info("Beginning testGetSubmissionsGl120368");
         final List<ApiSubmission> list = crud.readAll(helper.getDb());
         final ApiSubmission firstSubmission = list.get(0);
-        then(firstSubmission.getString()).isEqualTo("B1");
+        assertThat(firstSubmission).returns("B1", o -> o.getString());
         final ApiAttribute firstAttribute = firstSubmission.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("attribute");
-        then(firstAttribute.getString()).isEqualTo("Generations of descendants");
-        then(firstAttribute.getTail()).isEqualTo("2");
+        assertThat(firstAttribute)
+            .returns("attribute", o -> o.getType())
+            .returns("Generations of descendants", o -> o.getString())
+            .returns("2", o -> o.getTail());
     }
 
     /** */
@@ -93,9 +94,10 @@ public class SubmissionCrudTest {
         log.info("Beginning testGetSubmissionsGl120368B1");
         final ApiSubmission submission = crud.readOne(helper.getDb(), "B1");
         final ApiAttribute firstAttribute = submission.getAttributes().get(0);
-        then(firstAttribute.getType()).isEqualTo("attribute");
-        then(firstAttribute.getString()).isEqualTo("Generations of descendants");
-        then(firstAttribute.getTail()).isEqualTo("2");
+        assertThat(firstAttribute)
+            .returns("attribute", o -> o.getType())
+            .returns("Generations of descendants", o -> o.getString())
+            .returns("2", o -> o.getTail());
     }
 
     /** */
@@ -117,7 +119,7 @@ public class SubmissionCrudTest {
             .attributes(List.of())
             .build();
         final ApiSubmission outSubmission = crud.createOne(helper.getDb(), inSubmission);
-        then(outSubmission.getType()).isEqualTo(inSubmission.getType());
+        assertThat(outSubmission).returns(inSubmission.getType(), o -> o.getType());
     }
 
     /** */
@@ -133,7 +135,7 @@ public class SubmissionCrudTest {
         final String id = outSubmission.getString();
 
         final ApiSubmission deletedSubmission = crud.deleteOne(helper.getDb(), id);
-        then(deletedSubmission.getString()).isEqualTo(id);
+        assertThat(deletedSubmission).returns(id, o -> o.getString());
     }
 
     /** */
@@ -167,7 +169,7 @@ public class SubmissionCrudTest {
         final ApiSubmissionBuilder<?, ?> outSubmission = crud
             .createOne(helper.getDb(), inSubmission)
             .toBuilder();
-        then(outSubmission.getType()).isEqualTo(inSubmission.getType());
+        assertThat(outSubmission).returns(inSubmission.getType(), o -> o.getType());
         final ApiAttribute aNote = ApiAttribute.builder()
             .type("attribute")
             .string("Note")

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/SubmissionCrudTest.java
@@ -72,12 +72,12 @@ public class SubmissionCrudTest {
         log.info("Beginning testGetSubmissionsGl120368");
         final List<ApiSubmission> list = crud.readAll(helper.getDb());
         final ApiSubmission firstSubmission = list.get(0);
-        assertThat(firstSubmission).returns("B1", o -> o.getString());
-        final ApiAttribute firstAttribute = firstSubmission.getAttributes().get(0);
-        assertThat(firstAttribute)
-            .returns("attribute", o -> o.getType())
-            .returns("Generations of descendants", o -> o.getString())
-            .returns("2", o -> o.getTail());
+
+        assertThat(firstSubmission)
+            .returns("B1", o -> o.getString())
+            .returns("attribute", o -> o.getAttributes().get(0).getType())
+            .returns("Generations of descendants", o -> o.getAttributes().get(0).getString())
+            .returns("2", o -> o.getAttributes().get(0).getTail());
     }
 
     /** */
@@ -93,8 +93,8 @@ public class SubmissionCrudTest {
     void testGetSubmissionsGl120368B1() {
         log.info("Beginning testGetSubmissionsGl120368B1");
         final ApiSubmission submission = crud.readOne(helper.getDb(), "B1");
-        final ApiAttribute firstAttribute = submission.getAttributes().get(0);
-        assertThat(firstAttribute)
+
+        assertThat(submission.getAttributes().get(0))
             .returns("attribute", o -> o.getType())
             .returns("Generations of descendants", o -> o.getString())
             .returns("2", o -> o.getTail());

--- a/geoservice/src/test/java/org/schoellerfamily/geoservice/test/ApplicationTest.java
+++ b/geoservice/src/test/java/org/schoellerfamily/geoservice/test/ApplicationTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.geoservice.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
 import java.util.Map;
@@ -60,7 +60,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
     }
 
     /** */
@@ -73,7 +73,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
     }
 
     /** */
@@ -84,7 +84,7 @@ public class ApplicationTest {
                 .uri(URI.create("http://localhost:" + port + "/geocode?name=Bethlehem,%20PA"))
                 .exchange()
                 .returnResult(Map.class);
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("placeName")).orElse(null))
             .isEqualTo("Bethlehem, PA");
     }
@@ -99,7 +99,7 @@ public class ApplicationTest {
                         + "&modernName=Bethlehem,%20PA"))
                 .exchange()
                 .returnResult(Map.class);
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("placeName")).orElse(null))
             .isEqualTo("Bethlehem, PA");
     }
@@ -112,7 +112,7 @@ public class ApplicationTest {
                 .uri(URI.create("http://localhost:" + port + "/geocode?name=Allentown,%20PA"))
                 .exchange()
                 .returnResult(Map.class);
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("modernPlaceName")).orElse(null))
             .isEqualTo("Allentown, PA");
     }
@@ -127,7 +127,7 @@ public class ApplicationTest {
                         + "&modernName=Bethlehem,%20PA"))
                 .exchange()
                 .returnResult(Map.class);
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("modernPlaceName")).orElse(null))
             .isEqualTo("Bethlehem, PA");
     }
@@ -141,7 +141,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("result")).orElse(null)).isNotNull();
     }
 
@@ -154,7 +154,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(Optional.ofNullable(entity.getResponseBody())
+        assertThat(Optional.ofNullable(entity.getResponseBody())
             .map(b -> b.get("result")).orElse(null)).isNull();
     }
 
@@ -167,7 +167,7 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
     }
 
     /** */
@@ -179,6 +179,6 @@ public class ApplicationTest {
                 .exchange()
                 .returnResult(Map.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
     }
 }

--- a/geoservice/src/test/java/org/schoellerfamily/geoservice/test/BackupRestoreEndpointTest.java
+++ b/geoservice/src/test/java/org/schoellerfamily/geoservice/test/BackupRestoreEndpointTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.geoservice.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -48,8 +48,8 @@ public class BackupRestoreEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("backup succeeded to/from")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("backup succeeded to/from")
             .contains("locations in the cache");
     }
 
@@ -61,8 +61,8 @@ public class BackupRestoreEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("restore succeeded to/from")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("restore succeeded to/from")
             .contains("locations in the cache");
     }
 }

--- a/geoservice/src/test/java/org/schoellerfamily/geoservice/test/LoadEndpointTest.java
+++ b/geoservice/src/test/java/org/schoellerfamily/geoservice/test/LoadEndpointTest.java
@@ -1,6 +1,6 @@
 package org.schoellerfamily.geoservice.test;
 
-import static org.assertj.core.api.BDDAssertions.then;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
@@ -48,8 +48,8 @@ public class LoadEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("Load complete")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("Load complete")
                 .contains("0 locations in the cache");
     }
 
@@ -61,8 +61,8 @@ public class LoadEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("Load complete")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("Load complete")
                 .contains("917 locations in the cache");
     }
 
@@ -74,8 +74,8 @@ public class LoadEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("Load complete")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("Load complete")
                 .contains("0 locations in the cache");
     }
 
@@ -87,8 +87,8 @@ public class LoadEndpointTest {
                 .exchange()
                 .returnResult(String.class);
 
-        then(entity.getStatus()).isEqualTo(HttpStatus.OK);
-        then(entity.getResponseBody()).contains("Load complete")
+        assertThat(entity.getStatus()).isEqualTo(HttpStatus.OK);
+        assertThat(entity.getResponseBody()).contains("Load complete")
                 .contains("917 locations in the cache");
     }
 }


### PR DESCRIPTION
This PR completes the modernization of the test suite to use AssertJ fluent assertions throughout the codebase.

## Changes

### Phase 1: Assertion Consolidation
- Consolidated assertions in PersonCrudTest (4 methods: testGetPersonsGl120368, testGetPersonsMiniSchoeller, testGetPersonsMiniSchoellerI2, testUpdatePersonWithNote)
- Consolidated assertions in SubmissionCrudTest (2 methods: testGetSubmissionsGl120368, testGetSubmissionsGl120368B1)
- Removed intermediate variables and chained assertions directly on target objects

### Phase 2: Controller Test Updates (gedbrowserng module)
Updated 11 controller test files:
- PersonControllerTest
- FamilyControllerTest
- ChildrenControllerTest
- SpousesControllerTest
- ParentsControllerTest
- SourceControllerTest
- NoteControllerTest
- SubmissionControllerTest
- SubmitterControllerTest
- HeadControllerTest
- SaveControllerTest

### Phase 3: Remaining Test Files (gedbrowser + geoservice modules)
Updated 17 test files:
- gedbrowser module: 14 controller and application test files
- geoservice module: 3 endpoint and application test files

## Impact
- **Total files updated**: 28 test files across 3 modules
- **Pattern applied**: Replaced `BDDAssertions.then` with `Assertions.assertThat`
- **Verification**: All changes compiled successfully
- **Result**: Complete elimination of BDDAssertions.then usage project-wide

## Testing
- All files compile without errors
- Maven build successful

## Related Work
This PR builds on previous work modernizing the crud test package and continues the effort to standardize on modern AssertJ fluent assertions across the entire test suite.