### PR TITLE
Fix or suppress warnings

### DIFF
--- a/config/pmd.xml
+++ b/config/pmd.xml
@@ -110,7 +110,7 @@
         <rule ref="category/java/codestyle.xml/ConfusingTernary" />
         <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract" />
         <rule ref="category/java/codestyle.xml/FieldDeclarationsShouldBeAtStartOfClass" />
-        <rule ref="category/java/codestyle.xml/UnnecessaryLocalBeforeReturn" />
+        <rule ref="category/java/codestyle.xml/VariableCanBeInlined" />
 
         <rule ref="category/java/multithreading.xml/AvoidSynchronizedAtMethodLevel" />
         <rule ref="category/java/multithreading.xml/NonThreadSafeSingleton" />

--- a/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BirthDateFromSiblingsEstimator.java
+++ b/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BirthDateFromSiblingsEstimator.java
@@ -35,6 +35,7 @@ public final class BirthDateFromSiblingsEstimator extends Estimator {
      * @param localDate if not null we already have a better estimate
      * @return the estimate from siblings
      */
+    @SuppressWarnings("java:S3776")
     public LocalDate estimateFromSiblings(final LocalDate localDate) {
         if (localDate != null) {
             return localDate;
@@ -103,6 +104,7 @@ public final class BirthDateFromSiblingsEstimator extends Estimator {
      * @param localDate if not null we already have a better estimate
      * @return an estimate from spouses of siblings
      */
+    @SuppressWarnings("java:S3776")
     public LocalDate estimateFromSiblingsSpouses(final LocalDate localDate) {
         if (localDate != null) {
             return localDate;

--- a/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BirthDateFromSpousesEstimator.java
+++ b/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BirthDateFromSpousesEstimator.java
@@ -33,6 +33,7 @@ public final class BirthDateFromSpousesEstimator extends Estimator {
      * @param shortEstimate whether to do a short estimate or a deep estimate
      * @return the estimate from own marriages
      */
+    @SuppressWarnings("java:S3776")
     public LocalDate estimate(final LocalDate localDate,
             final boolean shortEstimate) {
         if (localDate != null) {
@@ -80,6 +81,7 @@ public final class BirthDateFromSpousesEstimator extends Estimator {
      * @param localDate if not null we already have a better estimate
      * @return estimate from spouses' ancestors
      */
+    @SuppressWarnings("java:S3776")
     public LocalDate estimateFromAncestors(final LocalDate localDate) {
         if (localDate != null) {
             return localDate;

--- a/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/domain/GedDocument.java
+++ b/gedbrowser-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/domain/GedDocument.java
@@ -70,6 +70,7 @@ public interface GedDocument<G extends GedObject> extends GetString {
     /**
      * @return the attributes
      */
+    @SuppressWarnings("java:S1452")
     List<GedDocument<? extends GedObject>> getAttributes();
 
     /**

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GetStringComparatorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GetStringComparatorTest.java
@@ -17,28 +17,28 @@ import org.schoellerfamily.gedbrowser.datamodel.util.GetStringComparator;
 public final class GetStringComparatorTest {
     /** */
     @SuppressWarnings("checkstyle:nowhitespaceafter")
-    private static final Object[][] PARAMETERS = { { null, null, Direction.equalto },
-        { null, "", Direction.lessthan }, { "", null, Direction.greaterthan },
-        { null, "A", Direction.lessthan }, { "A", null, Direction.greaterthan },
-        { "", "", Direction.equalto }, { "I", "I", Direction.equalto },
-        { "I", "J", Direction.lessthan }, { "I9", "I10", Direction.lessthan },
-        { "J", "I", Direction.greaterthan }, { "I9", "I8", Direction.greaterthan },
-        { "I7", "I8", Direction.lessthan }, { "I100", "I99", Direction.greaterthan },
-        { "I1J100", "I1J99", Direction.greaterthan }, { "I1J99", "I1J100", Direction.lessthan },
-        { "I1J99", "I1J991", Direction.lessthan }, { "I1J991", "I1J99", Direction.greaterthan },
-        { "&99", "&98", Direction.greaterthan }, { "I99", "&98", Direction.greaterthan },
-        { "I", "9", Direction.greaterthan }, { "9", "I", Direction.lessthan },
-        { "I01", "I10", Direction.lessthan }, { "I01J", "I1K", Direction.greaterthan },
-        { "999", "99", Direction.greaterthan }, { "99", "999", Direction.lessthan }, };
+    private static final Object[][] PARAMETERS = { { null, null, Direction.EQUALTO },
+        { null, "", Direction.LESSTHAN }, { "", null, Direction.GREATERTHAN },
+        { null, "A", Direction.LESSTHAN }, { "A", null, Direction.GREATERTHAN },
+        { "", "", Direction.EQUALTO }, { "I", "I", Direction.EQUALTO },
+        { "I", "J", Direction.LESSTHAN }, { "I9", "I10", Direction.LESSTHAN },
+        { "J", "I", Direction.GREATERTHAN }, { "I9", "I8", Direction.GREATERTHAN },
+        { "I7", "I8", Direction.LESSTHAN }, { "I100", "I99", Direction.GREATERTHAN },
+        { "I1J100", "I1J99", Direction.GREATERTHAN }, { "I1J99", "I1J100", Direction.LESSTHAN },
+        { "I1J99", "I1J991", Direction.LESSTHAN }, { "I1J991", "I1J99", Direction.GREATERTHAN },
+        { "&99", "&98", Direction.GREATERTHAN }, { "I99", "&98", Direction.GREATERTHAN },
+        { "I", "9", Direction.GREATERTHAN }, { "9", "I", Direction.LESSTHAN },
+        { "I01", "I10", Direction.LESSTHAN }, { "I01J", "I1K", Direction.GREATERTHAN },
+        { "999", "99", Direction.GREATERTHAN }, { "99", "999", Direction.LESSTHAN }, };
 
     /** */
     private enum Direction {
         /** */
-        greaterthan,
+        GREATERTHAN,
         /** */
-        lessthan,
+        LESSTHAN,
         /** */
-        equalto
+        EQUALTO
     };
 
     /**
@@ -58,13 +58,13 @@ public final class GetStringComparatorTest {
 
     private void assertMatches(final int result, final Direction expectation) {
         switch (expectation) {
-        case greaterthan:
+        case GREATERTHAN:
             assertTrue(result > 0, "result should be greater than 0");
             break;
-        case lessthan:
+        case LESSTHAN:
             assertTrue(result < 0, "result should be less than 0");
             break;
-        case equalto:
+        case EQUALTO:
             assertEquals(0, result, "result should be equal to 0");
             break;
         default:

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
@@ -34,6 +34,8 @@ public final class PersonDocumentRepositoryMongoImpl implements
         FindableByNameDocument<Person, PersonDocument>,
         LastId<PersonDocumentMongo> {
     /** */
+    private static final String SURNAME = "surname";
+    /** */
     private final MongoTemplate mongoTemplate;
     /** */
     private final GedDocumentMongoToGedObjectConverter toObjConverter;
@@ -73,7 +75,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
             return Collections.emptyList();
         }
         final Query searchQuery =
-                new Query(Criteria.where("surname").is(surname)
+                new Query(Criteria.where(SURNAME).is(surname)
                         .and(FILENAME).is(filename));
         final List<PersonDocumentMongo> personDocuments =
                 mongoTemplate.find(searchQuery, PersonDocumentMongo.class);
@@ -121,8 +123,8 @@ public final class PersonDocumentRepositoryMongoImpl implements
             final String filename) {
         final Query emptyQuery = new Query(
                 Criteria.where(FILENAME).is(filename).andOperator(
-                        Criteria.where("surname").in("", "?"),
-                        Criteria.where("surname").exists(false)));
+                        Criteria.where(SURNAME).in("", "?"),
+                        Criteria.where(SURNAME).exists(false)));
         return mongoTemplate.find(emptyQuery, PersonDocumentMongo.class);
     }
 
@@ -133,7 +135,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
      */
     private List<PersonDocumentMongo> querySurnameBeginsWith(
             final String filename, final String beginsWith) {
-        final Query searchQuery = new Query(Criteria.where("surname")
+        final Query searchQuery = new Query(Criteria.where(SURNAME)
                 .regex("^" + beginsWith + ".*").and(FILENAME)
                 .is(filename));
         return mongoTemplate.find(searchQuery, PersonDocumentMongo.class);

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryManagerMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryManagerMongo.java
@@ -18,6 +18,7 @@ public class RepositoryManagerMongo extends MappedRepositoryManagerMongo
      * @param clazz the class of ged object
      * @return the repository
      */
+    @SuppressWarnings("java:S1452")
     public final FindableDocument<? extends GedObject, ? extends GedDocument<?>>
         get(final Class<? extends GedObject> clazz) {
         return (FindableDocument<? extends GedObject, ? extends GedDocument<?>>)

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributesRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributesRenderer.java
@@ -10,6 +10,7 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
  *
  * @param <T> the data type being rendered
  */
+@SuppressWarnings("java:S1452")
 public interface AttributesRenderer<T extends GedObject> {
     /**
      * @return the gedobject necessary to render the attributes

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
@@ -105,6 +105,7 @@ public abstract class GedRenderer<G extends GedObject>
      *            The sub-object to render.
      * @return The renderer.
      */
+    @SuppressWarnings("java:S1452")
     public final GedRenderer<? extends GedObject> createGedRenderer(
             final GedObject attribute) {
         return getRendererFactory().create(attribute, getRenderingContext());

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRendererFactory.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRendererFactory.java
@@ -36,7 +36,6 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
  *
  * @author Dick Schoeller
  */
-@SuppressWarnings("PMD.CouplingBetweenObjects")
 public final class GedRendererFactory {
     /**
      * Dispatcher for factory.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteRenderer.java
@@ -62,6 +62,7 @@ public final class NoteRenderer extends GedRenderer<Note>
      *
      * @return the list of attribute renderers.
      */
+    @SuppressWarnings("java:S1452")
     public List<GedRenderer<?>> getAttributes() {
         final Note source = getGedObject();
         final List<GedRenderer<?>> list = new ArrayList<GedRenderer<?>>();

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameRenderer.java
@@ -22,6 +22,7 @@ public interface PersonNameRenderer {
      * @param attribute The sub-object to render.
      * @return The renderer.
      */
+    @SuppressWarnings("java:S1452")
     GedRenderer<? extends GedObject> createGedRenderer(GedObject attribute);
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
@@ -92,6 +92,7 @@ public final class PersonRenderer extends GedRenderer<Person>
      *
      * @return the list of attribute renderers.
      */
+    @SuppressWarnings("java:S1452")
     public List<GedRenderer<?>> getAttributes() {
         if (isConfidential() || isHiddenLiving()) {
             return List.of();

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceRenderer.java
@@ -56,6 +56,7 @@ public final class SourceRenderer extends GedRenderer<Source>
      *
      * @return the list of attribute renderers.
      */
+    @SuppressWarnings("java:S1452")
     public List<GedRenderer<?>> getAttributes() {
         final Source source = getGedObject();
         final List<GedRenderer<?>> list = new ArrayList<GedRenderer<?>>();

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/AuthenticationController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/AuthenticationController.java
@@ -52,7 +52,7 @@ public class AuthenticationController {
      * @return the response entity
      */
     @RequestMapping(value = "/refresh", method = RequestMethod.GET)
-    public ResponseEntity<?> refreshAuthenticationToken(
+    public ResponseEntity<UserTokenState> refreshAuthenticationToken(
             final HttpServletRequest request,
             final HttpServletResponse response) {
 
@@ -72,7 +72,7 @@ public class AuthenticationController {
      * @param authToken the authentication token
      * @return the response
      */
-    private ResponseEntity<?> doRefresh(final HttpServletResponse response,
+    private ResponseEntity<UserTokenState> doRefresh(final HttpServletResponse response,
             final String authToken) {
         final String refreshedToken = tokenHelper.refreshToken(authToken);
 

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/UserController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/UserController.java
@@ -80,7 +80,7 @@ public class UserController {
      * @return the new user
      */
     @RequestMapping(method = POST, value = "/signup")
-    public ResponseEntity<?> addUser(
+    public ResponseEntity<SecurityUser> addUser(
             @RequestBody final UserRequest userRequest,
             final UriComponentsBuilder ucBuilder) {
         final SecurityUser existUser =

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
@@ -45,7 +45,7 @@ public class LoginController {
      * @param request the servlet request
      * @return a string identifying which template to use.
      */
-    @RequestMapping(value = "/login", method = { RequestMethod.POST })
+    @RequestMapping(value = "/login", method = { RequestMethod.POST, RequestMethod.GET })
     public final String login(final Model model,
             final HttpServletRequest request) {
         log.debug("Entering login");
@@ -64,7 +64,7 @@ public class LoginController {
      * @param request the servlet request
      * @return a string identifying which template to use.
      */
-    @GetMapping("/logout")
+    @RequestMapping(value = "/logout", method = { RequestMethod.POST, RequestMethod.GET })
     public final String logout(final Model model,
             final HttpServletRequest request) {
         log.debug("Entering logout");

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/controller/LoginController.java
@@ -45,7 +45,7 @@ public class LoginController {
      * @param request the servlet request
      * @return a string identifying which template to use.
      */
-    @RequestMapping(value = "/login", method = { RequestMethod.POST, RequestMethod.GET })
+    @RequestMapping(value = "/login", method = { RequestMethod.POST })
     public final String login(final Model model,
             final HttpServletRequest request) {
         log.debug("Entering login");

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCode.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCode.java
@@ -101,6 +101,7 @@ public interface GeoCode {
      *
      * @return the collection
      */
+    @SuppressWarnings("java:S1452")
     Iterable<? extends GeoDocument> findAllDocuments();
 
     /**


### PR DESCRIPTION
This pull request primarily introduces code quality improvements and minor refactorings across several modules, focusing on suppressing static analysis warnings, improving code readability, and standardizing enum usage. It also includes small functional changes, such as refining method return types and restricting HTTP methods for a login endpoint.

**Code quality and static analysis suppressions:**
- Added `@SuppressWarnings` annotations (mostly for `java:S1452` and `java:S3776`) to interfaces and methods dealing with generic types and cyclomatic complexity in files such as `GedDocument.java`, `RepositoryManagerMongo.java`, `AttributesRenderer.java`, `GedRenderer.java`, `NoteRenderer.java`, `PersonRenderer.java`, `SourceRenderer.java`, `PersonNameRenderer.java`, and `GeoCode.java` to reduce noise from static analysis tools. [[1]](diffhunk://#diff-03ff83298214c16ab12a0b245493ddf0b0134635523ebe8fcd048cde45c658ceR73) [[2]](diffhunk://#diff-790487df33dfe3b91bf16b877d4f24dcadcbd8aec064ce79b36c96a592aaefa4R21) [[3]](diffhunk://#diff-85335723f30722b4cbb56fe950a37a5aba6f1212c70a5e69599adf15fab02a19R13) [[4]](diffhunk://#diff-ceeadb104bc1209db266ca36d926a9c8a85a96aa03b9f1bddb4e628f2cca50f8R108) [[5]](diffhunk://#diff-63edd957ed3403dc6312bbd8d9bd20148a1ae1b42bdbe3c7032f8262885f5fa3R65) [[6]](diffhunk://#diff-c356e468141638421c10daf8c45bab5ad077ba2f0a46fed1a35897602a742306R95) [[7]](diffhunk://#diff-749950f651e095d4cacc2f1b89f02d4e6f5574e22b38860cd0fe0f7cff7e6995R59) [[8]](diffhunk://#diff-ba90b4528b2bcb887ec5e2e0380445c7dfd1216f1e1e119065a389c6fd42793eR25) [[9]](diffhunk://#diff-21af14e71767f73b83d783e02cc4b9a876d268ade824b80e626d5a2016c5f9e3R104)
- Suppressed warnings about cyclomatic complexity in several estimation methods in `BirthDateFromSiblingsEstimator` and `BirthDateFromSpousesEstimator`. [[1]](diffhunk://#diff-cd5e2a15e380b137c805b7405e497dd220a24dcfa18742d74c56afb2de7ff972R38) [[2]](diffhunk://#diff-cd5e2a15e380b137c805b7405e497dd220a24dcfa18742d74c56afb2de7ff972R107) [[3]](diffhunk://#diff-b37032717d7c2028efcf121cacd1bfa26c5407582dcdd526b6715ab8f1f9c952R36) [[4]](diffhunk://#diff-b37032717d7c2028efcf121cacd1bfa26c5407582dcdd526b6715ab8f1f9c952R84)

**Refactoring and readability improvements:**
- Replaced hardcoded `"surname"` string with a static final variable `SURNAME` in `PersonDocumentRepositoryMongoImpl`, improving maintainability and reducing the risk of typos. [[1]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6R37-R38) [[2]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L76-R78) [[3]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L124-R127) [[4]](diffhunk://#diff-bcdfd2e819de819fe5b3724b72c3e259bb0dfdbb7b821208fee0d6e2b4f60dc6L136-R138)
- Standardized enum values in `GetStringComparatorTest` to use uppercase (`GREATERTHAN`, `LESSTHAN`, `EQUALTO`) instead of lowercase, and updated all references accordingly. [[1]](diffhunk://#diff-bdda94d86d6ed9b01920bd55583503ac0bfd5794ec00bf12c6a118c668907901L20-R41) [[2]](diffhunk://#diff-bdda94d86d6ed9b01920bd55583503ac0bfd5794ec00bf12c6a118c668907901L61-R67)

**Functional/API changes:**
- Changed the return types of authentication and user controller methods to be more specific (`ResponseEntity<UserTokenState>`, `ResponseEntity<SecurityUser>`) instead of using wildcard types, improving type safety and clarity in the security module. [[1]](diffhunk://#diff-3af008c88659cd9ba8cb349bf171f03c0d968963c9db38b071cb7f9bd38ee23aL55-R55) [[2]](diffhunk://#diff-3af008c88659cd9ba8cb349bf171f03c0d968963c9db38b071cb7f9bd38ee23aL75-R75) [[3]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L83-R83)
- Modified the login endpoint in `LoginController` to accept only POST requests instead of both POST and GET, likely for improved security and REST compliance.

**Other minor changes:**
- Removed a PMD suppression annotation from `GedRendererFactory`, possibly because it was no longer needed.