### PR TITLE
Potential fix for code scanning alert no. 11: Missing rate limiting

### DIFF
--- a/gedbrowserng-frontend/package.json
+++ b/gedbrowserng-frontend/package.json
@@ -51,7 +51,8 @@
     "tar-fs": "3.1.2",
     "tslib": "^2.0.0",
     "web-animations-js": "^2.3.2",
-    "zone.js": "^0.16.0"
+    "zone.js": "^0.16.0",
+    "express-rate-limit": "^8.3.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.0.0",

--- a/gedbrowserng-frontend/package.json
+++ b/gedbrowserng-frontend/package.json
@@ -51,8 +51,7 @@
     "tar-fs": "3.1.2",
     "tslib": "^2.0.0",
     "web-animations-js": "^2.3.2",
-    "zone.js": "^0.16.0",
-    "express-rate-limit": "^8.3.0"
+    "zone.js": "^0.16.0"
   },
   "devDependencies": {
     "@angular-devkit/build-angular": "^21.0.0",
@@ -73,6 +72,7 @@
     "@vitest/ui": "^4.0.0",
     "eslint": "9.39.3",
     "express": "^5.0.0",
+    "express-rate-limit": "^8.3.0",
     "jsdom": "28.1.0",
     "puppeteer": "24.38.0",
     "ts-node": "~10.9.0",

--- a/gedbrowserng-frontend/tools/headless-test.js
+++ b/gedbrowserng-frontend/tools/headless-test.js
@@ -6,7 +6,7 @@
 const express = require('express');
 const path = require('path');
 const puppeteer = require('puppeteer');
-const RateLimit = require('express-rate-limit');
+const { rateLimit } = require('express-rate-limit');
 
 const PORT = process.env.PORT || 4200;
 const HOST = 'http://localhost:' + PORT;
@@ -16,7 +16,7 @@ const pagesToTest = ['persons', 'notes', 'sources', 'submitters'];
 
 async function run() {
   const app = express();
-  const limiter = RateLimit({
+  const limiter = rateLimit({
     windowMs: 15 * 60 * 1000, // 15 minutes
     max: 1000, // limit each IP to 1000 requests per windowMs
   });

--- a/gedbrowserng-frontend/tools/headless-test.js
+++ b/gedbrowserng-frontend/tools/headless-test.js
@@ -6,6 +6,7 @@
 const express = require('express');
 const path = require('path');
 const puppeteer = require('puppeteer');
+const RateLimit = require('express-rate-limit');
 
 const PORT = process.env.PORT || 4200;
 const HOST = 'http://localhost:' + PORT;
@@ -15,6 +16,11 @@ const pagesToTest = ['persons', 'notes', 'sources', 'submitters'];
 
 async function run() {
   const app = express();
+  const limiter = RateLimit({
+    windowMs: 15 * 60 * 1000, // 15 minutes
+    max: 1000, // limit each IP to 1000 requests per windowMs
+  });
+  app.use(limiter);
   app.use(express.static(ROOT));
   // fallback to index.html
   app.get('*', (req, res) => res.sendFile(path.join(ROOT, 'index.html')));


### PR DESCRIPTION
Potential fix for [https://github.com/dickschoeller/gedbrowser/security/code-scanning/11](https://github.com/dickschoeller/gedbrowser/security/code-scanning/11)

Generally, to fix missing rate limiting in an Express app, you introduce a rate-limiting middleware (for example, using `express-rate-limit`) and apply it to the routes that perform expensive work (such as serving files) or to the entire app. This limits the number of requests per client IP over a time window, mitigating denial-of-service via request floods.

For this specific script, the best minimal change is to add `express-rate-limit` and apply a limiter to the whole `app` (or at least before `express.static` and the fallback `app.get('*', ...)`). This maintains existing behavior for normal usage, because typical headless tests will never hit the configured limit, while satisfying the security requirement. Concretely:
- Add `const RateLimit = require('express-rate-limit');` alongside the other `require` calls at the top of `gedbrowserng-frontend/tools/headless-test.js`.
- After `const app = express();` inside `run()`, define a limiter with a reasonable window and max requests (e.g., small but high enough that tests are unaffected, such as 1000 requests per 15 minutes).
- Add `app.use(limiter);` before `app.use(express.static(ROOT));` so both static file serving and the fallback `sendFile` route are protected.

No existing functionality (Puppeteer flows, routes, or logging) has to change; we only insert middleware and an import.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
