### PR TITLE
Clean up frontend layout alignment and collapsible sections

### DIFF
--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list.component.ts
@@ -41,8 +41,14 @@ import { AttributeListItemComponent } from './attribute-list-item.component';
                     }
                 </span>
             }
+            <button mat-icon-button
+                    [attr.aria-label]="showAttributes ? 'Collapse attributes' : 'Expand attributes'"
+                    (click)="showAttributes = !showAttributes">
+                <mat-icon>{{ showAttributes ? 'expand_less' : 'expand_more' }}</mat-icon>
+            </button>
     </mat-toolbar>
   </mat-card-title>
+    @if (showAttributes) {
   <mat-card-content>
         <div cdkDropList class="attribute-list" (cdkDropListDropped)="drop($event)"
                 [cdkDropListDisabled]="!hasSignedIn()">
@@ -55,6 +61,7 @@ import { AttributeListItemComponent } from './attribute-list-item.component';
             }
         </div>
   </mat-card-content>
+    }
 </mat-card>`,
     styles: [],
     imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatTooltip, MatIcon, NoteButtonComponent, SourceButtonComponent, SubmitterButtonComponent, MatCardContent, CdkDropList, CdkDrag, AttributeListItemComponent]
@@ -69,6 +76,7 @@ export class AttributeListComponent extends HasAttributeDialog implements OnInit
     @Input() showNotes = true;
     @Input() showSources = true;
     @Input() showSubmitters = true;
+    showAttributes = true;
 
     index;
     attributeDialogHelper = new AttributeDialogHelper(this);

--- a/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.css
+++ b/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.css
@@ -4,3 +4,10 @@
     align-items: center;
 }
 
+.title {
+    margin-left: 8px;
+    align-self: flex-end;
+    line-height: 1;
+    padding-bottom: 14px;
+}
+

--- a/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.html
+++ b/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.html
@@ -1,7 +1,7 @@
 <mat-toolbar color="primary">
   <div class="ui-toolbar-group-left with-icon">
     <button mat-icon-button (click)="toggle()"><mat-icon>menu</mat-icon></button>
-    <span class="title"> &nbsp; {{ title }}</span>
+    <span class="title">{{ title }}</span>
   </div>
   <span class="example-fill-remaining-space"></span>
   <app-user-buttons></app-user-buttons>

--- a/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
+++ b/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
@@ -6,15 +6,8 @@ import { UserButtonsComponent } from '../user-buttons/user-buttons.component';
 
 @Component({
     selector: 'app-main-menu',
-    template: `<mat-toolbar color="primary">
-  <div class="ui-toolbar-group-left with-icon">
-    <button mat-icon-button (click)="toggle()"><mat-icon>menu</mat-icon></button>
-    <span class="title"> &nbsp; {{ title }}</span>
-  </div>
-  <span class="example-fill-remaining-space"></span>
-  <app-user-buttons></app-user-buttons>
-</mat-toolbar>`,
-    styles: [],
+    templateUrl: './main-menu.component.html',
+    styleUrls: ['./main-menu.component.css'],
     imports: [MatToolbar, MatIconButton, MatIcon, UserButtonsComponent]
 })
 export class MainMenuComponent implements OnInit, OnChanges {

--- a/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
+++ b/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
@@ -6,8 +6,27 @@ import { UserButtonsComponent } from '../user-buttons/user-buttons.component';
 
 @Component({
     selector: 'app-main-menu',
-    templateUrl: './main-menu.component.html',
-    styleUrls: ['./main-menu.component.css'],
+  template: `<mat-toolbar color="primary">
+  <div class="ui-toolbar-group-left with-icon">
+  <button mat-icon-button (click)="toggle()"><mat-icon>menu</mat-icon></button>
+  <span class="title">{{ title }}</span>
+  </div>
+  <span class="example-fill-remaining-space"></span>
+  <app-user-buttons></app-user-buttons>
+</mat-toolbar>`,
+  styles: [`
+.with-icon {
+  display: flex;
+  align-items: center;
+}
+
+.title {
+  margin-left: 8px;
+  align-self: flex-end;
+  line-height: 1;
+  padding-bottom: 14px;
+}
+`],
     imports: [MatToolbar, MatIconButton, MatIcon, UserButtonsComponent]
 })
 export class MainMenuComponent implements OnInit, OnChanges {

--- a/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
+++ b/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
@@ -9,6 +9,8 @@ import { MultimediaDialogComponent, } from '../multimedia-dialog';
 import { UserService } from '../../services';
 import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { MatToolbar } from '@angular/material/toolbar';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedia-add-button.component';
 
 @Component({
@@ -23,8 +25,14 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
                     <app-multimedia-add-button [parent]="this" [dataset]="dataset"></app-multimedia-add-button>
                 </span>
             }
+            <button mat-icon-button
+                    [attr.aria-label]="showMultimedia ? 'Collapse multimedia' : 'Expand multimedia'"
+                    (click)="showMultimedia = !showMultimedia">
+                <mat-icon>{{ showMultimedia ? 'expand_less' : 'expand_more' }}</mat-icon>
+            </button>
     </mat-toolbar>
   </mat-card-title>
+        @if (showMultimedia) {
     @if (galleryImages().length) {
         <mat-card-content>
             <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
@@ -33,9 +41,10 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
     @if (!galleryImages().length) {
         <mat-card-content></mat-card-content>
     }
+    }
 </mat-card>`,
     styles: [],
