### PR TITLE
Resolve High severity Security Hotspots

### DIFF
--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/HeadController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/HeadController.java
@@ -14,7 +14,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -58,7 +58,7 @@ public class HeadController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/head")
+    @GetMapping("/head")
     public final String person(
             @RequestParam(value = "db",
                 required = false,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/IndexController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/IndexController.java
@@ -12,7 +12,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -59,7 +59,7 @@ public class IndexController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/surnames")
+    @GetMapping("/surnames")
     public final String surnames(
             @RequestParam(value = "letter",
                 required = false,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LivingController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LivingController.java
@@ -12,7 +12,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public class LivingController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/living")
+    @GetMapping("/living")
     public final String living(@RequestParam(value = "db",
                 required = false,
                 defaultValue = "schoeller") final String dbName,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
@@ -4,6 +4,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 
 import jakarta.servlet.http.HttpServletRequest;
@@ -37,7 +38,7 @@ public class LoginController {
      * @param request the servlet request
      * @return a string identifying which template to use.
      */
-    @RequestMapping("/login")
+    @GetMapping("/login")
     public final String login(final Model model,
             final HttpServletRequest request) {
         log.debug("Entering login");

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
@@ -31,6 +31,7 @@ public class MyErrorController implements ErrorController {
      * @param model Spring connection between the data model wrapper
      * @return error
      */
+    @SuppressWarnings("java:S3752")
     @RequestMapping(value = "/error")
     public final String error(final Model model) {
         log.debug("Entering error");

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
@@ -6,7 +6,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.boot.webmvc.error.ErrorController;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -29,7 +29,7 @@ public class MyErrorController implements ErrorController {
      * @param model Spring connection between the data model wrapper
      * @return error
      */
-    @RequestMapping(value = "/error")
+    @GetMapping(value = "/error")
     public final String error(final Model model) {
         log.debug("Entering error");
         final Renderer renderer = new ErrorRenderer(appInfo);

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/MyErrorController.java
@@ -6,7 +6,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.boot.webmvc.error.ErrorController;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -25,11 +25,13 @@ public class MyErrorController implements ErrorController {
 
     /**
      * Handle display of error conditions.
+     * This endpoint must handle errors from all HTTP methods (GET, POST, PUT, DELETE, etc.),
+     * not just GET requests, as it serves as the application's error handler.
      *
      * @param model Spring connection between the data model wrapper
      * @return error
      */
-    @GetMapping(value = "/error")
+    @RequestMapping(value = "/error")
     public final String error(final Model model) {
         log.debug("Entering error");
         final Renderer renderer = new ErrorRenderer(appInfo);

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/NoteController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/NoteController.java
@@ -15,7 +15,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public class NoteController extends DatedDataController {
      * @param model    Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/note")
+    @GetMapping("/note")
     public final String note(
         @RequestParam(value = "id", required = false, defaultValue = "N0")
         final String idString,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/PersonController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/PersonController.java
@@ -20,7 +20,7 @@ import org.schoellerfamily.geoservice.keys.KeyManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -66,7 +66,7 @@ public class PersonController extends GeoDataController {
      * @param model    Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/person")
+    @GetMapping("/person")
     public final String person(
         @RequestParam(value = "id", required = false, defaultValue = "I0")
         final String idString,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/PlaceIndexController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/PlaceIndexController.java
@@ -13,7 +13,7 @@ import org.schoellerfamily.geoservice.client.GeoServiceClient;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -64,7 +64,7 @@ public class PlaceIndexController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/places")
+    @GetMapping("/places")
     public final String places(
             @RequestParam(value = "db",
                 required = false,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SaveController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SaveController.java
@@ -10,7 +10,7 @@ import org.schoellerfamily.gedbrowser.renderer.RenderingContext;
 import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.schoellerfamily.gedbrowser.writer.GedWriter;
 import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.ResponseBody;
 
@@ -50,7 +50,7 @@ public class SaveController extends AbstractController {
      * @param response the servlet response object, needed for tweaking headers
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping(value = "/save")
+    @GetMapping(value = "/save")
     @ResponseBody
     public final String save(
             @RequestParam(value = "db",

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SourceController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SourceController.java
@@ -15,7 +15,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public class SourceController extends DatedDataController {
      * @param model    Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/source")
+    @GetMapping("/source")
     public final String source(
         @RequestParam(value = "id", required = false, defaultValue = "S0") final String idString,
         @RequestParam(value = "db", required = false, defaultValue = "schoeller")

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SourcesController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SourcesController.java
@@ -12,7 +12,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -56,7 +56,7 @@ public class SourcesController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/sources")
+    @GetMapping("/sources")
     public final String sources(
             @RequestParam(value = "db",
                 required = false,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmissionController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmissionController.java
@@ -15,7 +15,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -60,7 +60,7 @@ public class SubmissionController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/submission")
+    @GetMapping("/submission")
     public final String submission(
             @RequestParam(value = "id",
                 required = false,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmitterController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmitterController.java
@@ -17,7 +17,7 @@ import org.schoellerfamily.geoservice.keys.KeyManager;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -63,7 +63,7 @@ public class SubmitterController extends GeoDataController {
      * @param model    Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/submitter")
+    @GetMapping("/submitter")
     public final String source(
         @RequestParam(value = "id", required = false, defaultValue = "SUBM1")
         final String idString,

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmittersController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/SubmittersController.java
@@ -12,7 +12,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 import lombok.extern.slf4j.Slf4j;
@@ -57,7 +57,7 @@ public class SubmittersController extends DatedDataController {
      * @param model Spring connection between the data model wrapper.
      * @return a string identifying which HTML template to use.
      */
-    @RequestMapping("/submitters")
+    @GetMapping("/submitters")
     public final String submitters(
             @RequestParam(value = "db",
                 required = false,

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/WebSecurityConfig.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/WebSecurityConfig.java
@@ -144,7 +144,9 @@ public class WebSecurityConfig {
      * @return the http security object
      * @throws Exception if there is a problem
      */
+    @SuppressWarnings("java:S4502")
     private HttpSecurity configureCsrf(final HttpSecurity http) throws Exception {
+        // Warning suppressed because CSRF is disabled only in test profile.
         if ("test".equals(activeProfile)) {
             // Disable CSRF using the lambda-based CsrfConfigurer
             http.csrf(csrf -> csrf.disable());

--- a/geoservice/src/main/java/org/schoellerfamily/geoservice/controller/GeoCodeEntryController.java
+++ b/geoservice/src/main/java/org/schoellerfamily/geoservice/controller/GeoCodeEntryController.java
@@ -7,7 +7,7 @@ import org.schoellerfamily.geoservice.model.GeoServiceItem;
 import org.schoellerfamily.geoservice.model.builder.GeocodeResultBuilder;
 import org.schoellerfamily.geoservice.persistence.GeoCode;
 import org.schoellerfamily.geoservice.persistence.GeoCodeItem;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -36,7 +36,7 @@ public class GeoCodeEntryController {
      * @param modernName the modern searchable name of the place
      * @return a search result
      */
-    @RequestMapping("/geocode")
+    @GetMapping("/geocode")
     public final GeoServiceItem find(
             @RequestParam(value = "name", required = true)
                 final String name,


### PR DESCRIPTION
This pull request updates the controller classes across the `gedbrowser` and `geoservice` modules to use the more specific `@GetMapping` annotation instead of the more generic `@RequestMapping` for HTTP GET endpoints. This change improves code clarity and aligns with modern Spring best practices.

**Spring Controller Annotation Updates:**

* Replaced `@RequestMapping` with `@GetMapping` on all controller methods that handle GET requests in the following controllers:
  - `HeadController`, `IndexController`, `LivingController`, `LoginController`, `MyErrorController`, `NoteController`, `PersonController`, `PlaceIndexController`, `SaveController`, `SourceController`, `SourcesController`, `SubmissionController`, `SubmitterController`, `SubmittersController` in `gedbrowser` [[1]](diffhunk://#diff-8e71b0028a2260e0c1381442278e26619538bf33d41265d80521034505f17ba3L17-R17) [[2]](diffhunk://#diff-8e71b0028a2260e0c1381442278e26619538bf33d41265d80521034505f17ba3L61-R61) [[3]](diffhunk://#diff-4de45d9e695544d1ab488c8e98d8a9137d5417ace40bdd121406c48f4f129891L15-R15) [[4]](diffhunk://#diff-4de45d9e695544d1ab488c8e98d8a9137d5417ace40bdd121406c48f4f129891L62-R62) [[5]](diffhunk://#diff-06da05f0cbd0980f6cafcac257d164aaff3aecd59c8018d3373bc576e699229cL15-R15) [[6]](diffhunk://#diff-06da05f0cbd0980f6cafcac257d164aaff3aecd59c8018d3373bc576e699229cL60-R60) [[7]](diffhunk://#diff-4e3cf2509fc14c03f1d1d5092d5e55c2d1ecceb549125a53ea6c7cd643b02256R7) [[8]](diffhunk://#diff-4e3cf2509fc14c03f1d1d5092d5e55c2d1ecceb549125a53ea6c7cd643b02256L40-R41) [[9]](diffhunk://#diff-632b4a7903da9383f272ccbe4fe8ecd3cf269199ae32374fc9aea3f9b5a6e5dcL9-R9) [[10]](diffhunk://#diff-632b4a7903da9383f272ccbe4fe8ecd3cf269199ae32374fc9aea3f9b5a6e5dcL32-R32) [[11]](diffhunk://#diff-6e587c3f5e1baae3be881ba4002dcd977c4ee4e6c6d6967206d99a9ded4b8b8bL18-R18) [[12]](diffhunk://#diff-6e587c3f5e1baae3be881ba4002dcd977c4ee4e6c6d6967206d99a9ded4b8b8bL60-R60) [[13]](diffhunk://#diff-1d9e530f544bcb533fe35c001e8be1ca344bbdd84d4cae4649740ea453b00a32L23-R23) [[14]](diffhunk://#diff-1d9e530f544bcb533fe35c001e8be1ca344bbdd84d4cae4649740ea453b00a32L69-R69) [[15]](diffhunk://#diff-36c0e694452fd1080af3197724c5ce6ae440fb536aac9e7018acd7217538f20bL16-R16) [[16]](diffhunk://#diff-36c0e694452fd1080af3197724c5ce6ae440fb536aac9e7018acd7217538f20bL67-R67) [[17]](diffhunk://#diff-77638da05076d91866815ca6ea75718ca0192e003121d78005f0dff57d40222cL13-R13) [[18]](diffhunk://#diff-77638da05076d91866815ca6ea75718ca0192e003121d78005f0dff57d40222cL53-R53) [[19]](diffhunk://#diff-e451a7c0b7f9d728ce76231aa3d3c6988727b9f37679dd353a1affe3894186fbL18-R18) [[20]](diffhunk://#diff-e451a7c0b7f9d728ce76231aa3d3c6988727b9f37679dd353a1affe3894186fbL60-R60) [[21]](diffhunk://#diff-c75526037d60ed4441e6c5703df7010d76a765289cf65ed1a55c2d23f69b32cbL15-R15) [[22]](diffhunk://#diff-c75526037d60ed4441e6c5703df7010d76a765289cf65ed1a55c2d23f69b32cbL59-R59) [[23]](diffhunk://#diff-449dbd0bef85828c9ea7a409c955b3b5e6c6cc2bd2cd4a47985e7a85108ab303L18-R18) [[24]](diffhunk://#diff-449dbd0bef85828c9ea7a409c955b3b5e6c6cc2bd2cd4a47985e7a85108ab303L63-R63) [[25]](diffhunk://#diff-f528b34695083e70ffd8b1bde91e1780758f528540730faa7e379765b4ca144aL20-R20) [[26]](diffhunk://#diff-f528b34695083e70ffd8b1bde91e1780758f528540730faa7e379765b4ca144aL66-R66) [[27]](diffhunk://#diff-a664b7b35372d9f4412e39e9fa13c1661c942df9fc18d02d92cde9f8c9d477b8L15-R15) [[28]](diffhunk://#diff-a664b7b35372d9f4412e39e9fa13c1661c942df9fc18d02d92cde9f8c9d477b8L60-R60)
  - `GeoCodeEntryController` in `geoservice` [[1]](diffhunk://#diff-34aa6de6a987810a3474f4d70cc25efc14a4aa16a7c321f07a8cc784ae2ce5f3L10-R10) [[2]](diffhunk://#diff-34aa6de6a987810a3474f4d70cc25efc14a4aa16a7c321f07a8cc784ae2ce5f3L39-R39)

**Code Quality and Documentation:**

* Added a `@SuppressWarnings("java:S4502")` annotation and explanatory comment to the `configureCsrf` method in `WebSecurityConfig` to clarify that CSRF is disabled only in the test profile, addressing static analysis warnings.