### PR TITLE
Fix a large number of High maintainability issues

### DIFF
--- a/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/repository/FindableDocument.java
+++ b/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/repository/FindableDocument.java
@@ -13,6 +13,11 @@ import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
 public  interface FindableDocument
     <G extends GedObject, D extends GedDocument<G>>  {
     /**
+     * Constant for use in a number of calls.
+     */
+    String FILENAME = "filename";
+
+    /**
      * @param filename the value of filename
      * @param string the value of string
      * @return the matching item

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
@@ -70,46 +70,46 @@ public final class GedObjectBuilder implements PersonBuilderFacade,
     /** */
     private enum Construction {
         /** */
-        attribute,
+        ATTRIBUTE,
         /** */
-        hasid,
+        HASID,
         /** */
-        note,
+        NOTE,
         /** */
-        reference,
+        REFERENCE,
         /** */
-        value
+        VALUE
     };
 
     /** */
     private static final Map<String, Construction> CONSTRUCTION_MAP =
             new HashMap<>();
     static {
-        CONSTRUCTION_MAP.put("attribute", Construction.attribute);
-        CONSTRUCTION_MAP.put("child", Construction.reference);
-        CONSTRUCTION_MAP.put("date", Construction.value);
-        CONSTRUCTION_MAP.put("famc", Construction.reference);
-        CONSTRUCTION_MAP.put("family", Construction.hasid);
-        CONSTRUCTION_MAP.put("fams", Construction.reference);
-        CONSTRUCTION_MAP.put("head", Construction.value);
-        CONSTRUCTION_MAP.put("header", Construction.value);
-        CONSTRUCTION_MAP.put("husband", Construction.reference);
-        CONSTRUCTION_MAP.put("link", Construction.reference);
-        CONSTRUCTION_MAP.put("multimedia", Construction.value);
-        CONSTRUCTION_MAP.put("name", Construction.value);
-        CONSTRUCTION_MAP.put("note", Construction.note);
-        CONSTRUCTION_MAP.put("notelink", Construction.reference);
-        CONSTRUCTION_MAP.put("person", Construction.hasid);
-        CONSTRUCTION_MAP.put("place", Construction.value);
-        CONSTRUCTION_MAP.put("root", Construction.value);
-        CONSTRUCTION_MAP.put("source", Construction.hasid);
-        CONSTRUCTION_MAP.put("sourcelink", Construction.reference);
-        CONSTRUCTION_MAP.put("submission", Construction.hasid);
-        CONSTRUCTION_MAP.put("submissionlink", Construction.reference);
-        CONSTRUCTION_MAP.put("submitter", Construction.hasid);
-        CONSTRUCTION_MAP.put("submitterlink", Construction.reference);
-        CONSTRUCTION_MAP.put("trailer", Construction.value);
-        CONSTRUCTION_MAP.put("wife", Construction.reference);
+        CONSTRUCTION_MAP.put("attribute", Construction.ATTRIBUTE);
+        CONSTRUCTION_MAP.put("child", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("date", Construction.VALUE);
+        CONSTRUCTION_MAP.put("famc", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("family", Construction.HASID);
+        CONSTRUCTION_MAP.put("fams", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("head", Construction.VALUE);
+        CONSTRUCTION_MAP.put("header", Construction.VALUE);
+        CONSTRUCTION_MAP.put("husband", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("link", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("multimedia", Construction.VALUE);
+        CONSTRUCTION_MAP.put("name", Construction.VALUE);
+        CONSTRUCTION_MAP.put("note", Construction.NOTE);
+        CONSTRUCTION_MAP.put("notelink", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("person", Construction.HASID);
+        CONSTRUCTION_MAP.put("place", Construction.VALUE);
+        CONSTRUCTION_MAP.put("root", Construction.VALUE);
+        CONSTRUCTION_MAP.put("source", Construction.HASID);
+        CONSTRUCTION_MAP.put("sourcelink", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("submission", Construction.HASID);
+        CONSTRUCTION_MAP.put("submissionlink", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("submitter", Construction.HASID);
+        CONSTRUCTION_MAP.put("submitterlink", Construction.REFERENCE);
+        CONSTRUCTION_MAP.put("trailer", Construction.VALUE);
+        CONSTRUCTION_MAP.put("wife", Construction.REFERENCE);
     }
 
     /**
@@ -225,20 +225,20 @@ public final class GedObjectBuilder implements PersonBuilderFacade,
         }
         Construction construction = CONSTRUCTION_MAP.get(type);
         if (construction == null) {
-            construction = Construction.attribute;
+            construction = Construction.ATTRIBUTE;
         }
         GedObject gob;
         switch (construction) {
-        case attribute:
+        case ATTRIBUTE:
             gob = factory.create(parent, "", string, tail);
             break;
-        case hasid:
+        case HASID:
             gob = factory.create(parent, string, tag, tail);
             break;
-        case reference:
+        case REFERENCE:
             gob = factory.create(parent, "", tag, "@" + string + "@");
             break;
-        case value:
+        case VALUE:
             gob = factory.create(parent, "", tag, string);
             break;
         default:

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/FamilyDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/FamilyDocumentRepositoryMongoImpl.java
@@ -31,7 +31,7 @@ public class FamilyDocumentRepositoryMongoImpl implements
     public final FamilyDocument findByFileAndString(final String filename,
             final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final FamilyDocumentMongo familyDocument =
                 mongoTemplate.findOne(searchQuery, FamilyDocumentMongo.class);
         if (familyDocument == null) {
@@ -59,7 +59,7 @@ public class FamilyDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<FamilyDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<FamilyDocumentMongo> familyDocumentsMongo =
                 mongoTemplate.find(searchQuery, FamilyDocumentMongo.class);
         return familyDocumentsMongo.stream()
@@ -89,7 +89,7 @@ public class FamilyDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, FamilyDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/HeadDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/HeadDocumentRepositoryMongoImpl.java
@@ -32,7 +32,7 @@ public class HeadDocumentRepositoryMongoImpl implements
     public final HeadDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final HeadDocument headDocument =
                 mongoTemplate.findOne(searchQuery, HeadDocumentMongo.class);
         if (headDocument == null) {
@@ -60,7 +60,7 @@ public class HeadDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<HeadDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<HeadDocumentMongo> headDocumentsMongo =
                 mongoTemplate.find(searchQuery, HeadDocumentMongo.class);
         return headDocumentsMongo.stream()
@@ -90,7 +90,7 @@ public class HeadDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, HeadDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/NoteDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/NoteDocumentRepositoryMongoImpl.java
@@ -31,7 +31,7 @@ public class NoteDocumentRepositoryMongoImpl implements
     public final NoteDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final NoteDocument noteDocument =
                 mongoTemplate.findOne(searchQuery, NoteDocumentMongo.class);
         if (noteDocument == null) {
@@ -59,7 +59,7 @@ public class NoteDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<NoteDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<NoteDocumentMongo> noteDocumentsMongo =
                 mongoTemplate.find(searchQuery, NoteDocumentMongo.class);
         return noteDocumentsMongo.stream()
@@ -89,7 +89,7 @@ public class NoteDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, NoteDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
@@ -41,7 +41,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
     public PersonDocument findByFileAndString(final String filename,
             final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final PersonDocument personDocument = mongoTemplate.findOne(
                 searchQuery, PersonDocumentMongo.class);
         if (personDocument == null) {
@@ -74,7 +74,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
         }
         final Query searchQuery =
                 new Query(Criteria.where("surname").is(surname)
-                        .and("filename").is(filename));
+                        .and(FILENAME).is(filename));
         final List<PersonDocumentMongo> personDocuments =
                 mongoTemplate.find(searchQuery, PersonDocumentMongo.class);
         createGedObjects(personDocuments);
@@ -120,7 +120,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
     private List<PersonDocumentMongo> queryUnknownSurname(
             final String filename) {
         final Query emptyQuery = new Query(
-                Criteria.where("filename").is(filename).andOperator(
+                Criteria.where(FILENAME).is(filename).andOperator(
                         Criteria.where("surname").in("", "?"),
                         Criteria.where("surname").exists(false)));
         return mongoTemplate.find(emptyQuery, PersonDocumentMongo.class);
@@ -134,7 +134,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
     private List<PersonDocumentMongo> querySurnameBeginsWith(
             final String filename, final String beginsWith) {
         final Query searchQuery = new Query(Criteria.where("surname")
-                .regex("^" + beginsWith + ".*").and("filename")
+                .regex("^" + beginsWith + ".*").and(FILENAME)
                 .is(filename));
         return mongoTemplate.find(searchQuery, PersonDocumentMongo.class);
     }
@@ -208,7 +208,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
     @Override
     public Iterable<PersonDocument> findAll(final String filename) {
         final Query searchQuery = new Query(
-                Criteria.where("filename").is(filename));
+                Criteria.where(FILENAME).is(filename));
         final List<PersonDocumentMongo> personDocuments =
                 mongoTemplate.find(searchQuery, PersonDocumentMongo.class);
         createGedObjects(personDocuments);
@@ -232,7 +232,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
     @Override
     public long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, PersonDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RootDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RootDocumentRepositoryMongoImpl.java
@@ -33,7 +33,7 @@ public class RootDocumentRepositoryMongoImpl implements
     public final RootDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final RootDocument rootDocument = mongoTemplate.findOne(searchQuery,
                 RootDocumentMongo.class);
         if (rootDocument == null) {
@@ -55,7 +55,7 @@ public class RootDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<RootDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<RootDocumentMongo> rootDocumentsMongo =
                 mongoTemplate.find(searchQuery, RootDocumentMongo.class);
         return rootDocumentsMongo.stream()
@@ -85,7 +85,7 @@ public class RootDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, RootDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SourceDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SourceDocumentRepositoryMongoImpl.java
@@ -31,7 +31,7 @@ public class SourceDocumentRepositoryMongoImpl implements
     public final SourceDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final SourceDocument sourceDocument =
                 mongoTemplate.findOne(searchQuery, SourceDocumentMongo.class);
         if (sourceDocument == null) {
@@ -59,7 +59,7 @@ public class SourceDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<SourceDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<SourceDocumentMongo> sourceDocumentsMongo =
                 mongoTemplate.find(searchQuery, SourceDocumentMongo.class);
         return sourceDocumentsMongo.stream()
@@ -89,7 +89,7 @@ public class SourceDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, SourceDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SubmissionDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SubmissionDocumentRepositoryMongoImpl.java
@@ -31,7 +31,7 @@ public class SubmissionDocumentRepositoryMongoImpl implements
     public final SubmissionDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final SubmissionDocument submDocument = mongoTemplate
                 .findOne(searchQuery, SubmissionDocumentMongo.class);
         if (submDocument == null) {
@@ -59,7 +59,7 @@ public class SubmissionDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<SubmissionDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<SubmissionDocumentMongo> submissionDocumentsMongo =
                 mongoTemplate.find(searchQuery, SubmissionDocumentMongo.class);
         return submissionDocumentsMongo.stream()
@@ -89,7 +89,7 @@ public class SubmissionDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, SubmissionDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SubmitterDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/SubmitterDocumentRepositoryMongoImpl.java
@@ -32,7 +32,7 @@ public class SubmitterDocumentRepositoryMongoImpl implements
     public final SubmitterDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final SubmitterDocument submitterDocument =
                 mongoTemplate.findOne(searchQuery,
                         SubmitterDocumentMongo.class);
@@ -61,7 +61,7 @@ public class SubmitterDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<SubmitterDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<SubmitterDocumentMongo> submitterDocumentsMongo =
                 mongoTemplate.find(searchQuery, SubmitterDocumentMongo.class);
         return submitterDocumentsMongo.stream()
@@ -91,7 +91,7 @@ public class SubmitterDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, SubmitterDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/TrailerDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/TrailerDocumentRepositoryMongoImpl.java
@@ -32,7 +32,7 @@ public class TrailerDocumentRepositoryMongoImpl implements
     public final TrailerDocument findByFileAndString(
             final String filename, final String string) {
         final Query searchQuery = new Query(Criteria.where("string").is(string)
-                .and("filename").is(filename));
+                .and(FILENAME).is(filename));
         final TrailerDocument trailerDocument =
                 mongoTemplate.findOne(searchQuery, TrailerDocumentMongo.class);
         if (trailerDocument == null) {
@@ -60,7 +60,7 @@ public class TrailerDocumentRepositoryMongoImpl implements
     @Override
     public final Iterable<TrailerDocument> findAll(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         final List<TrailerDocumentMongo> trailerDocumentsMongo =
                 mongoTemplate.find(searchQuery, TrailerDocumentMongo.class);
         return trailerDocumentsMongo.stream()
@@ -90,7 +90,7 @@ public class TrailerDocumentRepositoryMongoImpl implements
     @Override
     public final long count(final String filename) {
         final Query searchQuery =
-                new Query(Criteria.where("filename").is(filename));
+                new Query(Criteria.where(FILENAME).is(filename));
         return mongoTemplate.count(searchQuery, TrailerDocumentMongo.class);
     }
 

--- a/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderCoverageTest.java
+++ b/gedbrowser-mongo-dao/src/test/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/test/GedDocumentFileLoaderCoverageTest.java
@@ -52,6 +52,7 @@ public class GedDocumentFileLoaderCoverageTest {
 
         final GedObjectToGedDocumentMongoConverter converter =
             new GedObjectToGedDocumentMongoConverter() {
+                @SuppressWarnings("unchecked")
                 @Override
                 public RootDocumentMongo createGedDocument(
                     final org.schoellerfamily.gedbrowser.datamodel.GedObject ged) {

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
@@ -22,18 +22,27 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 public class CharsetScanner {
-
+    /** */
+    private static final String ANSEL = "ANSEL";
+    /** */
+    private static final String ASCII = "ASCII";
+    /** */
+    private static final String CP1252 = "Cp1252";
+    /** */
+    private static final String UTF_8 = "UTF-8";
+    /** */
+    private static final String UTF_16 = "UTF-16";
     /**
      * Holds the mapping between GEDCOM known charsets and Java known charsets.
      */
     private static final Map<String, String> CHARSET_MAP = Map.of(
-        "ansel", "ANSEL",
-        "ansi", "Cp1252",
-        "cp1252", "Cp1252",
-        "unicode", "UTF-16",
-        "utf-8", "UTF-8",
-        "utf8", "UTF-8",
-        "ascii", "ASCII");
+        "ansel", ANSEL,
+        "ansi", CP1252,
+        "cp1252", CP1252,
+        "unicode", UTF_16,
+        "utf-8", UTF_8,
+        "utf8", UTF_8,
+        "ascii", ASCII);
 
     /**
      * @param filename the name of the file to scan
@@ -43,9 +52,9 @@ public class CharsetScanner {
         try (InputStream fis = new StreamManager(filename).getInputStream()) {
                 if (fis == null) {
                 log.warn("Could not open stream for: {}", filename);
-                return "UTF-8";
+                return UTF_8;
             }
-            try (Reader reader = new InputStreamReader(fis, "ASCII");
+            try (Reader reader = new InputStreamReader(fis, ASCII);
                     BufferedReader bufferedReader = new BufferedReader(reader)) {
                 String line;
                 while ((line = bufferedReader.readLine()) != null) {
@@ -57,7 +66,7 @@ public class CharsetScanner {
         } catch (IOException e) {
             log.warn("Could not read file: {}", filename);
         }
-        return "UTF-8";
+        return UTF_8;
     }
 
     /**
@@ -86,7 +95,7 @@ public class CharsetScanner {
         if ("Header".equals(gob.getString())) {
             return gedcomCharsetToJava(findCharsetInHeader(gob));
         }
-        return "UTF-8";
+        return UTF_8;
     }
 
     /**
@@ -101,7 +110,7 @@ public class CharsetScanner {
                 return ((Attribute) hgob).getTail();
             }
         }
-        return "UTF-8";
+        return UTF_8;
     }
 
     /**
@@ -112,7 +121,7 @@ public class CharsetScanner {
         final String javaCharset = CHARSET_MAP
                 .get(charset.toLowerCase(Locale.ENGLISH));
         if (javaCharset == null) {
-            return "UTF-8";
+            return UTF_8;
         }
         return javaCharset;
     }

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.Locale;
 import java.util.Map;
 
@@ -29,9 +30,9 @@ public class CharsetScanner {
     /** */
     private static final String CP1252 = "Cp1252";
     /** */
-    private static final String UTF_8 = "UTF-8";
+    private static final String UTF_8 = StandardCharsets.UTF_8.name();
     /** */
-    private static final String UTF_16 = "UTF-16";
+    private static final String UTF_16 = StandardCharsets.UTF_16.name();
     /**
      * Holds the mapping between GEDCOM known charsets and Java known charsets.
      */
@@ -54,7 +55,7 @@ public class CharsetScanner {
                 log.warn("Could not open stream for: {}", filename);
                 return UTF_8;
             }
-            try (Reader reader = new InputStreamReader(fis, ASCII);
+            try (Reader reader = new InputStreamReader(fis, StandardCharsets.US_ASCII);
                     BufferedReader bufferedReader = new BufferedReader(reader)) {
                 String line;
                 while ((line = bufferedReader.readLine()) != null) {

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListItemRenderer.java
@@ -57,7 +57,7 @@ public class AttributeListItemRenderer implements ListItemRenderer {
     protected final void renderListItemContents(final StringBuilder builder) {
         final Attribute attribute = attributeRenderer.getGedObject();
         builder.append("<span class=\"label\">");
-        builder.append(GedRenderer.escapeString(attribute));
+        builder.append(RenderingContextRenderer.escapeString(attribute));
         builder.append(":</span> ");
         builder.append(attributeRenderer.renderAsPhrase());
 

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributePhraseRenderer.java
@@ -24,7 +24,7 @@ public final class AttributePhraseRenderer implements PhraseRenderer {
      */
     @Override
     public String renderAsPhrase() {
-        return GedRenderer.escapeString(attributeRenderer.getGedObject()
+        return RenderingContextRenderer.escapeString(attributeRenderer.getGedObject()
                 .getTail());
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeRenderer.java
@@ -27,6 +27,6 @@ public final class AttributeRenderer extends GedRenderer<Attribute> {
      */
     public String getEscapedString() {
         final Attribute attribute = getGedObject();
-        return GedRenderer.escapeString(attribute);
+        return RenderingContextRenderer.escapeString(attribute);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeRenderer.java
@@ -27,6 +27,6 @@ public final class AttributeRenderer extends GedRenderer<Attribute> {
      */
     public String getEscapedString() {
         final Attribute attribute = getGedObject();
-        return RenderingContextRenderer.escapeString(attribute);
+        return escapeString(attribute);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ComplexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ComplexRenderer.java
@@ -15,7 +15,7 @@ public interface ComplexRenderer {
      * @return the string prepared for display in HTML
      */
     default String escapeString(final String input) {
-        return GedRenderer.escapeString(input).trim();
+        return RenderingContextRenderer.escapeString(input).trim();
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DatePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DatePhraseRenderer.java
@@ -29,6 +29,6 @@ public class DatePhraseRenderer implements PhraseRenderer {
         final GetDateVisitor visitor = new GetDateVisitor();
         final Date date1 = dateRenderer.getGedObject();
         date1.accept(visitor);
-        return GedRenderer.escapeString(visitor.getDate());
+        return RenderingContextRenderer.escapeString(visitor.getDate());
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
@@ -11,6 +11,11 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 @SuppressWarnings({ "PMD.AbstractClassWithoutAbstractMethod" })
 public abstract class GedRenderer<G extends GedObject>
         extends SectionedRenderer {
+    /**
+     * Beginning of common anchor.
+     */
+    private static final String A_HREF = "\n    <a href=\"?";
+
     /** */
     private final transient G gedObject;
 
@@ -158,15 +163,15 @@ public abstract class GedRenderer<G extends GedObject>
         final StringBuilder builder = new StringBuilder();
         builder.append("\n    <p>");
         if ("Header".equals(omit)) {
-            builder.append("\n    <a href=\"?" + gedObject.getDbName()
+            builder.append(A_HREF + gedObject.getDbName()
                     + "+Header\">Header</a><br>");
         }
         if ("Surnames".equals(omit)) {
-            builder.append("\n    <a href=\"?" + gedObject.getDbName()
+            builder.append(A_HREF + gedObject.getDbName()
                     + "+Surnames\">Surnames</a><br>");
         }
         if ("Index".equals(omit)) {
-            builder.append("\n    <a href=\"?" + gedObject.getDbName()
+            builder.append(A_HREF + gedObject.getDbName()
                     + "+Index\">Index</a><br>");
         }
         builder.append("\n    </p>");

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaListItemRenderer.java
@@ -57,7 +57,7 @@ public final class MultimediaListItemRenderer implements ListItemRenderer {
     private void renderListItemContents(final StringBuilder builder) {
         final Multimedia multimedia = multimediaRenderer.getGedObject();
         builder.append("<span class=\"label\">");
-        builder.append(GedRenderer.escapeString(multimedia));
+        builder.append(RenderingContextRenderer.escapeString(multimedia));
         builder.append(":</span> ");
 
         final MultimediaVisitor visitor = new MultimediaVisitor();

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaRenderer.java
@@ -25,6 +25,6 @@ public final class MultimediaRenderer extends GedRenderer<Multimedia> {
      */
     public String getEscapedString() {
         final Multimedia attribute = getGedObject();
-        return GedRenderer.escapeString(attribute);
+        return RenderingContextRenderer.escapeString(attribute);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaRenderer.java
@@ -25,6 +25,6 @@ public final class MultimediaRenderer extends GedRenderer<Multimedia> {
      */
     public String getEscapedString() {
         final Multimedia attribute = getGedObject();
-        return RenderingContextRenderer.escapeString(attribute);
+        return escapeString(attribute);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameHtmlRenderer.java
@@ -34,9 +34,9 @@ public class NameNameHtmlRenderer implements NameHtmlRenderer {
         final Name name = nameRenderer.getGedObject();
         final StringBuilder builder = new StringBuilder(40);
 
-        final String prefix = GedRenderer.escapeString(name.getPrefix());
-        final String surname = GedRenderer.escapeString(name.getSurname());
-        final String suffix = GedRenderer.escapeString(name.getSuffix());
+        final String prefix = RenderingContextRenderer.escapeString(name.getPrefix());
+        final String surname = RenderingContextRenderer.escapeString(name.getSurname());
+        final String suffix = RenderingContextRenderer.escapeString(name.getSuffix());
 
         builder.append(prefix);
         builder.append(" <span class=\"surname\">");

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlacePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlacePhraseRenderer.java
@@ -26,6 +26,6 @@ public class PlacePhraseRenderer implements PhraseRenderer {
     @Override
     public final String renderAsPhrase() {
         final Place place = placeRenderer.getGedObject();
-        return GedRenderer.escapeString(place.getString());
+        return RenderingContextRenderer.escapeString(place.getString());
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/RenderingContextRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/RenderingContextRenderer.java
@@ -102,8 +102,8 @@ public abstract class RenderingContextRenderer implements Renderer {
      * @return the escaped string.
      */
     public static final String escapeString(final String input) {
-        return input.replaceAll("&", "&amp;").replaceAll("<", "&lt;")
-                .replaceAll(">", "&gt;").replaceAll("\n", "<br/>\n");
+        return input.replace("&", "&amp;").replace("<", "&lt;")
+                .replace(">", "&gt;").replace("\n", "<br/>\n");
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleRenderer.java
@@ -15,7 +15,7 @@ public interface SimpleRenderer {
      * @return the string prepared for display in HTML
      */
     default String escapeString(final String input) {
-        return noQuestion(GedRenderer.escapeString(input)).trim();
+        return noQuestion(RenderingContextRenderer.escapeString(input)).trim();
     }
 
     /**

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/util/test/RequestUserUtilTest.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/util/test/RequestUserUtilTest.java
@@ -134,6 +134,7 @@ public class RequestUserUtilTest {
     private final class StubUserService implements UserService {
         @Override
         public void resetCredentials() {
+            // do nothing
         }
 
         @Override

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/AbstractController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/AbstractController.java
@@ -38,6 +38,11 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Getter
 public abstract class AbstractController {
+    /**
+     * Standard log message in the exception handlers.
+     */
+    private static final String HANDLING_EXCEPTION_MESSAGE = "Handling exception: {}";
+
     /** Contains application information, for display on every page. */
     private final ApplicationInfo appInfo;
 
@@ -91,7 +96,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView personNotFoundError(final HttpServletRequest request,
         final PersonNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "personNotFound",
             HttpStatus.NOT_FOUND);
     }
@@ -107,7 +112,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView noteNotFoundError(final HttpServletRequest request,
         final NoteNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "noteNotFound",
             HttpStatus.NOT_FOUND);
     }
@@ -123,7 +128,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView sourceNotFoundError(final HttpServletRequest request,
         final SourceNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "sourceNotFound",
             HttpStatus.NOT_FOUND);
     }
@@ -139,7 +144,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView submissionNotFoundError(final HttpServletRequest request,
         final SubmissionNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "submissionNotFound",
             HttpStatus.NOT_FOUND);
     }
@@ -155,7 +160,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView submitterNotFoundError(final HttpServletRequest request,
         final SubmitterNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "submitterNotFound",
             HttpStatus.NOT_FOUND);
     }
@@ -171,7 +176,7 @@ public abstract class AbstractController {
     @ResponseStatus(HttpStatus.NOT_FOUND)
     public final ModelAndView dataSetNotFoundError(final HttpServletRequest request,
         final DataSetNotFoundException exception) {
-        log.info("Handling exception: {}", exception.getMessage());
+        log.info(HANDLING_EXCEPTION_MESSAGE, exception.getMessage());
         return createModelAndViewForException(request, exception, "dataSetNotFound",
             HttpStatus.NOT_FOUND);
     }

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
@@ -22,6 +22,12 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 public class LoginController {
+    /** Return string. */
+    private static final String LOGIN = "login";
+
+    /** Referer header. */
+    private static final String REFERER = "referer";
+
     /** Key to find the login referer in the session attributes. */
     private static final String SESSION_REFERER_KEY = "SESSION_REFERER";
 
@@ -44,11 +50,11 @@ public class LoginController {
             final HttpServletRequest request) {
         log.debug("Entering login");
         final String referer = loginDestinationUrl(request);
-        model.addAttribute("referer", referer);
+        model.addAttribute(REFERER, referer);
         request.getSession().setAttribute(SESSION_REFERER_KEY, referer);
         model.addAttribute("appInfo", appInfo);
         log.debug("Exiting login");
-        return "login";
+        return LOGIN;
     }
 
     /**
@@ -63,11 +69,11 @@ public class LoginController {
             final HttpServletRequest request) {
         log.debug("Entering logout");
         final String referer = loginDestinationUrl(request);
-        model.addAttribute("referer", referer);
+        model.addAttribute(REFERER, referer);
         request.getSession().setAttribute(SESSION_REFERER_KEY, referer);
         model.addAttribute("appInfo", appInfo);
         log.debug("Exiting logout");
-        return "login";
+        return LOGIN;
     }
 
     /**
@@ -79,7 +85,7 @@ public class LoginController {
      */
     private String loginDestinationUrl(final HttpServletRequest request) {
         final HttpSession session = request.getSession();
-        final String requestReferer = request.getHeader("referer");
+        final String requestReferer = request.getHeader(REFERER);
         final String sessionReferer = (String) session
                 .getAttribute(SESSION_REFERER_KEY);
         if (useReferer(requestReferer)) {
@@ -99,6 +105,6 @@ public class LoginController {
      */
     private boolean useReferer(final String referer) {
         return referer != null && referer.contains(servletPath)
-                && !referer.contains("login");
+                && !referer.contains(LOGIN);
     }
 }

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/exception/ObjectNotFoundException.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/exception/ObjectNotFoundException.java
@@ -18,7 +18,7 @@ public class ObjectNotFoundException extends RuntimeException {
     private final String datasetName;
 
     /** Rendering context. */
-    private final RenderingContext context;
+    private final transient RenderingContext context;
 
     /**
      * Constructor.

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
@@ -65,6 +65,7 @@ export class PersonParentFamiliesComponent extends InitablePersonCreator
   }
 
   init(): void {
+    // Empty
   }
 
   personUB(): UrlBuilder {

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/UploadController.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/UploadController.java
@@ -65,7 +65,7 @@ public class UploadController {
         }
         log.info("in file upload: {}", originalFilename);
         storageService.store(file);
-        final String name = originalFilename.replaceAll("\\.ged", "");
+        final String name = originalFilename.replace(".ged", "");
         return readOne(name);
     }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/service/storage/test/package-info.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/service/storage/test/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Storage tests for the API service.
+ */
+package org.schoellerfamily.gedbrowser.api.service.storage.test;

--- a/geoservice-persistence/pom.xml
+++ b/geoservice-persistence/pom.xml
@@ -179,6 +179,10 @@
       <groupId>org.projectlombok</groupId>
       <artifactId>lombok</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-lang3</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/GeoServiceGeocodingResult.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/GeoServiceGeocodingResult.java
@@ -18,6 +18,9 @@ import com.google.maps.model.AddressType;
  */
 @SuppressWarnings("PMD.CommentSize")
 public final class GeoServiceGeocodingResult {
+    /** */
+    private static final String POSTCODE_LOCALITIES = "postcodeLocalities";
+
     /**
      * The {@code types} array indicates the type of the returned result. This
      * array contains a set of zero or more tags identifying the type of feature
@@ -73,9 +76,9 @@ public final class GeoServiceGeocodingResult {
             fg.setProperty("partialMatch", Boolean.valueOf(partialMatch));
             fg.setProperty("placeId", placeId);
             if (postcodeLocalities == null) {
-                fg.setProperty("postcodeLocalities", null);
+                fg.setProperty(POSTCODE_LOCALITIES, null);
             } else {
-                fg.setProperty("postcodeLocalities", Arrays
+                fg.setProperty(POSTCODE_LOCALITIES, Arrays
                         .copyOf(postcodeLocalities, postcodeLocalities.length));
             }
             fg.setProperty("types", types);
@@ -144,7 +147,7 @@ public final class GeoServiceGeocodingResult {
         if (location == null) {
             return null;
         }
-        return location.getProperty("postcodeLocalities");
+        return location.getProperty(POSTCODE_LOCALITIES);
     }
 
     /**

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeBasic.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeBasic.java
@@ -18,6 +18,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor
+@SuppressWarnings("PMD.TooManyMethods")
 public abstract class GeoCodeBasic implements GeoCode {
 
     /** The key string to use for talking to Google's map APIs. */
@@ -53,6 +54,7 @@ public abstract class GeoCodeBasic implements GeoCode {
         return gcce;
     }
 
+    @SuppressWarnings("PMD.UseVarargs")
     private GeoCodeItem createGeoCodeItem(final String placeName, final GeocodingResult[] results) {
         if (results.length > 0) {
             /* Work with the first result. */
@@ -62,6 +64,7 @@ public abstract class GeoCodeBasic implements GeoCode {
         return new GeoCodeItem(placeName);
     }
 
+    @SuppressWarnings("PMD.UseVarargs")
     private GeoCodeItem replaceItemInCache(final String placeName, final String modernPlaceName,
         final GeocodingResult[] results) {
         final GeoCodeItem newGcce = new GeoCodeItem(placeName, modernPlaceName, results[0]);
@@ -105,6 +108,7 @@ public abstract class GeoCodeBasic implements GeoCode {
         return gcce;
     }
 
+    @SuppressWarnings("PMD.UseVarargs")
     private GeoCodeItem createGeoCodeItem(final String placeName, final String modernPlaceName,
         final GeocodingResult[] results) {
         if (results.length > 0) {

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeBasic.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeBasic.java
@@ -4,6 +4,7 @@ import java.util.Collection;
 import java.util.SortedSet;
 import java.util.TreeSet;
 
+import org.apache.commons.lang3.StringUtils;
 import org.schoellerfamily.geoservice.geocoder.GeoCoder;
 import org.schoellerfamily.geoservice.persistence.domain.GeoDocument;
 
@@ -15,7 +16,6 @@ import lombok.extern.slf4j.Slf4j;
 /**
  * @author Dick Schoeller
  */
-@SuppressWarnings("PMD.CommentSize")
 @Slf4j
 @RequiredArgsConstructor
 public abstract class GeoCodeBasic implements GeoCode {
@@ -27,128 +27,102 @@ public abstract class GeoCodeBasic implements GeoCode {
     public final GeoCodeItem find(final String placeName) {
         log.debug("find(\"{}\")", placeName);
         final GeoDocument geoDocument = getDocument(placeName);
-        GeoCodeItem gcce;
-        if (geoDocument != null) {
-            gcce = geoDocument.getGeoItem();
-            if (gcce.getGeocodingResult() != null) {
-                return gcce;
-            }
-
-            // It doesn't have a coding result, see if there is one.
-            final GeocodingResult[] results = geoCoder.geocode(
-                    gcce.getModernPlaceName());
-            if (results.length == 0) {
-                // Nope, so we live with the current entry from the cache.
-                return gcce;
-            } else {
-                // Replace item in cache with new one.
-                gcce = new GeoCodeItem(gcce.getPlaceName(),
-                        gcce.getModernPlaceName(), results[0]);
-                add(gcce);
-                return gcce;
-            }
+        if (geoDocument == null) {
+            return addToCacheIfFound(placeName);
         }
+        final GeoCodeItem gcce = geoDocument.getGeoItem();
+        if (gcce.getGeocodingResult() != null) {
+            return gcce;
+        }
+
+        // It doesn't have a coding result, see if there is one.
+        final GeocodingResult[] results = geoCoder.geocode(gcce.getModernPlaceName());
+        if (results.length == 0) {
+            // Nope, so we live with the current entry from the cache.
+            return gcce;
+        }
+        return replaceItemInCache(gcce.getPlaceName(), gcce.getModernPlaceName(),
+            results);
+    }
+
+    private GeoCodeItem addToCacheIfFound(final String placeName) {
         // Not found in cache. Let's see what we can find.
         final GeocodingResult[] results = geoCoder.geocode(placeName);
-        if (results.length > 0) {
-            /* Work with the first result. */
-            gcce = new GeoCodeItem(placeName, results[0]);
-        } else {
-            // Not found, create empty.
-            gcce = new GeoCodeItem(placeName);
-        }
+        final GeoCodeItem gcce = createGeoCodeItem(placeName, results);
         add(gcce);
         return gcce;
     }
 
+    private GeoCodeItem createGeoCodeItem(final String placeName, final GeocodingResult[] results) {
+        if (results.length > 0) {
+            /* Work with the first result. */
+            return new GeoCodeItem(placeName, results[0]);
+        }
+        // Not found, create empty.
+        return new GeoCodeItem(placeName);
+    }
 
-    /**
-     * {@inheritDoc}
-     */
+    private GeoCodeItem replaceItemInCache(final String placeName, final String modernPlaceName,
+        final GeocodingResult[] results) {
+        final GeoCodeItem newGcce = new GeoCodeItem(placeName, modernPlaceName, results[0]);
+        add(newGcce);
+        return newGcce;
+    }
+
     @Override
-    public final GeoCodeItem find(final String placeName,
-            final String modernPlaceName) {
-        if (modernPlaceName == null || modernPlaceName.isEmpty()) {
+    public final GeoCodeItem find(final String placeName, final String modernPlaceName) {
+        if (StringUtils.isEmpty(modernPlaceName)) {
             return find(placeName);
         }
         log.debug("find(\"{}\", \"{}\")", placeName, modernPlaceName);
         final GeoDocument geoDocument = getDocument(placeName);
-        if (geoDocument != null) {
-            // We found one.
-            if (modernPlaceName.equals(geoDocument.getModernName())) {
-                // Modern name matches existing, so we don't have a change.
-                if (geoDocument.getResult() == null) {
-                    return modernWithNoResult(placeName, modernPlaceName,
-                            geoDocument);
-                } else {
-                    // Fully formed return it.
-                    return geoDocument.getGeoItem();
-                }
-            } else {
-                // Modern place names don't match, replace.
-                // No result, try to get.
-                final GeocodingResult[] results = geoCoder.geocode(
-                        modernPlaceName);
-                if (results.length == 0) {
-                    return noModernResult(placeName, modernPlaceName);
-                } else {
-                    return newModernResult(placeName, modernPlaceName, results);
-                }
-            }
+        if (geoDocument == null) {
+            return addToCacheIfFound(placeName, modernPlaceName);
         }
+        // We found one.
+        if (modernPlaceName.equals(geoDocument.getModernName())) {
+            // Modern name matches existing, so we don't have a change.
+            if (geoDocument.getResult() == null) {
+                return modernWithNoResult(placeName, modernPlaceName, geoDocument);
+            }
+            // Fully formed return it.
+            return geoDocument.getGeoItem();
+        }
+        // Modern place names don't match, replace.
+        // No result, try to get.
+        final GeocodingResult[] results = geoCoder.geocode(modernPlaceName);
+        if (results.length == 0) {
+            return noModernResult(placeName, modernPlaceName);
+        }
+        return replaceItemInCache(placeName, modernPlaceName, results);
+    }
 
-        GeoCodeItem gcce;
+    private GeoCodeItem addToCacheIfFound(final String placeName, final String modernPlaceName) {
         // Not found in cache. Let's see what we can find.
         final GeocodingResult[] results = geoCoder.geocode(modernPlaceName);
+        final GeoCodeItem gcce = createGeoCodeItem(placeName, modernPlaceName, results);
+        add(gcce);
+        return gcce;
+    }
+
+    private GeoCodeItem createGeoCodeItem(final String placeName, final String modernPlaceName,
+        final GeocodingResult[] results) {
         if (results.length > 0) {
             /* Work with the first result. */
-            gcce = new GeoCodeItem(placeName, modernPlaceName, results[0]);
-        } else {
-            // Not found, create empty.
-            gcce = new GeoCodeItem(placeName, modernPlaceName);
+            return new GeoCodeItem(placeName, modernPlaceName, results[0]);
         }
-        add(gcce);
-        return gcce;
+        // Not found, create empty.
+        return new GeoCodeItem(placeName, modernPlaceName);
     }
 
-
-    /**
-     * @param placeName the old place name
-     * @param modernPlaceName the modern place name
-     * @param results the geocoding result
-     * @return the new item
-     */
-    @SuppressWarnings("PMD.UseVarargs")
-    private GeoCodeItem newModernResult(final String placeName,
-            final String modernPlaceName, final GeocodingResult[] results) {
-        final GeoCodeItem gcce = new GeoCodeItem(placeName, modernPlaceName,
-                results[0]);
-        add(gcce);
-        return gcce;
-    }
-
-
-    /**
-     * @param placeName the old place name
-     * @param modernPlaceName the modern place name
-     * @return a geocode item
-     */
-    private GeoCodeItem noModernResult(final String placeName,
-            final String modernPlaceName) {
+    private GeoCodeItem noModernResult(final String placeName, final String modernPlaceName) {
         final GeoCodeItem gcce = new GeoCodeItem(placeName, modernPlaceName);
         add(gcce);
         return gcce;
     }
 
-
-    /**
-     * @param placeName the old place name
-     * @param modernPlaceName the modern place name
-     * @param geoDocument the document
-     * @return the matching geocode item
-     */
-    private GeoCodeItem modernWithNoResult(final String placeName,
-            final String modernPlaceName, final GeoDocument geoDocument) {
+    private GeoCodeItem modernWithNoResult(final String placeName, final String modernPlaceName,
+        final GeoDocument geoDocument) {
         // No result, try to get.
         final GeocodingResult[] results = geoCoder.geocode(modernPlaceName);
         if (results.length == 0) {
@@ -156,23 +130,16 @@ public abstract class GeoCodeBasic implements GeoCode {
             return geoDocument.getGeoItem();
         }
 
-        final GeoCodeItem gcce =
-                new GeoCodeItem(placeName, modernPlaceName, results[0]);
+        final GeoCodeItem gcce = new GeoCodeItem(placeName, modernPlaceName, results[0]);
         add(gcce);
         return gcce;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final void dump() {
         System.out.println(toString());
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final int countNotFound() {
         log.debug("Count the places that couldn't be found");
@@ -181,9 +148,6 @@ public abstract class GeoCodeBasic implements GeoCode {
         return count;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final Collection<String> allKeys() {
         final SortedSet<String> names = new TreeSet<>();
@@ -193,9 +157,6 @@ public abstract class GeoCodeBasic implements GeoCode {
         return names;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final Collection<String> notFoundKeys() {
         log.debug("Captures the places that couldn't be found");
@@ -215,18 +176,12 @@ public abstract class GeoCodeBasic implements GeoCode {
         return notFoundSet;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final GeoCodeItem add(final GeoCodeItem item) {
         addDocument(create(item));
         return item;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final GeoCodeItem delete(final GeoCodeItem item) {
         final String placeName = item.getPlaceName();
@@ -239,9 +194,6 @@ public abstract class GeoCodeBasic implements GeoCode {
         return item;
     }
 
-    /**
-     * {@inheritDoc}
-     */
     @Override
     public final GeoCodeItem get(final String placeName) {
         final GeoDocument geoDocument = getDocument(placeName);


### PR DESCRIPTION
This pull request standardizes the usage of the `"filename"` field across multiple repository implementations by introducing a constant `FILENAME` in the `FindableDocument` interface and updating all relevant queries to use this constant. Additionally, it refactors the `GedObjectBuilder` class to use uppercase enum constants for consistency and clarity.

Key changes include:

### Repository Query Standardization

* Added a `FILENAME` constant to the `FindableDocument` interface for consistent reference to the `"filename"` field in queries.
* Updated all MongoDB repository implementations (`FamilyDocumentRepositoryMongoImpl`, `HeadDocumentRepositoryMongoImpl`, `NoteDocumentRepositoryMongoImpl`, `PersonDocumentRepositoryMongoImpl`, `RootDocumentRepositoryMongoImpl`, `SourceDocumentRepositoryMongoImpl`) to use the `FILENAME` constant in query criteria instead of the hardcoded string `"filename"`. This affects methods like `findByFileAndString`, `findAll`, and `count`. [[1]](diffhunk://#diff-b2b24f5d0339f7958120bba19d86842b5fc4e8d9a85d2f11be206a746fee090eL34-R34) [[2]](diffhunk://#diff-b2b24f5d0339f7958120bba19d86842b5fc4e8d9a85d2f11be206a746fee090eL62-R62) [[3]](diffhunk://#diff-b2b24f5d0339f7958120bba19d86842b5fc4e8d9a85d2f11be206a746fee090eL92-R92) [[4]](diffhunk://#diff-a9b089e2bf81c7707124cd5bfed472c9d7f30e90c452e3576ce89c7b1b75b0a4L35-R35) [[5]](diffhunk://#diff-a9b089e2bf81c7707124cd5bfed472c9d7f30e90c452e3576ce89c7b1b75b0a4L63-R63) [[6]](diffhunk://#diff-a9b089e2bf81c7707124cd5bfed472c9d7f30e90c452e3576ce89c7b1b75b0a4L93-R93) [[7]](diffhunk://#diff-0fd2f768be91f8cb921eec0ba297b9b4ba4b6eb432d926d760385dca18ad9667L34-R34) [[8]](diffhunk://#diff-0fd2f768be91f8cb921eec0ba297b9b4ba4b6eb432d926d760385dca18ad9667L62-R62) [[9]](diffhunk://#diff-0fd2f768be91f8cb921eec0ba297b9b4ba4b6eb432d926d760385dca18ad9667L92-R92) [[10]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L44-R44) [[11]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L77-R77) [[12]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L123-R123) [[13]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L137-R137) [[14]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L211-R211) [[15]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L235-R235) [[16]](diffhunk://#diff-69d358c4ae015d59551babc7291b52a10fb387d9f3c1ddd7ced2bcac24e8a415L36-R36) [[17]](diffhunk://#diff-69d358c4ae015d59551babc7291b52a10fb387d9f3c1ddd7ced2bcac24e8a415L58-R58) [[18]](diffhunk://#diff-69d358c4ae015d59551babc7291b52a10fb387d9f3c1ddd7ced2bcac24e8a415L88-R88) [[19]](diffhunk://#diff-0878334ed010b425b7ce03692b1a926c57786741e665c109313b69a07c71687aL34-R34) [[20]](diffhunk://#diff-0878334ed010b425b7ce03692b1a926c57786741e665c109313b69a07c71687aL62-R62) [[21]](diffhunk://#diff-0878334ed010b425b7ce03692b1a926c57786741e665c109313b69a07c71687aL92-R92)

### Enum and Code Consistency Improvements

* Updated the `Construction` enum in `GedObjectBuilder` to use uppercase names, and refactored all usages and mappings to match the new naming convention for better readability and Java standards compliance. [[1]](diffhunk://#diff-ea16a0789bf80d0c30b389da0fa144ac8aa65909e70aed5e5ffbe8ea033c1f43L73-R112) [[2]](diffhunk://#diff-ea16a0789bf80d0c30b389da0fa144ac8aa65909e70aed5e5ffbe8ea033c1f43L228-R241)

These changes improve code maintainability, reduce the risk of typos, and bring consistency to both query construction and enum usage throughout the codebase.