### PR TITLE
More test cleanup

### DIFF
--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/BadLoadTest.java
@@ -36,10 +36,10 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("PMD.ExcessiveImports")
+@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.TooManyMethods" })
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
-public final class BadLoadTest {
+final class BadLoadTest {
     /** */
     @Autowired
     private transient GedObjectToGedDocumentMongoConverter toDocConverter;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedDocumentMongoToGedObjectConverterTest.java
@@ -66,10 +66,10 @@ import org.springframework.test.context.ContextConfiguration;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects" })
+@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.TooManyMethods" })
 @ExtendWith(org.springframework.test.context.junit.jupiter.SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
-public final class GedDocumentMongoToGedObjectConverterTest {
+final class GedDocumentMongoToGedObjectConverterTest {
     /** */
     @Autowired
     private transient GedDocumentMongoToGedObjectConverter toObjConverter;

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/test/GedObjectToGedDocumentMongoConverterTest.java
@@ -65,7 +65,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects" })
+@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.TooManyMethods" })
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
 class GedObjectToGedDocumentMongoConverterTest {
@@ -80,7 +80,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "attribute";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<AttributeDocumentMongo> expectedClass = AttributeDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -90,7 +91,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "child";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<ChildDocumentMongo> expectedClass = ChildDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -100,7 +102,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "date";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<DateDocumentMongo> expectedClass = DateDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -110,7 +113,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "multimedia";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<MultimediaDocumentMongo> expectedClass = MultimediaDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -120,7 +124,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "name";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<NameDocumentMongo> expectedClass = NameDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -130,7 +135,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "note";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<NoteDocumentMongo> expectedClass = NoteDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -140,7 +146,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "notelink";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<NoteLinkDocumentMongo> expectedClass = NoteLinkDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -150,7 +157,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "family";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<FamilyDocumentMongo> expectedClass = FamilyDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -160,7 +168,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "famc";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<FamCDocumentMongo> expectedClass = FamCDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -170,7 +179,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "fams";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<FamSDocumentMongo> expectedClass = FamSDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -180,7 +190,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "head";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<HeadDocumentMongo> expectedClass = HeadDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -190,7 +201,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "husband";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<HusbandDocumentMongo> expectedClass = HusbandDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -200,7 +212,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "person";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<PersonDocumentMongo> expectedClass = PersonDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -210,7 +223,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "place";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<PlaceDocumentMongo> expectedClass = PlaceDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -220,7 +234,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "source";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SourceDocumentMongo> expectedClass = SourceDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -230,7 +245,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "sourcelink";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SourceLinkDocumentMongo> expectedClass = SourceLinkDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -240,7 +256,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "submission";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SubmissionDocumentMongo> expectedClass = SubmissionDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -250,7 +267,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "submissionlink";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SubmissionLinkDocumentMongo> expectedClass = SubmissionLinkDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -260,7 +278,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "submitter";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SubmitterDocumentMongo> expectedClass = SubmitterDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -270,7 +289,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "submitterlink";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<SubmitterLinkDocumentMongo> expectedClass = SubmitterLinkDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -280,7 +300,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "trailer";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<TrailerDocumentMongo> expectedClass = TrailerDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -290,7 +311,8 @@ class GedObjectToGedDocumentMongoConverterTest {
         final String typeString = "wife";
         final GedDocument<?> gmd = toDocConverter.createGedDocument(ged);
         final Class<WifeDocumentMongo> expectedClass = WifeDocumentMongo.class;
-        assertTrue(checkGedDocument(ged, gmd, typeString, expectedClass), "Failed document check");
+        assertTrue(compareGedDocument(ged, gmd, typeString, expectedClass),
+            "Failed document check");
     }
 
     /** */
@@ -330,7 +352,7 @@ class GedObjectToGedDocumentMongoConverterTest {
      * @param expectedClass      the expected class
      * @return true or throws an assertion exception
      */
-    private boolean checkGedDocument(final GedObject ged, final GedDocument<?> gedDocument,
+    private boolean compareGedDocument(final GedObject ged, final GedDocument<?> gedDocument,
         final String expectedTypeString, final Class<? extends GedDocumentMongo<?>> expectedClass) {
         assertEquals(expectedClass, gedDocument.getClass(), "Wrong class");
         assertEquals(ged.getString(), gedDocument.getString(), "Content mismatch");

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RepositoryFinderTest.java
@@ -36,6 +36,7 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
+@SuppressWarnings({ "PMD.TooManyMethods" })
 public final class RepositoryFinderTest {
     /** */
     private static final String BOGUS_ID = "XYZZY";

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -1,8 +1,8 @@
 package org.schoellerfamily.gedbrowser.persistence.mongo.repository.test;
 
+import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
-import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 
 import java.io.IOException;
 import java.util.Map;
@@ -51,8 +51,8 @@ import org.springframework.test.context.junit.jupiter.SpringExtension;
  */
 @ExtendWith(SpringExtension.class)
 @ContextConfiguration(classes = { MongoTestConfiguration.class })
-@SuppressWarnings({ "PMD.ExcessiveImports" })
-public final class RootRepositoryTest {
+@SuppressWarnings({ "PMD.ExcessiveImports", "PMD.CouplingBetweenObjects", "PMD.TooManyMethods" })
+final class RootRepositoryTest {
     /** */
     @Autowired
     private transient RootDocumentRepositoryMongo rootDocumentRepository;
@@ -322,7 +322,7 @@ public final class RootRepositoryTest {
         final Iterable<RootDocument> list = rootDocumentRepository.findAll(rootDocument);
         int count = 0;
         for (final RootDocument root1 : list) {
-            checkEquals("Type string mismatch", "root", root1.getType());
+            equals("Type string mismatch", "root", root1.getType());
             count++;
         }
         assertEquals(1, count, "Should only be one root");
@@ -335,7 +335,7 @@ public final class RootRepositoryTest {
             .findAll(rootDocument.getFilename());
         int count = 0;
         for (final RootDocument root1 : list) {
-            checkEquals("Type string mismatch", "root", root1.getType());
+            equals("Type string mismatch", "root", root1.getType());
             count++;
         }
         assertEquals(1, count, "Should only be one root");
@@ -355,7 +355,7 @@ public final class RootRepositoryTest {
      * @param expected expected value
      * @param actual   actual value
      */
-    private void checkEquals(final String message, final Object expected, final Object actual) {
+    private void equals(final String message, final Object expected, final Object actual) {
         assertEquals(expected, actual, message);
     }
 }

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/test/RootRepositoryTest.java
@@ -322,7 +322,7 @@ final class RootRepositoryTest {
         final Iterable<RootDocument> list = rootDocumentRepository.findAll(rootDocument);
         int count = 0;
         for (final RootDocument root1 : list) {
-            equals("Type string mismatch", "root", root1.getType());
+            validate("Type string mismatch", "root", root1.getType());
             count++;
         }
         assertEquals(1, count, "Should only be one root");
@@ -335,7 +335,7 @@ final class RootRepositoryTest {
             .findAll(rootDocument.getFilename());
         int count = 0;
         for (final RootDocument root1 : list) {
-            equals("Type string mismatch", "root", root1.getType());
+            validate("Type string mismatch", "root", root1.getType());
             count++;
         }
         assertEquals(1, count, "Should only be one root");
@@ -355,7 +355,7 @@ final class RootRepositoryTest {
      * @param expected expected value
      * @param actual   actual value
      */
-    private void equals(final String message, final Object expected, final Object actual) {
+    private void validate(final String message, final Object expected, final Object actual) {
         assertEquals(expected, actual, message);
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -47,7 +47,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - gl120368</title>",
@@ -72,7 +72,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - mini-schoeller</title>",
@@ -95,7 +95,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -48,7 +48,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - gl120368</title>",
@@ -73,7 +73,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - mini-schoeller</title>",
@@ -96,7 +96,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
@@ -47,18 +46,19 @@ class HeadControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("<title>Header - gl120368</title>")
-            .contains("File:</span> C:\\Users\\Phil\\Documents\\W0803.GED")
-            .contains("GEDCOM:</span> 5.5, LINEAGE-LINKED")
-            .contains("Character Set:</span> ANSI")
-            .contains("Destination:</span> FTM")
-            .contains("Submitter:</span> <a class=\"name\""
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Header - gl120368</title>",
+                    "File:</span> C:\\Users\\Phil\\Documents\\W0803.GED",
+                    "GEDCOM:</span> 5.5, LINEAGE-LINKED",
+                    "Character Set:</span> ANSI",
+                    "Destination:</span> FTM",
+                    "Submitter:</span> <a class=\"name\""
                     + " href=\"submitter?db=gl120368&amp;id=U1\">Phil Williams"
-                    + " [U1]</a>")
-            .contains(getMenu("A"));
+                    + " [U1]</a>",
+                    getMenu("A"));
     }
 
     /** */
@@ -71,18 +71,19 @@ class HeadControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("<title>Header - mini-schoeller</title>")
-            .contains("Submitter:</span> <a class=\"name\""
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Header - mini-schoeller</title>",
+                    "Submitter:</span> <a class=\"name\""
                     + " href=\"submitter?db=mini-schoeller&amp;"
-                    + "id=SUB1\">Richard Schoeller [SUB1]</a>")
-            .contains("GEDCOM:</span> 5.5.1, LINEAGE-LINKED")
-            .contains("Destination:</span> GED55")
-            .contains("Date:</span> 16 FEB 2001 22:04</li>")
-            .contains("Character Set:</span> UTF-8")
-            .contains(getMenu("mini-schoeller", "A"));
+                    + "id=SUB1\">Richard Schoeller [SUB1]</a>",
+                    "GEDCOM:</span> 5.5.1, LINEAGE-LINKED",
+                    "Destination:</span> GED55",
+                    "Date:</span> 16 FEB 2001 22:04</li>",
+                    "Character Set:</span> UTF-8",
+                    getMenu("mini-schoeller", "A"));
     }
 
     /** */
@@ -93,8 +94,9 @@ class HeadControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/HeadControllerTest.java
@@ -47,7 +47,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - gl120368</title>",
@@ -72,7 +72,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Header - mini-schoeller</title>",
@@ -95,7 +95,7 @@ class HeadControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -52,7 +52,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - C - gl120368</title>",
@@ -72,7 +72,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - B - gl120368</title>",
@@ -92,7 +92,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -107,7 +107,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString()
                     .contains(

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -53,7 +53,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - C - gl120368</title>",
@@ -72,7 +72,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - B - gl120368</title>",
@@ -91,7 +91,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -106,7 +106,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString()
                     .contains(

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -52,7 +52,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - C - gl120368</title>",
@@ -71,7 +71,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - B - gl120368</title>",
@@ -90,7 +90,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -105,7 +105,7 @@ class IndexControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString()
                     .contains(

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
@@ -56,8 +57,7 @@ class IndexControllerTest implements MenuTestHelper {
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - C - gl120368</title>",
-                    "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                        + " class=\"name\">[?]</a>   </span>",
+                    "id=\"letter-?\" href=\"surnames?db=gl120368&amp;letter=?\"",
                     "<li id=\"I2508\"><a href=\"person?db=gl120368&amp;id=",
                     getMenu("C"));
     }
@@ -76,8 +76,7 @@ class IndexControllerTest implements MenuTestHelper {
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Index - B - gl120368</title>",
-                    "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                        + " class=\"name\">[?]</a>   </span>",
+                    "id=\"letter-?\" href=\"surnames?db=gl120368&amp;letter=?\"",
                     "<li id=\"I2561\"><a href=\"person?db=gl120368&amp;id=",
                     getMenu("B"));
     }
@@ -112,8 +111,7 @@ class IndexControllerTest implements MenuTestHelper {
                 .asString()
                     .contains(
                         "<title>Index - q - gl120368</title>",
-                        "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                            + " class=\"name\">[?]</a>   </span>",
+                        "id=\"letter-?\" href=\"surnames?db=gl120368&amp;letter=?\"",
                         getMenu("q"))
                     .doesNotContain("<li><a href=\"person?db=gl120368&amp;id=");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/IndexControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
@@ -52,13 +51,15 @@ class IndexControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Index - C - gl120368</title>")
-            .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                + " class=\"name\">[?]</a>   </span>")
-            .contains("<li id=\"I2508\"><a href=\"person?db=gl120368&amp;id=")
-            .contains(getMenu("C"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Index - C - gl120368</title>",
+                    "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
+                        + " class=\"name\">[?]</a>   </span>",
+                    "<li id=\"I2508\"><a href=\"person?db=gl120368&amp;id=",
+                    getMenu("C"));
     }
 
     /** */
@@ -70,13 +71,15 @@ class IndexControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Index - B - gl120368</title>")
-            .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                + " class=\"name\">[?]</a>   </span>")
-            .contains("<li id=\"I2561\"><a href=\"person?db=gl120368&amp;id=")
-            .contains(getMenu("B"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Index - B - gl120368</title>",
+                    "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
+                        + " class=\"name\">[?]</a>   </span>",
+                    "<li id=\"I2561\"><a href=\"person?db=gl120368&amp;id=",
+                    getMenu("B"));
     }
 
     /** */
@@ -88,9 +91,10 @@ class IndexControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -102,12 +106,15 @@ class IndexControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Index - q - gl120368</title>")
-            .contains("<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
-                + " class=\"name\">[?]</a>   </span>")
-            .doesNotContain("<li><a href=\"person?db=gl120368&amp;id=")
-            .contains(getMenu("q"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString()
+                    .contains(
+                        "<title>Index - q - gl120368</title>",
+                        "<span><a id=\"letter-?\"" + " href=\"surnames?db=gl120368&amp;letter=?\""
+                            + " class=\"name\">[?]</a>   </span>",
+                        getMenu("q"))
+                    .doesNotContain("<li><a href=\"person?db=gl120368&amp;id=");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -49,7 +49,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living - gl120368</title>",
@@ -65,7 +65,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -49,7 +49,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living - gl120368</title>",
@@ -65,7 +65,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -50,7 +50,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living - gl120368</title>",
@@ -66,7 +66,7 @@ class LivingControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -49,10 +49,12 @@ class LivingControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Living - gl120368</title>")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Living - gl120368</title>",
+                    getMenu("A"));
     }
 
     /** */
@@ -63,8 +65,9 @@ class LivingControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LivingControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -87,11 +87,13 @@ class LoginControllerTest {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
-            .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
-                    + refererUrl + "\"/>");
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Login to GedBrowser</title>",
+                    "<input type=\"hidden\" name=\"targetUrl\" value=\""
+                        + refererUrl + "\"/>");
     }
 
     /** */
@@ -104,11 +106,13 @@ class LoginControllerTest {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Login to GedBrowser</title>")
-            .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
-                    + refererUrl + "\"/>");
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Login to GedBrowser</title>",
+                    "<input type=\"hidden\" name=\"targetUrl\" value=\""
+                        + refererUrl + "\"/>");
     }
 
     /**

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
@@ -28,7 +27,6 @@ import org.springframework.web.client.RestTemplate;
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings({ "PMD.JUnitTestsShouldIncludeAssert" })
 class LoginControllerTest {
 
     /**
@@ -54,10 +52,13 @@ class LoginControllerTest {
         final ResponseEntity<String> entity =
                 restTemplate.getForEntity(url, String.class);
 
-        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(entity.getBody()).contains("<title>Login to GedBrowser</title>")
-            .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
-                    + refererUrl + "\"/>");
+        assertThat(entity)
+            .returns(HttpStatus.OK, ResponseEntity::getStatusCode)
+            .extracting(ResponseEntity::getBody)
+                .asString().contains(
+                    "<title>Login to GedBrowser</title>",
+                    "<input type=\"hidden\" name=\"targetUrl\" value=\""
+                        + refererUrl + "\"/>");
     }
 
     /** */
@@ -71,10 +72,13 @@ class LoginControllerTest {
         final ResponseEntity<String> entity =
                 restTemplate.getForEntity(url, String.class);
 
-        assertThat(entity.getStatusCode()).isEqualTo(HttpStatus.OK);
-        assertThat(entity.getBody()).contains("<title>Login to GedBrowser</title>")
-            .contains("<input type=\"hidden\" name=\"targetUrl\" value=\""
-                    + refererUrl + "\"/>");
+        assertThat(entity)
+            .returns(HttpStatus.OK, ResponseEntity::getStatusCode)
+            .extracting(ResponseEntity::getBody)
+                .asString().contains(
+                    "<title>Login to GedBrowser</title>",
+                    "<input type=\"hidden\" name=\"targetUrl\" value=\""
+                        + refererUrl + "\"/>");
     }
 
     /** */

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -93,7 +93,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",
@@ -112,7 +112,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -13,6 +13,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -92,7 +92,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",
@@ -111,7 +111,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -13,7 +13,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/LoginControllerTest.java
@@ -92,7 +92,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",
@@ -111,7 +111,7 @@ class LoginControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Login to GedBrowser</title>",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -46,10 +46,12 @@ class NoteControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>_P_CCINFO 1-1319 - N1 - gl120368")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>_P_CCINFO 1-1319 - N1 - gl120368",
+                    getMenu("A"));
     }
 
     /** */
@@ -60,9 +62,10 @@ class NoteControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -73,9 +76,11 @@ class NoteControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody())
-            .contains("Note XYZZY not found").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "Note XYZZY not found",
+                    getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -47,7 +47,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>_P_CCINFO 1-1319 - N1 - gl120368",
@@ -63,7 +63,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -77,7 +77,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Note XYZZY not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -46,7 +46,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>_P_CCINFO 1-1319 - N1 - gl120368",
@@ -62,7 +62,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -76,7 +76,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Note XYZZY not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -46,7 +46,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>_P_CCINFO 1-1319 - N1 - gl120368",
@@ -62,7 +62,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -76,7 +76,7 @@ class NoteControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Note XYZZY not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/NoteControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -48,7 +48,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living  - I4 - gl120368</title>",
@@ -65,7 +65,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
@@ -82,7 +82,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -96,7 +96,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Person not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -47,7 +47,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living  - I4 - gl120368</title>",
@@ -64,7 +64,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
@@ -81,7 +81,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -95,7 +95,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Person not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -47,10 +47,12 @@ public class PersonControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Living  - I4 - gl120368</title>")
-            .contains(getMenu("?#?"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Living  - I4 - gl120368</title>",
+                    getMenu("?#?"));
     }
 
     /** */
@@ -62,12 +64,13 @@ public class PersonControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
-                + "1951) - I9 - gl120368</title>")
-            .contains(getMenu("W#Williams"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
+                        + "1951) - I9 - gl120368</title>",
+                    getMenu("W#Williams"));
     }
 
     /** */
@@ -78,9 +81,10 @@ public class PersonControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -91,8 +95,11 @@ public class PersonControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Person not found").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "Person not found",
+                    getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PersonControllerTest.java
@@ -47,7 +47,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Living  - I4 - gl120368</title>",
@@ -64,7 +64,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Edwin Elijah A  Williams (13 DEC 1883-ABT AUG "
@@ -81,7 +81,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -95,7 +95,7 @@ public class PersonControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Person not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -46,10 +46,13 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .uri(URI.create(url))
                 .exchange()
                 .returnResult(String.class);
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Places - gl120368</title>")
-            .contains(getMenu("A"));
+
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Places - gl120368</title>",
+                    getMenu("A"));
     }
 
     /** */
@@ -60,8 +63,9 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -47,7 +47,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Places - gl120368</title>",
@@ -63,7 +63,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -47,7 +47,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Places - gl120368</title>",
@@ -63,7 +63,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -48,7 +48,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Places - gl120368</title>",
@@ -64,7 +64,7 @@ public class PlaceIndexControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/PlaceIndexControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -63,7 +63,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "0 HEAD",
@@ -101,7 +101,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
 
@@ -120,7 +120,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Sorry, you aren't authorized to do that!");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -64,7 +64,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "0 HEAD",
@@ -102,7 +102,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
 
@@ -121,7 +121,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Sorry, you aren't authorized to do that!");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -14,6 +14,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -62,20 +62,22 @@ public class SaveControllerTest {
                 .uri(URI.create(url))
                 .exchange()
                 .returnResult(String.class);
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("0 HEAD")
-            .contains("1 SOUR FAMILY_HISTORIAN")
-            .contains("2 VERS 3.1")
-            .contains("2 NAME Family Historian")
-            .contains("2 CORP Calico Pie Limited")
-            .contains("1 FILE C:\\Users\\Phil\\Documents\\W0803.GED")
-            .contains("1 GEDC")
-            .contains("2 VERS 5.5")
-            .contains("2 FORM LINEAGE-LINKED")
-            .contains("1 CHAR ANSI")
-            .contains("1 DEST FTM");
+
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "0 HEAD",
+                    "1 SOUR FAMILY_HISTORIAN",
+                    "2 VERS 3.1",
+                    "2 NAME Family Historian",
+                    "2 CORP Calico Pie Limited",
+                    "1 FILE C:\\Users\\Phil\\Documents\\W0803.GED",
+                    "1 GEDC",
+                    "2 VERS 5.5",
+                    "2 FORM LINEAGE-LINKED",
+                    "1 CHAR ANSI",
+                    "1 DEST FTM");
 
         // Turn off anonymous admin.
         users.remove(user);
@@ -99,9 +101,10 @@ public class SaveControllerTest {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
 
         // Turn off anonymous admin.
         users.remove(user);
@@ -117,9 +120,9 @@ public class SaveControllerTest {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("Sorry, you aren't authorized to do that!");
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Sorry, you aren't authorized to do that!");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -63,7 +63,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "0 HEAD",
@@ -101,7 +101,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
 
@@ -120,7 +120,7 @@ public class SaveControllerTest {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Sorry, you aren't authorized to do that!");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SaveControllerTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -46,7 +46,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>File (merged):"
@@ -63,7 +63,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -77,7 +77,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Source not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -47,7 +47,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>File (merged):"
@@ -64,7 +64,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -78,7 +78,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Source not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,17 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SourceControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.
@@ -55,7 +50,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>File (merged):"
-                        + " C:\\Users\\Phil\\Downloads\\butcher\\butcher.GED" + " - S33750 - gl120368",
+                    + " C:\\Users\\Phil\\Downloads\\butcher\\butcher.GED" + " - S33750 - gl120368",
                     getMenu("A"));
     }
 

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -46,7 +46,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>File (merged):"
@@ -63,7 +63,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -77,7 +77,7 @@ public class SourceControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Source not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourceControllerTest.java
@@ -50,11 +50,13 @@ public class SourceControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>File (merged):"
-            + " C:\\Users\\Phil\\Downloads\\butcher\\butcher.GED" + " - S33750 - gl120368")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>File (merged):"
+                        + " C:\\Users\\Phil\\Downloads\\butcher\\butcher.GED" + " - S33750 - gl120368",
+                    getMenu("A"));
     }
 
     /** */
@@ -65,9 +67,10 @@ public class SourceControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -78,9 +81,11 @@ public class SourceControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        final String responseBody = entity.getResponseBody();
-        assertThat(responseBody).contains("Source not found").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "Source not found",
+                    getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -47,7 +47,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Sources - gl120368</title>",
@@ -70,7 +70,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -47,7 +47,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Sources - gl120368</title>",
@@ -70,7 +70,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -48,7 +48,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Sources - gl120368</title>",
@@ -71,7 +71,7 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -51,17 +51,19 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Sources - gl120368</title>")
-            .contains("Sources for dataset: gl120368</h2>")
-            .contains("href=\"source?db=gl120368&amp;id=S2050\" class=\"name\""
-                    + " id=\"source-S2050\">Parish records (S2050)")
-            .contains("href=\"source?db=gl120368&amp;id=S2124\" class=\"name\""
-                    + " id=\"source-S2124\">Www.peake.net (S2124)")
-            .contains("href=\"source?db=gl120368&amp;id=S2122\" class=\"name\""
-                    + " id=\"source-S2122\">Will of R Harris (S2122)")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Sources - gl120368</title>",
+                    "Sources for dataset: gl120368</h2>",
+                    "href=\"source?db=gl120368&amp;id=S2050\" class=\"name\""
+                        + " id=\"source-S2050\">Parish records (S2050)",
+                    "href=\"source?db=gl120368&amp;id=S2124\" class=\"name\""
+                        + " id=\"source-S2124\">Www.peake.net (S2124)",
+                    "href=\"source?db=gl120368&amp;id=S2122\" class=\"name\""
+                        + " id=\"source-S2122\">Will of R Harris (S2122)",
+                    getMenu("A"));
     }
 
     /** */
@@ -72,8 +74,9 @@ public class SourcesControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SourcesControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,17 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SourcesControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -46,7 +46,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>B1 - gl120368",
@@ -63,7 +63,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -78,7 +78,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submission not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -46,7 +46,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>B1 - gl120368",
@@ -63,7 +63,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -78,7 +78,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submission not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -47,7 +47,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>B1 - gl120368",
@@ -64,7 +64,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -79,7 +79,7 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submission not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,17 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SubmissionControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmissionControllerTest.java
@@ -50,9 +50,12 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>B1 - gl120368").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>B1 - gl120368",
+                    getMenu("A"));
     }
 
     /** */
