### PR TITLE
Use Apache Commons utilities to clean up code

### DIFF
--- a/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BasicBirthDateEstimator.java
+++ b/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/BasicBirthDateEstimator.java
@@ -2,6 +2,7 @@ package org.schoellerfamily.gedbrowser.analytics;
 
 import java.util.List;
 
+import org.apache.commons.lang3.StringUtils;
 import org.joda.time.LocalDate;
 import org.schoellerfamily.gedbrowser.analytics.visitor.PersonAnalysisVisitor;
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
@@ -113,7 +114,7 @@ public class BasicBirthDateEstimator extends Estimator {
      */
     private LocalDate estimateFromEvent(final GedObject gob,
             final String dateString) {
-        if (dateString == null || dateString.isEmpty()) {
+        if (StringUtils.isEmpty(dateString)) {
             return null;
         }
         LocalDate date = createLocalDate(dateString);

--- a/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/Estimator.java
+++ b/gedbrowser-analytics/src/main/java/org/schoellerfamily/gedbrowser/analytics/Estimator.java
@@ -99,7 +99,7 @@ public abstract class Estimator {
      * @return true if valid
      */
     protected final boolean validDateString(final String dateString) {
-        return dateString != null && !dateString.isEmpty();
+        return StringUtils.isNotEmpty(dateString);
     }
 
     /**

--- a/gedbrowser-datamodel/pom.xml
+++ b/gedbrowser-datamodel/pom.xml
@@ -46,6 +46,10 @@
       <artifactId>commons-lang3</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
+    <dependency>
       <groupId>commons-logging</groupId>
       <artifactId>commons-logging</artifactId>
     </dependency>

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Date.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Date.java
@@ -4,6 +4,8 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.schoellerfamily.gedbrowser.datamodel.util.DateParser;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.GedObjectVisitor;
 
@@ -46,7 +48,7 @@ public final class Date extends AbstractAttribute {
      * @return the year as a string.
      */
     public String getYear() {
-        if (getString() == null || getString().isEmpty()) {
+        if (StringUtils.isEmpty(getString())) {
             return "";
         }
         final SimpleDateFormat dateFormatter = new SimpleDateFormat("yyyy",
@@ -58,7 +60,7 @@ public final class Date extends AbstractAttribute {
      * @return the string in a sortable format.
      */
     public String getSortDate() {
-        if (getString() == null || getString().isEmpty()) {
+        if (StringUtils.isEmpty(getString())) {
             return "";
         }
         final SimpleDateFormat formatter = new SimpleDateFormat("yyyyMMdd",

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/visitor/PersonVisitor.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/visitor/PersonVisitor.java
@@ -3,6 +3,7 @@ package org.schoellerfamily.gedbrowser.datamodel.visitor;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.apache.commons.collections4.CollectionUtils;
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
 import org.schoellerfamily.gedbrowser.datamodel.FamC;
 import org.schoellerfamily.gedbrowser.datamodel.FamS;
@@ -73,7 +74,7 @@ public final class PersonVisitor implements GedObjectVisitor {
      * @return the father.
      */
     public Person getFather() {
-        if (familyCNavigators == null || familyCNavigators.isEmpty()) {
+        if (CollectionUtils.isEmpty(familyCNavigators)) {
             return new Person();
         }
         return familyCNavigators.get(0).getFather();
@@ -85,7 +86,7 @@ public final class PersonVisitor implements GedObjectVisitor {
      * @return the mother.
      */
     public Person getMother() {
-        if (familyCNavigators == null || familyCNavigators.isEmpty()) {
+        if (CollectionUtils.isEmpty(familyCNavigators)) {
             return new Person();
         }
         return familyCNavigators.get(0).getMother();

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
@@ -13,6 +13,8 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.stream.StreamSupport;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.schoellerfamily.gedbrowser.datamodel.Root;
 import org.schoellerfamily.gedbrowser.datamodel.finder.FinderStrategy;
 import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
@@ -93,7 +95,7 @@ public class GedDocumentFileLoader {
      * @throws IllegalArgumentException if dbName is invalid
      */
     private void validateDatabaseName(final String dbName) {
-        if (dbName == null || dbName.isEmpty()) {
+        if (StringUtils.isEmpty(dbName)) {
             throw new IllegalArgumentException("Database name cannot be null or empty");
         }
 

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/StreamManager.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/StreamManager.java
@@ -50,8 +50,9 @@ public class StreamManager {
         if (filename.isEmpty()) {
             throw new IllegalArgumentException("Filename cannot be empty");
         }
-        final boolean looksLikeFile = (!filename.isEmpty() && filename.charAt(0) == '/')
-            || (!filename.isEmpty() && filename.charAt(0) == '.')
+        final char firstChar = filename.charAt(0);
+        final boolean looksLikeFile = firstChar == '/'
+            || firstChar == '.'
             || filename.contains(":") || filename.contains("src/") || filename.contains("target/");
         if (looksLikeFile) {
             validateFilePath(filename);

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/StreamManager.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/StreamManager.java
@@ -6,6 +6,8 @@ import java.io.InputStream;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 
+import org.apache.commons.lang3.StringUtils;
+
 /**
  * Can open a stream either in an absolute file location or in the classpath.
  *
@@ -48,8 +50,8 @@ public class StreamManager {
         if (filename.isEmpty()) {
             throw new IllegalArgumentException("Filename cannot be empty");
         }
-        final boolean looksLikeFile = (filename.length() > 0 && filename.charAt(0) == '/')
-            || (filename.length() > 0 && filename.charAt(0) == '.')
+        final boolean looksLikeFile = (!filename.isEmpty() && filename.charAt(0) == '/')
+            || (!filename.isEmpty() && filename.charAt(0) == '.')
             || filename.contains(":") || filename.contains("src/") || filename.contains("target/");
         if (looksLikeFile) {
             validateFilePath(filename);
@@ -71,7 +73,7 @@ public class StreamManager {
      * @throws IllegalArgumentException if filePath contains path traversal sequences
      */
     private void validateFilePath(final String filePath) {
-        if (filePath == null || filePath.isEmpty()) {
+        if (StringUtils.isEmpty(filePath)) {
             throw new IllegalArgumentException("File path cannot be null or empty");
         }
         // Check for null bytes and other dangerous characters
@@ -90,7 +92,7 @@ public class StreamManager {
      * @throws IllegalArgumentException if resourcePath contains path traversal sequences
      */
     private void validateResourcePath(final String resourcePath) {
-        if (resourcePath == null || resourcePath.isEmpty()) {
+        if (StringUtils.isEmpty(resourcePath)) {
             throw new IllegalArgumentException("Resource path cannot be null or empty");
         }
         // Check for null bytes and absolute paths

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/base/WebDriverFactory.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/base/WebDriverFactory.java
@@ -5,6 +5,8 @@ import java.net.URI;
 import java.net.URL;
 import java.util.logging.Level;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.openqa.selenium.MutableCapabilities;
 import org.openqa.selenium.logging.LogType;
 import org.openqa.selenium.logging.LoggingPreferences;
@@ -80,10 +82,10 @@ public class WebDriverFactory {
 
         // Standard W3C capability keys
         capabilities.setCapability(CapabilityType.BROWSER_NAME, browserName);
-        if (browserVersion != null && !browserVersion.isEmpty()) {
+        if (StringUtils.isNotEmpty(browserVersion)) {
             capabilities.setCapability("browserVersion", browserVersion);
         }
-        if (platform != null && !platform.isEmpty()) {
+        if (StringUtils.isNotEmpty(platform)) {
             // W3C uses "platformName" (string) instead of the old Platform enum
             capabilities.setCapability("platformName", platform);
         }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PersonPage.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PersonPage.java
@@ -2,6 +2,8 @@ package org.schoellerfamily.gedbrowser.selenium.pageobjects;
 
 import java.util.Map;
 
+import org.apache.commons.lang3.StringUtils;
+
 import lombok.extern.slf4j.Slf4j;
 import org.openqa.selenium.By;
 import org.openqa.selenium.NoSuchElementException;
@@ -59,8 +61,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
      * @return the built url string
      */
     private String url(final String baseUrl, final String iD) {
-        if (baseUrl == null || baseUrl.isEmpty() || iD == null
-                || iD.isEmpty()) {
+        if (StringUtils.isEmpty(baseUrl) || StringUtils.isEmpty(iD)) {
             return "";
         }
         return getBaseUrl() + "person?db=gl120368&id=" + iD;

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/service/storage/test/FileSystemStorageServiceTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/service/storage/test/FileSystemStorageServiceTest.java
@@ -10,6 +10,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -109,7 +110,7 @@ public class FileSystemStorageServiceTest {
         throws IOException {
         final MultipartFile file = mock(MultipartFile.class);
         when(file.getOriginalFilename()).thenReturn(filename);
-        when(file.isEmpty()).thenReturn(content == null || content.isEmpty());
+        when(file.isEmpty()).thenReturn(StringUtils.isEmpty(content));
         when(file.getInputStream())
             .thenReturn(new ByteArrayInputStream(
                 content == null ? new byte[0] : content.getBytes()));

--- a/geoservice-persistence/pom.xml
+++ b/geoservice-persistence/pom.xml
@@ -183,6 +183,10 @@
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-collections4</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.junit.jupiter</groupId>

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/GeoServiceGeocodingResult.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/GeoServiceGeocodingResult.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.geojson.Feature;
 import org.geojson.FeatureCollection;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.google.maps.model.AddressComponent;
 import com.google.maps.model.AddressType;
@@ -231,7 +232,7 @@ public final class GeoServiceGeocodingResult {
             return null;
         }
         final List<Feature> features = geometry.getFeatures();
-        if (features == null || features.isEmpty()) {
+        if (CollectionUtils.isEmpty(features)) {
             return null;
         }
         return features.get(0);

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/builder/BoundsBuilder.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/model/builder/BoundsBuilder.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.geojson.Feature;
 import org.geojson.LngLatAlt;
 import org.geojson.Polygon;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.google.maps.model.Bounds;
 
@@ -24,7 +25,7 @@ public interface BoundsBuilder extends LatLngBuilder {
         }
         final Polygon polygon = (Polygon) feature.getGeometry();
         final List<List<LngLatAlt>> coordinates = polygon.getCoordinates();
-        if (coordinates == null || coordinates.isEmpty()) {
+        if (CollectionUtils.isEmpty(coordinates)) {
             return new Bounds();
         }
         final List<LngLatAlt> list = coordinates.get(0);

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeLoader.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/GeoCodeLoader.java
@@ -7,6 +7,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.nio.charset.Charset;
 
+import org.apache.commons.lang3.StringUtils;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -120,9 +122,9 @@ public class GeoCodeLoader {
         ) {
             while ((line = br.readLine()) != null) {
                 final String[] splitLine = line.split("[|]", 4);
-                if (splitLine.length >= 2 && !splitLine[1].isEmpty()) {
+                if (splitLine.length >= 2 && StringUtils.isNotEmpty(splitLine[1])) {
                     loader.load(splitLine[0], splitLine[1]);
-                } else if (splitLine[0] != null && !splitLine[0].isEmpty()) {
+                } else if (StringUtils.isNotEmpty(splitLine[0])) {
                     loader.load(splitLine[0], splitLine[0]);
                 }
             }

--- a/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/fixture/GeoCodeTestFixture.java
+++ b/geoservice-persistence/src/main/java/org/schoellerfamily/geoservice/persistence/fixture/GeoCodeTestFixture.java
@@ -2,6 +2,8 @@ package org.schoellerfamily.geoservice.persistence.fixture;
 
 import java.util.Arrays;
 
+import org.apache.commons.lang3.StringUtils;
+
 import org.schoellerfamily.geoservice.persistence.GeoCode;
 
 /**
@@ -162,7 +164,7 @@ public class GeoCodeTestFixture {
      */
     private void load(final String[][] strings, final GeoCode gcc) {
         for (final String[] line : strings) {
-            if (line.length < 2 || line[1] == null || line[1].isEmpty()) {
+            if (line.length < 2 || StringUtils.isEmpty(line[1])) {
                 gcc.find(line[0]);
             } else {
                 gcc.find(line[0], line[1]);

--- a/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeValidator.java
+++ b/geoservice-persistence/src/test/java/org/schoellerfamily/geoservice/model/builder/test/GeocodeValidator.java
@@ -9,6 +9,7 @@ import org.geojson.LngLatAlt;
 import org.geojson.Point;
 import org.geojson.Polygon;
 import org.schoellerfamily.geoservice.model.GeoServiceGeocodingResult;
+import org.apache.commons.collections4.CollectionUtils;
 
 import com.google.maps.model.AddressComponent;
 import com.google.maps.model.AddressComponentType;
@@ -306,7 +307,7 @@ public class GeocodeValidator {
         } else if (geometry instanceof Polygon) {
             final Polygon poly = (Polygon) geometry;
             final List<List<LngLatAlt>> coordinates = poly.getCoordinates();
-            if (coordinates != null && !coordinates.isEmpty()) {
+            if (CollectionUtils.isNotEmpty(coordinates)) {
                 return false;
             }
         }

--- a/geoservice/src/main/java/org/schoellerfamily/geoservice/controller/GeoCodeEntryController.java
+++ b/geoservice/src/main/java/org/schoellerfamily/geoservice/controller/GeoCodeEntryController.java
@@ -3,6 +3,7 @@ package org.schoellerfamily.geoservice.controller;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 
+import org.apache.commons.lang3.StringUtils;
 import org.schoellerfamily.geoservice.model.GeoServiceItem;
 import org.schoellerfamily.geoservice.model.builder.GeocodeResultBuilder;
 import org.schoellerfamily.geoservice.persistence.GeoCode;
@@ -42,7 +43,7 @@ public class GeoCodeEntryController {
                 final String name,
             @RequestParam(value = "modernName", required = false)
                 final String modernName) {
-        if (modernName == null || modernName.isEmpty()) {
+        if (StringUtils.isEmpty(modernName)) {
             log.debug("Find location: \"{}\"", name);
         } else {
             log.debug("Find location: \"{}\", \"{}\"", name, modernName);
@@ -54,7 +55,7 @@ public class GeoCodeEntryController {
             findName = name;
         }
         String findModernName;
-        if (modernName == null || modernName.isEmpty()) {
+        if (StringUtils.isEmpty(modernName)) {
             final GeoCodeItem find = gcc.find(findName);
             final GeocodeResultBuilder builder = new GeocodeResultBuilder();
             return builder.toGeoServiceItem(find);

--- a/pom.xml
+++ b/pom.xml
@@ -83,6 +83,7 @@
     <commons-io.version>2.21.0</commons-io.version>
     <commons-logging.version>1.3.5</commons-logging.version>
     <commons-lang3.version>3.20.0</commons-lang3.version>
+    <commons-collections4.version>4.5.0</commons-collections4.version>
     <assertj.version>3.27.7</assertj.version>
 
     <coveralls-plugin.version>4.3.0</coveralls-plugin.version>
@@ -733,6 +734,11 @@
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>
         <version>${commons-lang3.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.commons</groupId>
+        <artifactId>commons-collections4</artifactId>
+        <version>${commons-collections4.version}</version>
       </dependency>
       <!-- related to working forward on google-maps-services -->
       <dependency>


### PR DESCRIPTION
This pull request introduces consistent usage of Apache Commons utility classes (`StringUtils` and `CollectionUtils`) across the codebase to simplify and standardize checks for empty or null strings and collections. This refactoring replaces manual null/empty checks with these utilities, improving code readability and reducing the risk of errors. Additionally, the necessary dependencies are added to the relevant Maven `pom.xml` files.

**Dependency and Utility Adoption**

* Added `commons-collections4` as a dependency in `gedbrowser-datamodel/pom.xml` and `geoservice-persistence/pom.xml` to enable use of `CollectionUtils`. [[1]](diffhunk://#diff-96a2bf4438eb3e6f8c28cf707f05fc4d1b1bb70050ccb73a3340d3eb10eb1631R48-R51) [[2]](diffhunk://#diff-19d7e526192fe0ab118cc983617c31e138c9fb441e6e5f7ceab6a972d2a0b80dR186-R189)
* Standardized string emptiness checks throughout the codebase by replacing manual checks with `StringUtils.isEmpty` and `StringUtils.isNotEmpty` from Apache Commons Lang. [[1]](diffhunk://#diff-bfed05a71ae2733077e61f24765733cc7552377e8638d335af69e47e58a855bdL116-R117) [[2]](diffhunk://#diff-aeb558a6b94054f8212c183d529f8afa1dafb88d495ac669599084b519ebb981L102-R102) [[3]](diffhunk://#diff-49bf8d8646d09e493fd0cfdf9d5c18e10184f8b423c9497bbd298ce66a3c341fL49-R51) [[4]](diffhunk://#diff-49bf8d8646d09e493fd0cfdf9d5c18e10184f8b423c9497bbd298ce66a3c341fL61-R63) [[5]](diffhunk://#diff-d60fb3e78aa30246b2e6c0e2c5974857c0236ca8c3db4d65d306fc7181eef163L96-R98) [[6]](diffhunk://#diff-5ec87e919215a5aa8c5a441059ddcf34c2e1bd1bb69ecb601c72a3538ec1f4d3L74-R76) [[7]](diffhunk://#diff-5ec87e919215a5aa8c5a441059ddcf34c2e1bd1bb69ecb601c72a3538ec1f4d3L93-R95) [[8]](diffhunk://#diff-eeeaaa0490f399214616f7ecc527d2183db4c7046e337af3dfe7ecaba4cdad59L83-R88) [[9]](diffhunk://#diff-25b671c74e0c40dbe40115c87b176fb7544ff75fb4966086773c3e70d524349aL62-R64) [[10]](diffhunk://#diff-3d00d0223f08b157b1cdd6106a101efca0a5ebe49e83c76c1d0a142aca913505L112-R113) [[11]](diffhunk://#diff-d2660b9c2feedd2d872dc088e56c7ac74a0effaae6ea02799e864be67ca1aa4bL123-R127) [[12]](diffhunk://#diff-0d64e7d99c9f8e2178b833b3d40d334b4381b41e17fde63327a7a4c021cab9b4L165-R167)
* Standardized collection emptiness checks by replacing manual null/empty checks with `CollectionUtils.isEmpty` from Apache Commons Collections. [[1]](diffhunk://#diff-b1ee2c31f40f40b28ab92a4113f294fadd53475b9e266c674da93c020933beecL76-R77) [[2]](diffhunk://#diff-b1ee2c31f40f40b28ab92a4113f294fadd53475b9e266c674da93c020933beecL88-R89) [[3]](diffhunk://#diff-f840e789de2c5b654608786a119778306eaa09d3812d587b5bfdb5c1eeea41a6L234-R235) [[4]](diffhunk://#diff-54ea3be6e29b467a3fc25b3a137fdd3b17d741a7c407a1dc56d96a0186520eddL27-R28)

**Code Quality and Readability**

* Improved code readability and maintainability by reducing repetitive boilerplate and potential for null pointer exceptions through the use of utility methods. [[1]](diffhunk://#diff-bfed05a71ae2733077e61f24765733cc7552377e8638d335af69e47e58a855bdL116-R117) [[2]](diffhunk://#diff-aeb558a6b94054f8212c183d529f8afa1dafb88d495ac669599084b519ebb981L102-R102) [[3]](diffhunk://#diff-49bf8d8646d09e493fd0cfdf9d5c18e10184f8b423c9497bbd298ce66a3c341fL49-R51) [[4]](diffhunk://#diff-49bf8d8646d09e493fd0cfdf9d5c18e10184f8b423c9497bbd298ce66a3c341fL61-R63) [[5]](diffhunk://#diff-d60fb3e78aa30246b2e6c0e2c5974857c0236ca8c3db4d65d306fc7181eef163L96-R98) [[6]](diffhunk://#diff-5ec87e919215a5aa8c5a441059ddcf34c2e1bd1bb69ecb601c72a3538ec1f4d3L74-R76) [[7]](diffhunk://#diff-5ec87e919215a5aa8c5a441059ddcf34c2e1bd1bb69ecb601c72a3538ec1f4d3L93-R95) [[8]](diffhunk://#diff-eeeaaa0490f399214616f7ecc527d2183db4c7046e337af3dfe7ecaba4cdad59L83-R88) [[9]](diffhunk://#diff-25b671c74e0c40dbe40115c87b176fb7544ff75fb4966086773c3e70d524349aL62-R64) [[10]](diffhunk://#diff-3d00d0223f08b157b1cdd6106a101efca0a5ebe49e83c76c1d0a142aca913505L112-R113) [[11]](diffhunk://#diff-d2660b9c2feedd2d872dc088e56c7ac74a0effaae6ea02799e864be67ca1aa4bL123-R127) [[12]](diffhunk://#diff-0d64e7d99c9f8e2178b833b3d40d334b4381b41e17fde63327a7a4c021cab9b4L165-R167) [[13]](diffhunk://#diff-b1ee2c31f40f40b28ab92a4113f294fadd53475b9e266c674da93c020933beecL76-R77) [[14]](diffhunk://#diff-b1ee2c31f40f40b28ab92a4113f294fadd53475b9e266c674da93c020933beecL88-R89) [[15]](diffhunk://#diff-f840e789de2c5b654608786a119778306eaa09d3812d587b5bfdb5c1eeea41a6L234-R235) [[16]](diffhunk://#diff-54ea3be6e29b467a3fc25b3a137fdd3b17d741a7c407a1dc56d96a0186520eddL27-R28)

**Imports and Test Updates**

* Updated import statements in affected files to include the newly used utility classes. [[1]](diffhunk://#diff-bfed05a71ae2733077e61f24765733cc7552377e8638d335af69e47e58a855bdR5) [[2]](diffhunk://#diff-49bf8d8646d09e493fd0cfdf9d5c18e10184f8b423c9497bbd298ce66a3c341fR7-R8) [[3]](diffhunk://#diff-b1ee2c31f40f40b28ab92a4113f294fadd53475b9e266c674da93c020933beecR6) [[4]](diffhunk://#diff-d60fb3e78aa30246b2e6c0e2c5974857c0236ca8c3db4d65d306fc7181eef163R16-R17) [[5]](diffhunk://#diff-5ec87e919215a5aa8c5a441059ddcf34c2e1bd1bb69ecb601c72a3538ec1f4d3R9-R10) [[6]](diffhunk://#diff-eeeaaa0490f399214616f7ecc527d2183db4c7046e337af3dfe7ecaba4cdad59R8-R9) [[7]](diffhunk://#diff-25b671c74e0c40dbe40115c87b176fb7544ff75fb4966086773c3e70d524349aR5-R6) [[8]](diffhunk://#diff-3d00d0223f08b157b1cdd6106a101efca0a5ebe49e83c76c1d0a142aca913505R13) [[9]](diffhunk://#diff-d2660b9c2feedd2d872dc088e56c7ac74a0effaae6ea02799e864be67ca1aa4bR10-R11) [[10]](diffhunk://#diff-0d64e7d99c9f8e2178b833b3d40d334b4381b41e17fde63327a7a4c021cab9b4R5-R6) [[11]](diffhunk://#diff-f840e789de2c5b654608786a119778306eaa09d3812d587b5bfdb5c1eeea41a6R9) [[12]](diffhunk://#diff-3c4aae2959e263171ba4f21e133d97800da91bb8a09d6bc0a6c30c9b1f5b6c07R12) [[13]](diffhunk://#diff-54ea3be6e29b467a3fc25b3a137fdd3b17d741a7c407a1dc56d96a0186520eddR8)

These changes collectively modernize the codebase by leveraging well-tested library utilities, making the codebase easier to maintain and less error-prone.