-    imports: [MatCard, MatCardTitle, MatToolbar, MultimediaAddButtonComponent, MatCardContent, NgxGalleryModule]
+    imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatIcon, MultimediaAddButtonComponent, MatCardContent, NgxGalleryModule]
 })
 export class MultimediaGalleryComponent implements OnInit, HasMultimedia {
     @Input() dataset: string;
@@ -44,6 +53,7 @@ export class MultimediaGalleryComponent implements OnInit, HasMultimedia {
     @Input() styleClass: string;
     galleryOptions: NgxGalleryOptions[];
     dialogIndex = -1;
+    showMultimedia = true;
 
     constructor(@Inject(MatDialog) @Inject(MatDialog) @Inject(MatDialog) @Inject(MatDialog) public readonly dialog: MatDialog,
         @Inject(UserService) @Inject(UserService) @Inject(UserService) private readonly userService: UserService) { }

--- a/gedbrowserng-frontend/src/app/components/user-buttons/user-buttons.component.html
+++ b/gedbrowserng-frontend/src/app/components/user-buttons/user-buttons.component.html
@@ -13,7 +13,7 @@
   }
   @if (hasSignedIn()) {
     <button class="greeting-button" mat-button mat-ripple [matMenuTriggerFor]="accountMenu">
-      <span>{{ userName() }}</span>
+      <span class="title">{{ userName() }}</span>
     </button>
   }
   @if (hasSignedIn()) {

--- a/gedbrowserng-frontend/src/app/components/user-buttons/user-buttons.component.ts
+++ b/gedbrowserng-frontend/src/app/components/user-buttons/user-buttons.component.ts
@@ -25,7 +25,7 @@ import { AccountMenuComponent } from '../account-menu/account-menu.component';
   }
   @if (hasSignedIn()) {
     <button class="greeting-button" mat-button mat-ripple [matMenuTriggerFor]="accountMenu">
-      <span>{{ userName() }}</span>
+      <span class="user-title">{{ userName() }}</span>
     </button>
   }
   @if (hasSignedIn()) {
@@ -37,7 +37,14 @@ import { AccountMenuComponent } from '../account-menu/account-menu.component';
     <app-account-menu></app-account-menu>
   </mat-menu>
 </div>`,
-    styles: [],
+    styles: [`
+  .user-title {
+    margin-left: 8px;
+    display: inline-block;
+    line-height: 1;
+    transform: translateY(-4px);
+  }
+  `],
     imports: [MatButton, RouterLinkActive, RouterLink, MatMenuTrigger, MatIconButton, MatIcon, MatMenu, AccountMenuComponent]
 })
 export class UserButtonsComponent {

--- a/gedbrowserng-frontend/src/app/modules/note/note.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/note/note.component.ts
@@ -21,7 +21,9 @@ import { AttributeListComponent } from '../../components/attribute-list/attribut
         </div>
     <mat-card-content>
       <p class="multi_lines_text">{{ note?.tail }}</p>
-      <app-attribute-list [dataset]="dataset" [attributes]="note?.attributes" [parent]="this" [showAdd]="false" [showNotes]="false" [showSubmitters]="false"></app-attribute-list>
+      <div class="attributes-section">
+        <app-attribute-list [dataset]="dataset" [attributes]="note?.attributes" [parent]="this" [showAdd]="false" [showNotes]="false" [showSubmitters]="false"></app-attribute-list>
+      </div>
     </mat-card-content>
   </mat-card>
 </app-main-layout>`,
@@ -48,6 +50,10 @@ mat-card-subtitle {
 .mat-icon {
     vertical-align: top;
     font-size: 1.25em;
+}
+
+.attributes-section {
+  margin-top: 10px;
 }
     `],
     imports: [MainLayoutComponent, MatCard, MatCardTitle, MatIcon, MatCardSubtitle, MatCardContent, AttributeListComponent]

--- a/gedbrowserng-frontend/src/app/modules/person/person-family-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-family-list.component.ts
@@ -8,6 +8,8 @@ import { UrlBuilder, NewPersonHelper } from '../../utils';
 import { PersonService, UserService } from '../../services';
 import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { MatToolbar } from '@angular/material/toolbar';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { PersonFamilyComponent } from './person-family.component';
 import { NewPersonComponent } from './new-person.component';
 import { LinkPersonComponent } from './link-person.component';
@@ -23,8 +25,17 @@ import { LinkPersonComponent } from './link-person.component';
     selector: 'app-person-family-list',
     template: `<mat-card>
   <mat-card-title>
-        <mat-toolbar><span class="list-toolbar-title">Spouses and Children</span></mat-toolbar>
+                <mat-toolbar>
+                    <span class="list-toolbar-title">Spouses and Children</span>
+                    <span class="example-fill-remaining-space"></span>
+                    <button mat-icon-button
+                            [attr.aria-label]="showSpousesAndChildren ? 'Collapse spouses and children' : 'Expand spouses and children'"
+                            (click)="showSpousesAndChildren = !showSpousesAndChildren">
+                        <mat-icon>{{ showSpousesAndChildren ? 'expand_less' : 'expand_more' }}</mat-icon>
+                    </button>
+                </mat-toolbar>
   </mat-card-title>
+    @if (showSpousesAndChildren) {
   <mat-card-content>
     <div cdkDropList class="family-list" (cdkDropListDropped)="drop($event)"
         [cdkDropListDisabled]="!hasSignedIn()">
@@ -57,6 +68,7 @@ import { LinkPersonComponent } from './link-person.component';
       </div>
     }
   </mat-card-content>
+    }
 </mat-card>`,
     styles: [`
 .family-action-buttons {
@@ -65,7 +77,7 @@ import { LinkPersonComponent } from './link-person.component';
   gap: 4px;
 }
 `],
-    imports: [MatCard, MatCardTitle, MatToolbar, MatCardContent, CdkDropList, CdkDrag, PersonFamilyComponent, NewPersonComponent, LinkPersonComponent]
+    imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatIcon, MatCardContent, CdkDropList, CdkDrag, PersonFamilyComponent, NewPersonComponent, LinkPersonComponent]
 })
 export class PersonFamilyListComponent extends InitablePersonCreator implements LinkCheck {
     @Input() dataset: string;
@@ -75,6 +87,7 @@ export class PersonFamilyListComponent extends InitablePersonCreator implements 
     childSurname: string;
     partnerSex: string;
     childSex = 'M';
+    showSpousesAndChildren = true;
     _ub: UrlBuilder;
 
     constructor(@Inject(PersonService) @Inject(PersonService) @Inject(PersonService) @Inject(PersonService) public readonly personService: PersonService,

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
@@ -8,6 +8,8 @@ import { PersonService, UserService } from '../../services';
 import { UrlBuilder } from '../../utils';
 import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { MatToolbar } from '@angular/material/toolbar';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
 import { NewPersonComponent } from './new-person.component';
 import { LinkPersonComponent } from './link-person.component';
 import { PersonParentFamilyComponent } from './person-parent-family.component';
@@ -32,8 +34,14 @@ import { PersonParentFamilyComponent } from './person-parent-family.component';
             (emitOK)="linkPerson($event)"></app-link-person>
       </span>
     }
+    <button mat-icon-button
+        [attr.aria-label]="showParentsAndSiblings ? 'Collapse parents and siblings' : 'Expand parents and siblings'"
+        (click)="showParentsAndSiblings = !showParentsAndSiblings">
+      <mat-icon>{{ showParentsAndSiblings ? 'expand_less' : 'expand_more' }}</mat-icon>
+    </button>
     </mat-toolbar>
   </mat-card-title>
+  @if (showParentsAndSiblings) {
   <mat-card-content>
     <div cdkDropList class="family-list" (cdkDropListDropped)="drop($event)"
         [cdkDropListDisabled]="!hasSignedIn()">
@@ -45,9 +53,10 @@ import { PersonParentFamilyComponent } from './person-parent-family.component';
       }
     </div>
   </mat-card-content>
+  }
 </mat-card>`,
     styles: [],
-    imports: [MatCard, MatCardTitle, MatToolbar, NewPersonComponent, LinkPersonComponent, MatCardContent, CdkDropList, CdkDrag, PersonParentFamilyComponent]
+    imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatIcon, NewPersonComponent, LinkPersonComponent, MatCardContent, CdkDropList, CdkDrag, PersonParentFamilyComponent]
 })
 export class PersonParentFamiliesComponent extends InitablePersonCreator
   implements HasLifespan, HasPerson, RefreshPerson, Saveable {
@@ -55,6 +64,7 @@ export class PersonParentFamiliesComponent extends InitablePersonCreator
   @Input() parent: HasPerson & HasLifespan & Saveable;
   @Input() person: ApiPerson;
   sex = 'M';
+  showParentsAndSiblings = true;
   get surname(): string {
     return this.person.surname;
   }

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.ts
@@ -30,7 +30,7 @@ import { PersonParentFamiliesComponent } from './person-parent-families.componen
         </div>
     <mat-card-content>
       <div class="ui-g">
-        <div class="ui-g-12">
+        <div class="ui-g-12 attributes-section">
           <app-attribute-list [dataset]="dataset" [parent]="this" [attributes]="attributes"
                   [toggleable]="true"></app-attribute-list>
         </div>
@@ -83,6 +83,10 @@ mat-card-subtitle {
 .mat-icon {
     vertical-align: top;
     font-size: 1.25em;
+}
+
+.attributes-section {
+  margin-top: 10px;
 }
 
 .family-sections-row {

--- a/gedbrowserng-frontend/src/app/modules/source/source.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/source/source.component.ts
@@ -22,7 +22,7 @@ import { MultimediaGalleryComponent } from '../../components/multimedia-gallery/
         </div>
     <mat-card-content>
       <div class="ui-g">
-        <div class="ui-g-12">
+        <div class="ui-g-12 attributes-section">
           <app-attribute-list [dataset]="dataset" [attributes]="source?.attributes" [parent]="this" [showSources]="false" [showSubmitters]="false"></app-attribute-list>
         </div>
         <div class="ui-g-12">
@@ -55,6 +55,10 @@ mat-card-subtitle {
 .mat-icon {
     vertical-align: top;
     font-size: 1.25em;
+}
+
+.attributes-section {
+  margin-top: 10px;
 }
     `],
     imports: [MainLayoutComponent, MatCard, MatCardTitle, MatIcon, MatCardSubtitle, MatCardContent, AttributeListComponent, MultimediaGalleryComponent]

--- a/gedbrowserng-frontend/src/app/modules/submitter/submitter.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/submitter/submitter.component.ts
@@ -21,7 +21,9 @@ import { AttributeListComponent } from '../../components/attribute-list/attribut
           <mat-card-subtitle>{{ submitter?.string }}</mat-card-subtitle>
         </div>
     <mat-card-content>
-      <app-attribute-list [dataset]="dataset" [attributes]="submitter?.attributes" [parent]="this" [showSources]="false" [showSubmitters]="false"></app-attribute-list>
+      <div class="attributes-section">
+        <app-attribute-list [dataset]="dataset" [attributes]="submitter?.attributes" [parent]="this" [showSources]="false" [showSubmitters]="false"></app-attribute-list>
+      </div>
     </mat-card-content>
   </mat-card>
 </app-main-layout>`,
@@ -48,6 +50,10 @@ mat-card-subtitle {
 .mat-icon {
     vertical-align: top;
     font-size: 1.25em;
+}
+
+.attributes-section {
+  margin-top: 10px;
 }
     `],
     imports: [MainLayoutComponent, MatCard, MatCardTitle, MatIcon, MatCardSubtitle, MatCardContent, AttributeListComponent]

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -128,10 +128,10 @@ app-person-family-child-list mat-toolbar .mat-mdc-icon-button .mat-mdc-button-to
 app-attribute-list mat-toolbar .mat-icon,
 app-multimedia-gallery mat-toolbar .mat-icon,
 app-person-family-child-list mat-toolbar .mat-icon {
-  width: 18px;
-  height: 18px;
-  font-size: 18px;
-  line-height: 18px;
+  width: 24px;
+  height: 24px;
+  font-size: 24px;
+  line-height: 24px;
   margin: 0;
   padding: 0;
 }


### PR DESCRIPTION
## Summary
This PR cleans up layout and alignment behavior across the Angular frontend.

## What changed
- Made these sections collapsible:
  - Attributes
  - Multimedia
  - Spouses and Children
  - Parents and Siblings
- Reordered section show/hide toggle buttons so they appear after other toolbar action buttons.
- Increased spacing between page title area and attributes block on:
  - person
  - note
  - source
  - submitter
- Normalized main menu title alignment and moved  to external template/style files.
- Added a dedicated user-buttons text class so its alignment can be adjusted independently.

## Manual visual tuning included
- Incorporated iterative manual alignment tweaks from review feedback, including title/text baseline offsets and spacing adjustments.