@@ -64,9 +67,10 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -78,8 +82,11 @@ public class SubmissionControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Submission not found").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "Submission not found",
+                    getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -47,7 +47,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Phil Williams - U1 - gl120368</title>",
@@ -65,7 +65,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Arthur PUNCHARD - U2 - gl120368</title>",
@@ -84,7 +84,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Created by FamilySearch (TM) Internet"
@@ -104,7 +104,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -119,7 +119,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submitter not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -46,7 +46,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Phil Williams - U1 - gl120368</title>",
@@ -64,7 +64,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Arthur PUNCHARD - U2 - gl120368</title>",
@@ -83,7 +83,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Created by FamilySearch (TM) Internet"
@@ -103,7 +103,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -118,7 +118,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submitter not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -46,7 +46,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Phil Williams - U1 - gl120368</title>",
@@ -64,7 +64,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Arthur PUNCHARD - U2 - gl120368</title>",
@@ -83,7 +83,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Created by FamilySearch (TM) Internet"
@@ -103,7 +103,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }
@@ -118,7 +118,7 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "Submitter not found",

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -50,11 +50,13 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Phil Williams - U1 - gl120368</title>")
-            .contains("Name:</span> Phil Williams")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Phil Williams - U1 - gl120368</title>",
+                    "Name:</span> Phil Williams",
+                    getMenu("A"));
     }
 
     /** */
@@ -66,12 +68,14 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Arthur PUNCHARD - U2 - gl120368</title>")
-            .contains("Name:</span> Arthur PUNCHARD")
-            .contains("Changed:</span> 24 MAR 2007")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Arthur PUNCHARD - U2 - gl120368</title>",
+                    "Name:</span> Arthur PUNCHARD",
+                    "Changed:</span> 24 MAR 2007",
+                    getMenu("A"));
     }
 
     /** */
@@ -83,15 +87,16 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody())
-            .contains("<title>Created by FamilySearch (TM) Internet"
-                + " Genealogy Service - U4 - gl120368</title>")
-            .contains("Name:</span> Created by FamilySearch")
-            .contains("Address:</span> 50 East North Temple Street<br/>")
-            .contains("Salt Lake City, Utah 84150")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Created by FamilySearch (TM) Internet"
+                        + " Genealogy Service - U4 - gl120368</title>",
+                    "Name:</span> Created by FamilySearch",
+                    "Address:</span> 50 East North Temple Street<br/>",
+                    "Salt Lake City, Utah 84150",
+                    getMenu("A"));
     }
 
     /** */
@@ -102,9 +107,10 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 
     /** */
@@ -116,8 +122,11 @@ public class SubmitterControllerTest implements MenuTestHelper {
             .exchange()
             .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Submitter not found").contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "Submitter not found",
+                    getMenu("A"));
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,17 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class,
     TestConfiguration.class }, webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = { "management.port=0" })
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SubmitterControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmitterControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -12,7 +12,6 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.net.URI;
 
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.schoellerfamily.gedbrowser.Application;
 import org.schoellerfamily.gedbrowser.test.TestConfiguration;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -13,21 +12,17 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;
 
 /**
  * @author Dick Schoeller
  */
-@ExtendWith(SpringExtension.class)
 @SpringBootTest(classes = { Application.class, TestConfiguration.class },
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
 @TestPropertySource(properties = {"management.port=0"})
 @AutoConfigureRestTestClient
-@SuppressWarnings("PMD.JUnitTestsShouldIncludeAssert")
 public class SubmittersControllerTest implements MenuTestHelper {
     /**
      * Not sure what this is good for.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -47,7 +47,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Submitters - gl120368</title>",
@@ -79,7 +79,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND.value(), result -> result.getStatus().value())
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -48,7 +48,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.OK, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Submitters - gl120368</title>",
@@ -80,7 +80,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
+            .returns(HttpStatus.NOT_FOUND, EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -51,26 +51,28 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.OK.value()));
-        assertThat(entity.getResponseBody()).contains("<title>Submitters - gl120368</title>")
-            .contains("Submitters for dataset: gl120368</h2>")
-            .contains("href=\"submitter?db=gl120368&amp;id=U1\">Phil Williams")
-            .contains("href=\"submitter?db=gl120368&amp;id=U3\"> ")
-            .contains("href=\"submitter?db=gl120368&amp;id=U14\">A K Robinson")
-            .contains("href=\"submitter?db=gl120368&amp;id=U15\">Michael ")
-            .contains("href=\"submitter?db=gl120368&amp;id=U2\">Arthur PUNCHA")
-            .contains("href=\"submitter?db=gl120368&amp;id=U4\">Created by Fa")
-            .contains("href=\"submitter?db=gl120368&amp;id=U5\">Paul Alger")
-            .contains("href=\"submitter?db=gl120368&amp;id=U6\">Jim Beecroft")
-            .contains("href=\"submitter?db=gl120368&amp;id=U7\">ken stel")
-            .contains("href=\"submitter?db=gl120368&amp;id=U8\">Mark Willis B")
-            .contains("href=\"submitter?db=gl120368&amp;id=U9\">Patricia Fisc")
-            .contains("href=\"submitter?db=gl120368&amp;id=U10\">Hirt-Klooze")
-            .contains("href=\"submitter?db=gl120368&amp;id=U11\">Lester LeMay")
-            .contains("href=\"submitter?db=gl120368&amp;id=U12\">David A. Blo")
-            .contains("href=\"submitter?db=gl120368&amp;id=U13\">Dave Morris")
-            .contains(getMenu("A"));
+        assertThat(entity)
+            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains(
+                    "<title>Submitters - gl120368</title>",
+                    "Submitters for dataset: gl120368</h2>",
+                    "href=\"submitter?db=gl120368&amp;id=U1\">Phil Williams",
+                    "href=\"submitter?db=gl120368&amp;id=U3\"> ",
+                    "href=\"submitter?db=gl120368&amp;id=U14\">A K Robinson",
+                    "href=\"submitter?db=gl120368&amp;id=U15\">Michael ",
+                    "href=\"submitter?db=gl120368&amp;id=U2\">Arthur PUNCHA",
+                    "href=\"submitter?db=gl120368&amp;id=U4\">Created by Fa",
+                    "href=\"submitter?db=gl120368&amp;id=U5\">Paul Alger",
+                    "href=\"submitter?db=gl120368&amp;id=U6\">Jim Beecroft",
+                    "href=\"submitter?db=gl120368&amp;id=U7\">ken stel",
+                    "href=\"submitter?db=gl120368&amp;id=U8\">Mark Willis B",
+                    "href=\"submitter?db=gl120368&amp;id=U9\">Patricia Fisc",
+                    "href=\"submitter?db=gl120368&amp;id=U10\">Hirt-Klooze",
+                    "href=\"submitter?db=gl120368&amp;id=U11\">Lester LeMay",
+                    "href=\"submitter?db=gl120368&amp;id=U12\">David A. Blo",
+                    "href=\"submitter?db=gl120368&amp;id=U13\">Dave Morris",
+                    getMenu("A"));
     }
 
     /** */
@@ -81,8 +83,9 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .exchange()
                 .returnResult(String.class);
 
-        final HttpStatusCode status = entity.getStatus();
-        assertThat(status).isEqualTo(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()));
-        assertThat(entity.getResponseBody()).contains("Data set not found");
+        assertThat(entity)
+            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .extracting(EntityExchangeResult::getResponseBody)
+                .asString().contains("Data set not found");
     }
 }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -47,7 +47,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.OK.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.OK.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains(
                     "<title>Submitters - gl120368</title>",
@@ -79,7 +79,7 @@ public class SubmittersControllerTest implements MenuTestHelper {
                 .returnResult(String.class);
 
         assertThat(entity)
-            .returns(HttpStatus.NOT_FOUND.value(), EntityExchangeResult::getStatus)
+            .returns(HttpStatusCode.valueOf(HttpStatus.NOT_FOUND.value()), EntityExchangeResult::getStatus)
             .extracting(EntityExchangeResult::getResponseBody)
                 .asString().contains("Data set not found");
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/controller/test/SubmittersControllerTest.java
@@ -12,6 +12,7 @@ import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureRestTe
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.client.EntityExchangeResult;
 import org.springframework.test.web.servlet.client.RestTestClient;

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderTest.java
@@ -28,7 +28,8 @@ import com.google.maps.model.LocationType;
 /**
  * @author Dick Schoeller
  */
-public final class GeocodeResultBuilderTest extends GeocodeChecker {
+@SuppressWarnings({ "PMD.TooManyMethods" })
+public final class GeocodeResultBuilderTest extends GeocodeValidator {
     /** */
     private final GeocodeResultBuilder builder = new GeocodeResultBuilder();
 
@@ -68,7 +69,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH",
             new GeoServiceGeocodingResult());
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -82,7 +83,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             null, null, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -95,7 +96,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             null, null, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /**
@@ -121,7 +122,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             "formatted address", null, null, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -131,7 +132,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             null, false, "ladkjsfdlaskjfdlfj");
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -143,7 +144,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             postcodeLocalities, null, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -155,7 +156,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             types, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -166,7 +167,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -181,7 +182,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -194,7 +195,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -233,7 +234,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -245,7 +246,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -258,7 +259,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -297,7 +298,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
             geometry, null, false, null);
         final GeoServiceItem bgci = new GeoServiceItem("XYZZY", "PLUGH", bgr);
         final GeoCodeItem gci = builder.toGeoCodeItem(bgci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -305,7 +306,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
     void testPointToLatLng() {
         final Point point = new Point(1.0, 2.0);
         final LatLng latLng = builder.toLatLng(point);
-        assertTrue(checker(latLng, point), "coordinates should match");
+        assertTrue(validate(latLng, point), "coordinates should match");
     }
 
     /** */
@@ -319,7 +320,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
     void testLngLatAltToLatLng() {
         final LngLatAlt lngLatAlt = new LngLatAlt(1.0, 2.0);
         final LatLng latLng = builder.toLatLng(lngLatAlt);
-        assertTrue(checker(latLng, lngLatAlt), "coordinates should match");
+        assertTrue(validate(latLng, lngLatAlt), "coordinates should match");
     }
 
     /** */
@@ -333,7 +334,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
     void testLatLngToPoint() {
         final LatLng latLng = new LatLng(1.0, 2.0);
         final Point point = builder.toPoint(latLng);
-        assertTrue(checker(latLng, point), "coordinates should match");
+        assertTrue(validate(latLng, point), "coordinates should match");
     }
 
     /** */
@@ -347,7 +348,7 @@ public final class GeocodeResultBuilderTest extends GeocodeChecker {
     void testLatLngToLngLatAlt() {
         final LatLng latLng = new LatLng(1.0, 2.0);
         final LngLatAlt lngLatAlt = builder.toLngLatAlt(latLng);
-        assertTrue(checker(latLng, lngLatAlt), "coordinates should match");
+        assertTrue(validate(latLng, lngLatAlt), "coordinates should match");
     }
 
     /** */

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderToBackupTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeResultBuilderToBackupTest.java
@@ -22,7 +22,8 @@ import com.google.maps.model.LocationType;
 /**
  * @author Dick Schoeller
  */
-public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
+@SuppressWarnings({ "PMD.TooManyMethods" })
+public class GeocodeResultBuilderToBackupTest extends GeocodeValidator {
     /** */
     private final GeocodeResultBuilder builder = new GeocodeResultBuilder();
 
@@ -53,7 +54,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
     void testToBackupGeoCodeItemNullResult() {
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", null);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -62,7 +63,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         final GeocodingResult gr = new GeocodingResult();
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -77,7 +78,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.addressComponents[0].types[0] = AddressComponentType.ADMINISTRATIVE_AREA_LEVEL_1;
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -91,7 +92,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.addressComponents[0].types = new AddressComponentType[0];
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -101,7 +102,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.formattedAddress = "formatted address";
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -111,7 +112,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.placeId = "kfdhasfokjhkljdasf";
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -122,7 +123,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.postcodeLocalities[0] = "foobar";
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -133,7 +134,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.types[0] = AddressType.ADMINISTRATIVE_AREA_LEVEL_1;
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -143,7 +144,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry = new Geometry();
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -156,7 +157,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry.location = new LatLng(lat, lng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -212,7 +213,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry.bounds.southwest = new LatLng(swLat, swLng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -223,7 +224,7 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry.locationType = LocationType.APPROXIMATE;
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 
     /** */
@@ -279,6 +280,6 @@ public class GeocodeResultBuilderToBackupTest extends GeocodeChecker {
         gr.geometry.viewport.southwest = new LatLng(swLat, swLng);
         final GeoCodeItem gci = new GeoCodeItem("XYZZY", "PLUGH", gr);
         final GeoServiceItem bgci = builder.toGeoServiceItem(gci);
-        assertTrue(checker(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
+        assertTrue(validate(gci.getGeocodingResult(), bgci.getResult()), "Failed comparison");
     }
 }

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeValidator.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeValidator.java
@@ -22,15 +22,15 @@ import com.google.maps.model.LocationType;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("PMD.GodClass")
-public class GeocodeChecker {
+@SuppressWarnings({ "PMD.TooManyMethods", "PMD.SimplifyBooleanReturns", "PMD.UseVarargs",
+    "PMD.UnusedPrivateMethod" })
+public class GeocodeValidator {
     /**
      * @param result a geocoding result
      * @param backupResult a backup geocoding result
      * @return true if they match
      */
-    @SuppressWarnings({ "PMD.CyclomaticComplexity", "PMD.NPathComplexity" })
-    protected boolean checker(final GeocodingResult result,
+    protected boolean validate(final GeocodingResult result,
             final GeoServiceGeocodingResult backupResult) {
         if (result == null && backupResult == null) {
             return true;
@@ -38,25 +38,25 @@ public class GeocodeChecker {
         if (result == null || backupResult == null) {
             return false;
         }
-        if (!checker(result.addressComponents,
+        if (!validate(result.addressComponents,
                 backupResult.getAddressComponents())) {
             return false;
         }
-        if (!checker(result.formattedAddress,
+        if (!validate(result.formattedAddress,
                 backupResult.getFormattedAddress())) {
             return false;
         }
-        if (!checker(result.geometry, backupResult.getGeometry())) {
+        if (!validate(result.geometry, backupResult.getGeometry())) {
             return false;
         }
-        if (!checker(result.placeId, backupResult.getPlaceId())) {
+        if (!validate(result.placeId, backupResult.getPlaceId())) {
             return false;
         }
-        if (!checker(result.postcodeLocalities,
+        if (!validate(result.postcodeLocalities,
                 backupResult.getPostcodeLocalities())) {
             return false;
         }
-        if (!checker(result.types, backupResult.getTypes())) {
+        if (!validate(result.types, backupResult.getTypes())) {
             return false;
         }
         return result.partialMatch == backupResult.isPartialMatch();
@@ -67,8 +67,7 @@ public class GeocodeChecker {
      * @param backupAddressComponents address components from backup model
      * @return true if all match
      */
-    @SuppressWarnings("PMD.UseVarargs")
-    private boolean checker(final AddressComponent[] addressComponents,
+    private boolean validate(final AddressComponent[] addressComponents,
             final AddressComponent[] backupAddressComponents) {
         if (addressComponents == null && backupAddressComponents == null) {
             return true;
@@ -80,7 +79,7 @@ public class GeocodeChecker {
             return false;
         }
         for (int i = 0; i < addressComponents.length; i++) {
-            if (!checker(addressComponents[i], backupAddressComponents[i])) {
+            if (!validate(addressComponents[i], backupAddressComponents[i])) {
                 return false;
             }
         }
@@ -92,7 +91,7 @@ public class GeocodeChecker {
      * @param backupAddressComponent a backup address component
      * @return true if they match
      */
-    private boolean checker(final AddressComponent addressComponent,
+    private boolean validate(final AddressComponent addressComponent,
             final AddressComponent backupAddressComponent) {
         if (addressComponent == null && backupAddressComponent == null) {
             return true;
@@ -100,15 +99,15 @@ public class GeocodeChecker {
         if (addressComponent == null || backupAddressComponent == null) {
             return false;
         }
-        if (!checker(addressComponent.longName,
+        if (!validate(addressComponent.longName,
                 backupAddressComponent.longName)) {
             return false;
         }
-        if (!checker(addressComponent.shortName,
+        if (!validate(addressComponent.shortName,
                 backupAddressComponent.shortName)) {
             return false;
         }
-        return checker(addressComponent.types,
+        return validate(addressComponent.types,
                 backupAddressComponent.types);
     }
 
@@ -117,7 +116,7 @@ public class GeocodeChecker {
      * @param backupString string from backup model
      * @return true if strings match
      */
-    private boolean checker(final String string, final String backupString) {
+    private boolean validate(final String string, final String backupString) {
         if (string == null && backupString == null) {
             return true;
         }
@@ -132,8 +131,7 @@ public class GeocodeChecker {
      * @param backupTypes array of types from backup
      * @return true if they match
      */
-    @SuppressWarnings("PMD.UseVarargs")
-    private boolean checker(final AddressComponentType[] types,
+    private boolean validate(final AddressComponentType[] types,
             final AddressComponentType[] backupTypes) {
         if (types == null && backupTypes == null) {
             return true;
@@ -145,7 +143,7 @@ public class GeocodeChecker {
             return false;
         }
         for (int i = 0; i < types.length; i++) {
-            if (!checker(types[i], backupTypes[i])) {
+            if (!validate(types[i], backupTypes[i])) {
                 return false;
             }
         }
@@ -157,7 +155,7 @@ public class GeocodeChecker {
      * @param type1 type from backup
      * @return true if they match
      */
-    private boolean checker(final AddressComponentType type0,
+    private boolean validate(final AddressComponentType type0,
             final AddressComponentType type1) {
         if (type0 == null && type1 == null) {
             return true;
@@ -173,11 +171,7 @@ public class GeocodeChecker {
      * @param featureCollection the collection that represents the geometry
      * @return true if they match
      */
-    @SuppressWarnings({ "PMD.CyclomaticComplexity",
-        "PMD.ModifiedCyclomaticComplexity",
-        "PMD.NPathComplexity",
-        "PMD.StdCyclomaticComplexity" })
-    private boolean checker(final Geometry geometry,
+    private boolean validate(final Geometry geometry,
             final FeatureCollection featureCollection) {
         if (isEmpty(geometry) && isEmpty(featureCollection)) {
             return true;
@@ -185,39 +179,39 @@ public class GeocodeChecker {
         if (isEmpty(geometry) || isEmpty(featureCollection)) {
             return false;
         }
-        Feature location;
+        final Feature location;
         if (featureCollection.getFeatures().isEmpty()) {
             location = null;
         } else {
             location = featureCollection.getFeatures().get(0);
         }
         if (location == null) {
-            if (!checker(geometry.location, (Point) null)) {
+            if (!validate(geometry.location, (Point) null)) {
                 return false;
             }
-            if (!checker(geometry.locationType, (LocationType) null)) {
+            if (!validate(geometry.locationType, (LocationType) null)) {
                 return false;
             }
         } else {
-            if (!checker(geometry.location, (Point) location.getGeometry())) {
+            if (!validate(geometry.location, (Point) location.getGeometry())) {
                 return false;
             }
-            if (!checker(geometry.locationType,
+            if (!validate(geometry.locationType,
                     location.getProperty("locationType"))) {
                 return false;
             }
         }
         if (featureCollection.getFeatures().isEmpty()) {
-            if (!checker("bounds", geometry.bounds, (Feature) null)) {
+            if (!validate("bounds", geometry.bounds, (Feature) null)) {
                 return false;
             }
-            return checker("viewport", geometry.viewport, null);
+            return validate("viewport", geometry.viewport, null);
         } else {
-            if (!checker("bounds", geometry.bounds,
+            if (!validate("bounds", geometry.bounds,
                     featureCollection.getFeatures().get(1))) {
                 return false;
             }
-            return checker("viewport", geometry.viewport,
+            return validate("viewport", geometry.viewport,
                     featureCollection.getFeatures().get(2));
         }
     }
@@ -325,7 +319,7 @@ public class GeocodeChecker {
      * @param backupBounds backup boundary
      * @return true if they match
      */
-    private boolean checker(final String id, final Bounds bounds,
+    private boolean validate(final String id, final Bounds bounds,
             final Feature backupBounds) {
         if (bounds == null && backupBounds == null) {
             return true;
@@ -342,11 +336,11 @@ public class GeocodeChecker {
         final Polygon polygon = (Polygon) backupBounds.getGeometry();
         final List<LngLatAlt> list = polygon.getCoordinates().get(0);
         final LngLatAlt northeast = list.get(2);
-        if (!checker(bounds.northeast, northeast)) {
+        if (!validate(bounds.northeast, northeast)) {
             return false;
         }
         final LngLatAlt southwest = list.get(0);
-        return checker(bounds.southwest, southwest);
+        return validate(bounds.southwest, southwest);
     }
 
     /**
@@ -354,7 +348,7 @@ public class GeocodeChecker {
      * @param point GeoJSON Point version of location
      * @return true if they match
      */
-    protected boolean checker(final LatLng latLng, final Point point) {
+    protected boolean validate(final LatLng latLng, final Point point) {
         if (latLng == null && point == null) {
             return true;
         }
@@ -375,7 +369,7 @@ public class GeocodeChecker {
      * @param lla GeoJSON LngLatAlt version of location
      * @return true if they match
      */
-    protected boolean checker(final LatLng latLng, final LngLatAlt lla) {
+    protected boolean validate(final LatLng latLng, final LngLatAlt lla) {
         if (latLng == null && lla == null) {
             return true;
         }
@@ -407,7 +401,7 @@ public class GeocodeChecker {
      * @param locationType1 second location type
      * @return true if they match
      */
-    private boolean checker(final LocationType locationType0,
+    private boolean validate(final LocationType locationType0,
             final LocationType locationType1) {
         if (locationType0 == null && locationType1 == null) {
             return true;
@@ -423,8 +417,7 @@ public class GeocodeChecker {
      * @param array1 string array 2
      * @return true if they match
      */
-    @SuppressWarnings("PMD.UseVarargs")
-    private boolean checker(final String[] array0, final String[] array1) {
+    private boolean validate(final String[] array0, final String[] array1) {
         if (array0 == null && array1 == null) {
             return true;
         }
@@ -447,8 +440,7 @@ public class GeocodeChecker {
      * @param types1 second array
      * @return true if they match
      */
-    @SuppressWarnings("PMD.UseVarargs")
-    private boolean checker(final AddressType[] types0,
+    private boolean validate(final AddressType[] types0,
             final AddressType[] types1) {
         if (types0 == null && types1 == null) {
             return true;

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/test/GeoServiceItemComparatorTest.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/test/GeoServiceItemComparatorTest.java
@@ -13,12 +13,12 @@ import org.schoellerfamily.geoservice.model.GeoServiceGeocodingResult;
 import org.schoellerfamily.geoservice.model.GeoServiceGeometry;
 import org.schoellerfamily.geoservice.model.GeoServiceItem;
 import org.schoellerfamily.geoservice.model.GeoServiceItemComparator;
-import org.schoellerfamily.geoservice.model.builder.test.GeocodeChecker;
+import org.schoellerfamily.geoservice.model.builder.test.GeocodeValidator;
 
 /**
  * @author Dick Schoeller
  */
-public class GeoServiceItemComparatorTest extends GeocodeChecker {
+public class GeoServiceItemComparatorTest extends GeocodeValidator {
     /** */
     private GeoServiceGeocodingResult bgr;
 


### PR DESCRIPTION
This pull request primarily addresses improvements to test code quality and maintainability in the `gedbrowser-mongo-dao` module. The main changes include broadening PMD suppression annotations to cover additional warnings, removing unnecessary `public` and `final` modifiers from test classes, and refactoring test assertion helper methods for better clarity and consistency.

### Code quality and PMD suppression:

* Expanded `@SuppressWarnings` annotations in test classes (`BadLoadTest`, `GedDocumentMongoToGedObjectConverterTest`, `GedObjectToGedDocumentMongoConverterTest`, and `RepositoryFinderTest`) to suppress `"PMD.TooManyMethods"` and `"PMD.CouplingBetweenObjects"` warnings, improving code maintainability and reducing false positives from static analysis. [[1]](diffhunk://#diff-9d638531fe68eaae272fcb054d2fe4ea09c15eb352d9ecb79ddccf50238731abL39-R42) [[2]](diffhunk://#diff-b64d3ff41c5215e2dae2d18a01d8a9b1c3955d3d107fa9ac57ae3ad48d8c1655L69-R72) [[3]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L68-R68) [[4]](diffhunk://#diff-50039730037130c8cbe6617347323ba88ef11f7303bf57144d962fbe088c2a2aR39)

### Test class definition cleanup:

* Removed unnecessary `public` and `final` modifiers from test class declarations to align with JUnit 5 best practices and reduce verbosity. [[1]](diffhunk://#diff-9d638531fe68eaae272fcb054d2fe4ea09c15eb352d9ecb79ddccf50238731abL39-R42) [[2]](diffhunk://#diff-b64d3ff41c5215e2dae2d18a01d8a9b1c3955d3d107fa9ac57ae3ad48d8c1655L69-R72) [[3]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L68-R68)

### Assertion helper refactoring:

* Renamed the helper method from `checkGedDocument` to `compareGedDocument` in `GedObjectToGedDocumentMongoConverterTest`, and updated all usages to improve clarity and consistency in test assertions. [[1]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L83-R84) [[2]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L93-R95) [[3]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L103-R106) [[4]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L113-R117) [[5]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L123-R128) [[6]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L133-R139) [[7]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L143-R150) [[8]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L153-R161) [[9]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L163-R172) [[10]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L173-R183) [[11]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L183-R194) [[12]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L193-R205) [[13]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L203-R216) [[14]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L213-R227) [[15]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L223-R238) [[16]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L233-R249) [[17]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L243-R260) [[18]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L253-R271) [[19]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L263-R282) [[20]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L273-R293) [[21]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L283-R304) [[22]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L293-R315) [[23]](diffhunk://#diff-d96ebd4f9159b11c9f911d21a741c0ffa391e22d53e40f366bab61d1a4edfd21L333-R355)

These changes help keep the test codebase clean, maintainable, and in line with current best practices.