### PR TITLE
Replace ngx-gallery with LightGallery and add video support

### DIFF
--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/visitor/MultimediaVisitor.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/visitor/MultimediaVisitor.java
@@ -39,7 +39,10 @@ public final class MultimediaVisitor implements GedObjectVisitor {
         return "jpg".equalsIgnoreCase(form)
                 || "gif".equalsIgnoreCase(form)
                 || "png".equalsIgnoreCase(form)
-                || "tif".equalsIgnoreCase(form);
+                || "tif".equalsIgnoreCase(form)
+                || "avi".equalsIgnoreCase(form)
+                || "mp4".equalsIgnoreCase(form)
+	        || "youtube".equalsIgnoreCase(form);
     }
 
     /**

--- a/gedbrowserng-frontend/package.json
+++ b/gedbrowserng-frontend/package.json
@@ -39,7 +39,7 @@
     "font-awesome": "^4.7.0",
     "fstream": "^1.0.12",
     "hammerjs": "^2.0.8",
-    "ngx-gallery-15": "^21.0.0",
+    "lightgallery": "^2.8.3",
     "ngx-page-scroll": "^15.0.1",
     "ngx-page-scroll-core": "^15.0.1",
     "npm": "11.11.0",

--- a/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.html
+++ b/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.html
@@ -10,12 +10,35 @@
       }
     </mat-toolbar>
   </mat-card-title>
-  @if (galleryImages().length) {
-    <mat-card-content>
-      <ngx-gallery [options]="galleryOptions" [images]="galleryImages()"></ngx-gallery>
-    </mat-card-content>
-  }
-  @if (!galleryImages().length) {
-    <mat-card-content></mat-card-content>
+  @if (showMultimedia) {
+    @if (galleryImagesList.length) {
+      <mat-card-content>
+        <lightgallery [settings]="lightGallerySettings" [onInit]="onGalleryInit" [onBeforeSlide]="onBeforeSlide">
+          @for (image of galleryImagesList; track image.url; let i = $index) {
+            <a [attr.data-src]="image.mediaType === 'video' ? null : image.url" [attr.data-poster]="image.mediaType === 'video' ? image.small : null" [attr.data-sub-html]="image.description || 'Image'" [attr.data-gallery-index]="i" [attr.data-video]="image.mediaType === 'video' ? image.videoData : null" class="multimedia-thumb-wrapper">
+              <img [src]="image.small" [alt]="image.description || 'Image'" class="multimedia-thumb multimedia-video-preview" />
+              @if (image.mediaType === 'video' || image.mediaType === 'youtube') {
+                <div class="multimedia-video-play">
+                  <i class="fa fa-play-circle"></i>
+                </div>
+              }
+              @if (hasSignedIn()) {
+                <div class="multimedia-thumb-overlay">
+                  <button mat-icon-button class="multimedia-thumb-action" (click)="editButtonClicked($event, i)" [attr.aria-label]="'Edit image ' + (i + 1)">
+                    <i class="fa fa-pencil"></i>
+                  </button>
+                  <button mat-icon-button class="multimedia-thumb-action" (click)="deleteButtonClicked($event, i)" [attr.aria-label]="'Delete image ' + (i + 1)">
+                    <i class="fa fa-trash"></i>
+                  </button>
+                </div>
+              }
+            </a>
+          }
+        </lightgallery>
+      </mat-card-content>
+    }
+    @if (!galleryImagesList.length) {
+      <mat-card-content></mat-card-content>
+    }
   }
 </mat-card>

--- a/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.spec.ts
@@ -1,7 +1,6 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogModule, MatDialog } from '@angular/material/dialog';
-import { NgxGalleryModule } from 'ngx-gallery-15';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
 import { describe, it, expect, beforeEach, vi } from 'vitest';
@@ -30,18 +29,17 @@ describe('MultimediaGalleryComponent', () => {
     };
 
     TestBed.configureTestingModule({
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [MatDialogModule, NgxGalleryModule, MultimediaGalleryComponent],
-    providers: [
-      provideHttpClient(),
-      provideHttpClientTesting(),
-      { provide: UserService, useValue: mockUserService },
-      { provide: MatDialog, useValue: mockDialog },
-      AuthApiService,
-      ConfigService
-    ]
-})
-    .compileComponents();
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MatDialogModule, MultimediaGalleryComponent],
+      providers: [
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        { provide: UserService, useValue: mockUserService },
+        { provide: MatDialog, useValue: mockDialog },
+        AuthApiService,
+        ConfigService
+      ]
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -56,20 +54,21 @@ describe('MultimediaGalleryComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('should initialize gallery options on ngOnInit', () => {
+  it('should initialize lightgallery settings', () => {
     component.ngOnInit();
-    expect(component.galleryOptions).toBeDefined();
-    expect(component.galleryOptions.length).toBe(3);
+    expect(component.lightGallerySettings).toBeDefined();
+    expect(component.lightGallerySettings.thumbnail).toBe(true);
+    expect(component.lightGallerySettings.download).toBe(false);
   });
 
   it('should return empty array for undefined multimedia', () => {
-    component.multimedia = undefined;
+    component.multimedia = undefined as any;
     const images = component.galleryImages();
     expect(images).toEqual([]);
   });
 
   it('should return empty array for null multimedia', () => {
-    component.multimedia = null;
+    component.multimedia = null as any;
     const images = component.galleryImages();
     expect(images).toEqual([]);
   });
@@ -86,55 +85,14 @@ describe('MultimediaGalleryComponent', () => {
       { name: 'photo2.jpg', value: 'data:image/jpeg;base64,def456' } as ApiAttribute
     ];
     component.multimedia = mockMultimedia;
-    
+
     vi.spyOn(utils.ImageUtil, 'galleryImages').mockReturnValue([
-      { big: 'url1', small: 'url1', medium: 'url1', description: 'photo1.jpg' },
-      { big: 'url2', small: 'url2', medium: 'url2', description: 'photo2.jpg' }
+      { big: 'url1', small: 'url1', medium: 'url1', description: 'photo1.jpg', url: 'url1' },
+      { big: 'url2', small: 'url2', medium: 'url2', description: 'photo2.jpg', url: 'url2' }
     ]);
-    
+
     const images = component.galleryImages();
     expect(images.length).toBeGreaterThan(0);
-  });
-
-  it('should return undefined gallery image actions when not signed in', () => {
-    mockUserService.currentUser = null;
-    const actions = component.galleryImageActions();
-    expect(actions).toBeUndefined();
-  });
-
-  it('should return gallery image actions when signed in', () => {
-    mockUserService.currentUser = { id: 'user123' };
-    component.multimedia = [{ name: 'photo.jpg' } as ApiAttribute];
-    
-    const actions = component.galleryImageActions();
-    expect(actions).toBeDefined();
-    expect(actions.length).toBe(2);
-    expect(actions[0].icon).toContain('pencil');
-    expect(actions[1].icon).toContain('trash');
-  });
-
-  it('should call buildGalleryOptions with correct screen widths', () => {
-    component.ngOnInit();
-    
-    // Check that we have options for different breakpoints
-    const defaultOption = component.galleryOptions[0];
-    const mediumOption = component.galleryOptions[1];
-    const narrowOption = component.galleryOptions[2];
-    
-    expect(defaultOption).toBeDefined();
-    expect(mediumOption.breakpoint).toBe(500);
-    expect(narrowOption.breakpoint).toBe(300);
-  });
-
-  it('should set correct gallery options for default width', () => {
-    component.ngOnInit();
-    const defaultOption = component.galleryOptions[0];
-    
-    expect(defaultOption.image).toBe(false);
-    expect(defaultOption.preview).toBe(true);
-    expect(defaultOption.previewCloseOnClick).toBe(true);
-    expect(defaultOption.previewFullscreen).toBe(true);
-    expect(defaultOption.thumbnailsColumns).toBe(6);
   });
 
   it('should delete multimedia item at index', () => {
@@ -142,9 +100,9 @@ describe('MultimediaGalleryComponent', () => {
       { name: 'photo1.jpg' } as ApiAttribute,
       { name: 'photo2.jpg' } as ApiAttribute
     ];
-    
-    component.deleteButtonClicked(null, 0);
-    
+
+    component.deleteButtonClicked(new Event('click'), 0);
+
     expect(component.multimedia.length).toBe(1);
     expect(component.multimedia[0].name).toBe('photo2.jpg');
     expect(component.parent.save).toHaveBeenCalled();
@@ -153,14 +111,14 @@ describe('MultimediaGalleryComponent', () => {
   it('should open dialog on edit button click', () => {
     component.multimedia = [{ name: 'photo.jpg', attributes: [] } as ApiAttribute];
     mockUserService.currentUser = { id: 'user123' };
-    
+
     const mockDialogRef = {
       afterClosed: () => of(undefined)
     };
     mockDialog.open.mockReturnValue(mockDialogRef);
-    
-    component.editButtonClicked(null, 0);
-    
+
+    component.editButtonClicked(new Event('click'), 0);
+
     expect(mockDialog.open).toHaveBeenCalled();
     expect(component.dialogIndex).toBe(0);
   });
@@ -169,14 +127,15 @@ describe('MultimediaGalleryComponent', () => {
     const originalMultimedia = { name: 'photo.jpg', value: 'old' } as ApiAttribute;
     component.multimedia = [originalMultimedia];
     component.parent = { save: vi.fn() };
-    
+    component.dialogIndex = 0;
+
     vi.spyOn(utils.MultimediaDialogHelper, 'buildMultimediaAttribute').mockReturnValue({
       name: 'photo.jpg',
       value: 'new'
     } as ApiAttribute);
-    
+
     component.update({ value: 'new' } as any);
-    
+
     expect(component.multimedia[0].value).toBe('new');
     expect(component.parent.save).toHaveBeenCalled();
   });
@@ -196,66 +155,8 @@ describe('MultimediaGalleryComponent', () => {
     expect(component.hasSignedIn()).toBe(false);
   });
 
-  it('should handle multiple multimedia items', () => {
-    const multimedia = [
-      { name: 'photo1.jpg' } as ApiAttribute,
-      { name: 'photo2.jpg' } as ApiAttribute,
-      { name: 'photo3.jpg' } as ApiAttribute
-    ];
-    component.multimedia = multimedia;
-    
-    const images = component.galleryImages();
-    expect(images).toBeDefined();
-  });
-
-  it('should properly bind edit button clicked method', () => {
-    mockUserService.currentUser = { id: 'user123' };
-    
-    const actions = component.galleryImageActions();
-    
-    // Verify the edit action is bound
-    expect(actions[0].onClick).toBeDefined();
-  });
-
-  it('should properly bind delete button clicked method', () => {
-    mockUserService.currentUser = { id: 'user123' };
-    
-    const actions = component.galleryImageActions();
-    
-    // Verify the delete action is bound
-    expect(actions[1].onClick).toBeDefined();
-  });
-
-  it('should initialize dialogIndex to -1', () => {
-    fixture.detectChanges();
-    expect(component.dialogIndex).toBe(-1);
-  });
-
-  it('should set dialogIndex when edit button clicked', () => {
-    component.multimedia = [{ name: 'photo.jpg', attributes: [] } as ApiAttribute];
-    mockUserService.currentUser = { id: 'user123' };
-    mockDialog.open.mockReturnValue({ afterClosed: () => of(undefined) });
-    
-    component.editButtonClicked(null, 0);
-    
-    expect(component.dialogIndex).toBe(0);
-  });
-
-  it('should handle gallery options for medium width breakpoint', () => {
-    component.ngOnInit();
-    const mediumOption = component.galleryOptions[1];
-    
-    expect(mediumOption.breakpoint).toBe(500);
-    expect(mediumOption.width).toBe('300px');
-    expect(mediumOption.thumbnailsColumns).toBe(3);
-  });
-
-  it('should handle gallery options for narrow width breakpoint', () => {
-    component.ngOnInit();
-    const narrowOption = component.galleryOptions[2];
-    
-    expect(narrowOption.breakpoint).toBe(300);
-    expect(narrowOption.width).toBe('100%');
-    expect(narrowOption.thumbnailsColumns).toBe(2);
+  it('should update selected image index on slide event', () => {
+    component.onBeforeSlide({ index: 2 } as any);
+    expect(component.selectedImageIndex).toBe(2);
   });
 });

--- a/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
+++ b/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
@@ -1,11 +1,16 @@
-import { Component, OnInit, Input , Inject, ChangeDetectorRef, OnChanges, SimpleChanges } from '@angular/core';
+import { Component, OnInit, Input, Inject, ChangeDetectorRef, OnChanges, SimpleChanges, AfterViewChecked } from '@angular/core';
 import { MatDialog } from '@angular/material/dialog';
-import { NgxGalleryOptions, NgxGalleryImage, NgxGalleryAction, NgxGalleryModule } from 'ngx-gallery-15';
+import { LightgalleryModule } from 'lightgallery/angular';
+import { LightGallerySettings } from 'lightgallery/lg-settings';
+import { BeforeSlideDetail, InitDetail } from 'lightgallery/lg-events';
+import lgThumbnail from 'lightgallery/plugins/thumbnail';
+import lgVideo from 'lightgallery/plugins/video';
+import type { LightGallery } from 'lightgallery/lightgallery';
 
 import { HasMultimedia, Saveable } from '../../interfaces';
-import { ApiAttribute, MultimediaDialogData, MultimediaFileData, MultimediaFormat } from '../../models';
-import { ImageUtil, StringUtil, MultimediaDialogHelper, ArrayUtil } from '../../utils';
-import { MultimediaDialogComponent, } from '../multimedia-dialog';
+import { ApiAttribute, MultimediaDialogData } from '../../models';
+import { ImageUtil, MultimediaDialogHelper, GalleryImage } from '../../utils';
+import { MultimediaDialogComponent } from '../multimedia-dialog';
 import { UserService } from '../../services';
 import { MatCard, MatCardTitle, MatCardContent } from '@angular/material/card';
 import { MatToolbar } from '@angular/material/toolbar';
@@ -16,52 +21,101 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
 @Component({
     selector: 'app-multimedia-gallery',
     template: `<mat-card>
-  <mat-card-title>
-    <mat-toolbar>
+    <mat-card-title>
+        <mat-toolbar>
             <span class="list-toolbar-title">Multimedia</span>
-      <span class="example-fill-remaining-space"></span>
+            <span class="example-fill-remaining-space"></span>
             @if (hasSignedIn()) {
                 <span>
                     <app-multimedia-add-button [parent]="this" [dataset]="dataset"></app-multimedia-add-button>
                 </span>
             }
-            <button mat-icon-button
-                    [attr.aria-label]="showMultimedia ? 'Collapse multimedia' : 'Expand multimedia'"
-                    (click)="showMultimedia = !showMultimedia">
+            <button mat-icon-button [attr.aria-label]="showMultimedia ? 'Collapse multimedia' : 'Expand multimedia'" (click)="showMultimedia = !showMultimedia">
                 <mat-icon>{{ showMultimedia ? 'expand_less' : 'expand_more' }}</mat-icon>
             </button>
-    </mat-toolbar>
-  </mat-card-title>
-        @if (showMultimedia) {
-    @if (galleryImagesList.length) {
-        <mat-card-content>
-            <ngx-gallery [options]="galleryOptions" [images]="galleryImagesList"></ngx-gallery>
-        </mat-card-content>
-    }
-    @if (!galleryImagesList.length) {
-        <mat-card-content></mat-card-content>
-    }
+        </mat-toolbar>
+    </mat-card-title>
+    @if (showMultimedia) {
+        @if (galleryImagesList.length) {
+            <mat-card-content>
+                <lightgallery [settings]="lightGallerySettings" [onInit]="onGalleryInit" [onBeforeSlide]="onBeforeSlide">
+                    @for (image of galleryImagesList; track image.url; let i = $index) {
+                        <a [attr.data-src]="image.mediaType === 'video' ? null : image.url" [attr.data-poster]="image.mediaType === 'video' ? image.small : null" [attr.data-sub-html]="image.description || 'Image'" [attr.data-gallery-index]="i" [attr.data-video]="image.mediaType === 'video' ? image.videoData : null" class="multimedia-thumb-wrapper">
+                            <img [src]="image.small" [alt]="image.description || 'Image'" class="multimedia-thumb multimedia-video-preview" />
+                            @if (image.mediaType === 'video' || image.mediaType === 'youtube') {
+                                <div class="multimedia-video-play">
+                                    <i class="fa fa-play-circle"></i>
+                                </div>
+                            }
+                            @if (hasSignedIn()) {
+                                <div class="multimedia-thumb-overlay">
+                                    <button mat-icon-button class="multimedia-thumb-action" (click)="editButtonClicked($event, i)" [attr.aria-label]="'Edit image ' + (i + 1)">
+                                        <i class="fa fa-pencil"></i>
+                                    </button>
+                                    <button mat-icon-button class="multimedia-thumb-action" (click)="deleteButtonClicked($event, i)" [attr.aria-label]="'Delete image ' + (i + 1)">
+                                        <i class="fa fa-trash"></i>
+                                    </button>
+                                </div>
+                            }
+                        </a>
+                    }
+                </lightgallery>
+            </mat-card-content>
+        }
+        @if (!galleryImagesList.length) {
+            <mat-card-content></mat-card-content>
+        }
     }
 </mat-card>`,
-    styles: [],
-    imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatIcon, MultimediaAddButtonComponent, MatCardContent, NgxGalleryModule]
+    styles: [
+        '.multimedia-thumb-wrapper { position: relative; display: inline-block; width: 120px; height: 90px; margin: 0 6px 6px 0; }',
+        '.multimedia-thumb { width: 120px; height: 90px; object-fit: cover; border-radius: 4px; display: block; }',
+        '.multimedia-video-preview { pointer-events: none; background: #111; }',
+        '.multimedia-video-play { position: absolute; inset: 0; display: flex; align-items: center; justify-content: center; color: #fff; font-size: 28px; text-shadow: 0 1px 3px rgba(0, 0, 0, 0.8); pointer-events: none; }',
+        '.multimedia-thumb-overlay { position: absolute; top: 0; left: 0; right: 0; bottom: 0; display: flex; align-items: center; justify-content: center; gap: 4px; background: rgba(0, 0, 0, 0.5); border-radius: 4px; opacity: 0; transition: opacity 0.2s; pointer-events: none; }',
+        '.multimedia-thumb-wrapper:hover .multimedia-thumb-overlay { opacity: 1; pointer-events: auto; }',
+        '.multimedia-thumb-action { color: white !important; width: 32px; height: 32px; min-width: 32px; min-height: 32px; background: rgba(0, 0, 0, 0.7) !important; }',
+        '.multimedia-thumb-action:hover { background: rgba(0, 0, 0, 0.9) !important; }',
+        '.multimedia-thumb-action .fa { font-size: 16px; }'
+    ],
+    imports: [MatCard, MatCardTitle, MatToolbar, MatIconButton, MatIcon, MultimediaAddButtonComponent, MatCardContent, LightgalleryModule]
 })
-export class MultimediaGalleryComponent implements OnInit, OnChanges, HasMultimedia {
+export class MultimediaGalleryComponent implements OnInit, OnChanges, AfterViewChecked, HasMultimedia {
     @Input() dataset: string;
     @Input() parent: Saveable;
     @Input() multimedia: Array<ApiAttribute>;
     @Input() styleClass: string;
-    galleryOptions: NgxGalleryOptions[];
-    galleryImagesList: Array<NgxGalleryImage> = [];
+
+    galleryImagesList: Array<GalleryImage> = [];
+    selectedImageIndex = 0;
     dialogIndex = -1;
     showMultimedia = true;
+    lightGallerySettings: LightGallerySettings = {
+        plugins: [lgThumbnail, lgVideo],
+        thumbnail: true,
+        download: false,
+        counter: true,
+        selector: 'a'
+    };
 
-    constructor(@Inject(MatDialog) @Inject(MatDialog) @Inject(MatDialog) @Inject(MatDialog) public readonly dialog: MatDialog,
-        @Inject(UserService) @Inject(UserService) @Inject(UserService) private readonly userService: UserService,
-        private readonly cdr: ChangeDetectorRef) { }
+    onBeforeSlide = (detail: BeforeSlideDetail): void => {
+        this.selectedImageIndex = detail.index;
+    };
 
-    ngOnInit() {
-        this.galleryOptions = this.buildGalleryOptions();
+    onGalleryInit = (detail: InitDetail): void => {
+        this.lightGallery = detail.instance;
+    };
+
+    private lightGallery?: LightGallery;
+    private needGalleryRefresh = false;
+
+    constructor(
+        @Inject(MatDialog) public readonly dialog: MatDialog,
+        @Inject(UserService) private readonly userService: UserService,
+        private readonly cdr: ChangeDetectorRef
+    ) {}
+
+    ngOnInit(): void {
         this.refreshGalleryImages();
     }
 
@@ -71,41 +125,26 @@ export class MultimediaGalleryComponent implements OnInit, OnChanges, HasMultime
         }
     }
 
-    galleryImages(): Array<NgxGalleryImage> {
+    ngAfterViewChecked(): void {
+        if (this.needGalleryRefresh && this.lightGallery) {
+            this.lightGallery.refresh();
+            this.needGalleryRefresh = false;
+        }
+    }
+
+    galleryImages(): Array<GalleryImage> {
         this.refreshGalleryImages();
         return this.galleryImagesList;
     }
 
-    galleryImageActions() {
-        if (!this.hasSignedIn()) {
-            return;
-        }
-        this.editButtonClicked = this.editButtonClicked.bind(this);
-        this.deleteButtonClicked = this.deleteButtonClicked.bind(this);
-
-        const editAction = <NgxGalleryAction>{
-            icon: 'fa fa-pencil',
-            titleText: 'Edit',
-            onClick: this.editButtonClicked
-        };
-
-        const deleteAction = <NgxGalleryAction>{
-            icon: 'fa fa-trash',
-            titleText: 'Delete',
-            onClick: this.deleteButtonClicked
-        };
-
-        return [editAction, deleteAction];
-    }
-
-    editButtonClicked(event, i) {
+    editButtonClicked(event: Event, i: number): void {
+        event.preventDefault();
+        event.stopPropagation();
         this.dialogIndex = i;
         this.update = this.update.bind(this);
-        const dialogRef = this.dialog.open(
-            MultimediaDialogComponent,
-            {
-                data: MultimediaDialogHelper.buildMultimediaDialogData(this.multimedia, this.dialogIndex)
-            });
+        const dialogRef = this.dialog.open(MultimediaDialogComponent, {
+            data: MultimediaDialogHelper.buildMultimediaDialogData(this.multimedia, this.dialogIndex)
+        });
 
         dialogRef.afterClosed().subscribe((result: MultimediaDialogData) => {
             if (result !== undefined) {
@@ -114,58 +153,20 @@ export class MultimediaGalleryComponent implements OnInit, OnChanges, HasMultime
         });
     }
 
-    deleteButtonClicked(event, i) {
+    deleteButtonClicked(event: Event, i: number): void {
+        event.preventDefault();
+        event.stopPropagation();
         this.multimedia.splice(i, 1);
+        this.selectedImageIndex = Math.max(0, Math.min(this.selectedImageIndex, this.multimedia.length - 1));
         this.forceViewRefresh();
         this.save();
-    }
-
-    buildGalleryOptions(): Array<NgxGalleryOptions> {
-        return [
-            this.galleryOptionsDefault(),
-            this.galleryOptionsMediumWidth(),
-            this.galleryOptionsNarrow()
-        ];
-    }
-
-    private galleryOptionsDefault(): NgxGalleryOptions {
-        return {
-            image: false,
-            preview: true,
-            previewCloseOnClick: true,
-            previewCloseOnEsc: true,
-            previewKeyboardNavigation: true,
-            previewFullscreen: true,
-            height: '200px',
-            width: '800px',
-            thumbnailsColumns: 6,
-            thumbnailActions: this.galleryImageActions(),
-            imageActions: this.galleryImageActions(),
-        };
-    }
-
-    private galleryOptionsMediumWidth(): NgxGalleryOptions {
-        return {
-            preview: true,
-            breakpoint: 500,
-            width: '300px',
-            thumbnailsColumns: 3,
-        };
-    }
-
-    private galleryOptionsNarrow(): NgxGalleryOptions {
-        return {
-            breakpoint: 300,
-            width: '100%',
-            thumbnailsColumns: 2,
-        };
     }
 
     save(): void {
         this.parent.save();
     }
 
-    update(data: MultimediaDialogData) {
+    update(data: MultimediaDialogData): void {
         const updatedAttribute = MultimediaDialogHelper.buildMultimediaAttribute(data);
         this.multimedia.splice(this.dialogIndex, 1, updatedAttribute);
         this.forceViewRefresh();
@@ -176,20 +177,26 @@ export class MultimediaGalleryComponent implements OnInit, OnChanges, HasMultime
         this.forceViewRefresh();
     }
 
-    hasSignedIn() {
+    hasSignedIn(): boolean {
         return !!this.userService.currentUser;
     }
 
     private refreshGalleryImages(): void {
         if (!this.multimedia || this.multimedia.length === 0) {
             this.galleryImagesList = [];
+            this.selectedImageIndex = 0;
+            this.needGalleryRefresh = true;
             return;
         }
+
         try {
             this.galleryImagesList = ImageUtil.galleryImages(this.multimedia);
+            this.selectedImageIndex = Math.min(this.selectedImageIndex, Math.max(0, this.galleryImagesList.length - 1));
         } catch {
             this.galleryImagesList = [];
+            this.selectedImageIndex = 0;
         }
+        this.needGalleryRefresh = true;
     }
 
     private forceViewRefresh(): void {

--- a/gedbrowserng-frontend/src/app/models/multimedia-dialog-data.ts
+++ b/gedbrowserng-frontend/src/app/models/multimedia-dialog-data.ts
@@ -29,6 +29,7 @@ export enum MultimediaFormat {
   mpg = 'mpg',
   mp4 = 'mp4',
   mov = 'mov',
+  youtube = 'youtube',
   // Document formats
   doc = 'doc',
   docx = 'docx',

--- a/gedbrowserng-frontend/src/app/utils/image-util.spec.ts
+++ b/gedbrowserng-frontend/src/app/utils/image-util.spec.ts
@@ -31,6 +31,21 @@ describe('ImageUtil', () => {
     });
   });
 
+  describe('isVideo', () => {
+    it.each(['mp4', 'mov', 'avi', 'm4v', 'mpg', 'webm'])(
+      'should identify %s as video',
+      (extension) => {
+        const attr = createAttribute(`clip.${extension}`);
+        expect(ImageUtil.isVideo(attr)).toBe(true);
+      }
+    );
+
+    it('should not identify non-video file', () => {
+      const attr = createAttribute('document.pdf');
+      expect(ImageUtil.isVideo(attr)).toBe(false);
+    });
+  });
+
   describe('imageFormat', () => {
     it.each([
       ['photo.jpg', 'jpg'],
@@ -90,6 +105,12 @@ describe('ImageUtil', () => {
       const wrapper = createWrapper(innerImage);
       expect(ImageUtil.isImageWrapper(wrapper)).toBe(true);
     });
+
+    it('should return true for wrapper containing video', () => {
+      const innerVideo = createAttribute('clip.mp4');
+      const wrapper = createWrapper(innerVideo);
+      expect(ImageUtil.isImageWrapper(wrapper)).toBe(true);
+    });
   });
 
   describe('galleryImages', () => {
@@ -119,6 +140,15 @@ describe('ImageUtil', () => {
       const result = ImageUtil.galleryImages([wrapper]);
       expect(result.length).toBe(1);
       expect(result[0]).toBeDefined();
+    });
+
+    it('should convert wrapper with video to gallery images', () => {
+      const innerVideo = createAttribute('clip.mp4');
+      const wrapper = createWrapper(innerVideo);
+      const result = ImageUtil.galleryImages([wrapper]);
+      expect(result.length).toBe(1);
+      expect(result[0].mediaType).toBe('video');
+      expect(result[0].videoData).toContain('video/mp4');
     });
   });
 });

--- a/gedbrowserng-frontend/src/app/utils/image-util.ts
+++ b/gedbrowserng-frontend/src/app/utils/image-util.ts
@@ -1,6 +1,14 @@
-import { NgxGalleryImage, NgxGalleryOptions } from 'ngx-gallery-15';
-
 import { ApiAttribute } from '../models';
+
+export interface GalleryImage {
+  small: string;
+  medium: string;
+  big: string;
+  description: string;
+  url: string;
+  mediaType?: 'image' | 'video' | 'youtube';
+  videoData?: string;
+}
 
 export class ImageUtil {
   constructor() {}
@@ -8,15 +16,15 @@ export class ImageUtil {
   public static imageAttributes(attributes: Array<ApiAttribute>): Array<ApiAttribute> {
     const images: Array<ApiAttribute> = new Array<ApiAttribute>();
     for (const attribute of attributes) {
-      if (this.isImageWrapper(attribute)) {
+      if (this.isMediaWrapper(attribute)) {
         images.push(attribute);
       }
     }
     return images;
   }
 
-  public static galleryImages(attributes: Array<ApiAttribute>): Array<NgxGalleryImage> {
-    const gallery: Array<NgxGalleryImage> = new Array<NgxGalleryImage>();
+  public static galleryImages(attributes: Array<ApiAttribute>): Array<GalleryImage> {
+    const gallery: Array<GalleryImage> = new Array<GalleryImage>();
     for (const attribute of this.imageAttributes(attributes)) {
       gallery.push(this.galleryImage(attribute));
     }
@@ -24,8 +32,12 @@ export class ImageUtil {
   }
 
   public static isImageWrapper(attr: ApiAttribute): boolean {
+    return this.isMediaWrapper(attr);
+  }
+
+  public static isMediaWrapper(attr: ApiAttribute): boolean {
     for (const attribute of attr.attributes) {
-      if (this.isImage(attribute) || this.isImageWrapper(attribute)) {
+      if (this.isImage(attribute) || this.isVideo(attribute) || this.isMediaWrapper(attribute)) {
         return true;
       }
     }
@@ -34,12 +46,29 @@ export class ImageUtil {
 
   public static isImage(attribute: ApiAttribute): boolean {
     const types = [ 'bmp', 'gif', 'ico', 'jpg', 'jpeg', 'png', 'tiff', 'tif', 'svg' ];
+    const tail = (attribute.tail || '').toLowerCase();
     for (const t of types) {
-      if (attribute.tail.toLowerCase().endsWith(t)) {
+      if (tail.endsWith(`.${t}`) || tail.endsWith(t)) {
         return true;
       }
     }
     return false;
+  }
+
+  public static isVideo(attribute: ApiAttribute): boolean {
+    const types = [ 'avi', 'm4v', 'mov', 'mp4', 'mpg', 'mpeg', 'webm' ];
+    const tail = (attribute.tail || '').toLowerCase();
+    for (const t of types) {
+      if (tail.endsWith(`.${t}`) || tail.endsWith(t)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  public static isYouTube(attribute: ApiAttribute): boolean {
+    const tail = (attribute.tail || '').toLowerCase();
+    return tail.includes('youtube.com/watch') || tail.includes('youtu.be/');
   }
 
   public static imageFormat(attribute: ApiAttribute): string {
@@ -52,10 +81,16 @@ export class ImageUtil {
     return 'jpg';
   }
 
-  public static galleryImage(attr: ApiAttribute): NgxGalleryImage {
-    const description = 'Image';
+  public static galleryImage(attr: ApiAttribute): GalleryImage {
+    const description = 'Media';
+    if (this.isYouTube(attr)) {
+      return this.buildGalleryImage(attr.tail, this.youtubePoster(attr.tail), description, 'youtube');
+    }
     if (this.isImage(attr)) {
-      return this.buildGalleryImage(attr.tail, description);
+      return this.buildGalleryImage(attr.tail, attr.tail, description, 'image');
+    }
+    if (this.isVideo(attr)) {
+      return this.buildGalleryImage(attr.tail, this.defaultVideoPoster(), description, 'video');
     }
     return this.buildGalleryImageFromArray(attr.attributes, description);
   }
@@ -68,22 +103,103 @@ export class ImageUtil {
   }
 
   private static buildGalleryImageFromArray(attributes: Array<ApiAttribute>,
-    description: string): NgxGalleryImage {
+    description: string): GalleryImage {
     for (const attribute of attributes) {
       description = this.buildDescription(attribute, description);
-      if (this.isImage(attribute)) {
-        return this.buildGalleryImage(attribute.tail, description);
+      if (this.isYouTube(attribute)) {
+        return this.buildGalleryImage(attribute.tail, this.findPoster(attributes) || this.youtubePoster(attribute.tail), description, 'youtube');
       }
-      if (this.isImageWrapper(attribute)) {
+      if (this.isImage(attribute)) {
+        return this.buildGalleryImage(attribute.tail, attribute.tail, description, 'image');
+      }
+      if (this.isVideo(attribute)) {
+        return this.buildGalleryImage(attribute.tail, this.findPoster(attributes) || this.defaultVideoPoster(), description, 'video');
+      }
+      if (this.isMediaWrapper(attribute)) {
         return this.buildGalleryImageFromArray(attribute.attributes, description);
       }
     }
     return null;
   }
 
-  private static buildGalleryImage(url: string, description: string): NgxGalleryImage {
-    return {
-      small: url, medium: url, big: url, description: description, url: url
+  private static buildGalleryImage(url: string, previewUrl: string, description: string, mediaType: 'image' | 'video' | 'youtube'): GalleryImage {
+    const media: GalleryImage = {
+      small: previewUrl,
+      medium: previewUrl,
+      big: url,
+      description: description,
+      url: url,
+      mediaType,
     };
+
+    if (mediaType === 'video') {
+      media.videoData = JSON.stringify({
+        source: [{ src: url, type: this.videoMimeType(url) }],
+        attributes: { controls: true, preload: false, playsinline: true }
+      });
+    }
+
+    return media;
+  }
+
+  private static videoMimeType(url: string): string {
+    const tail = (url || '').toLowerCase();
+    if (tail.endsWith('.webm')) {
+      return 'video/webm';
+    }
+    if (tail.endsWith('.avi')) {
+      return 'video/x-msvideo';
+    }
+    if (tail.endsWith('.mov')) {
+      return 'video/quicktime';
+    }
+    if (tail.endsWith('.m4v')) {
+      return 'video/x-m4v';
+    }
+    if (tail.endsWith('.mpg') || tail.endsWith('.mpeg')) {
+      return 'video/mpeg';
+    }
+    return 'video/mp4';
+  }
+
+  private static findPoster(attributes: Array<ApiAttribute>): string | null {
+    for (const attribute of attributes) {
+      if (this.isImage(attribute)) {
+        return attribute.tail;
+      }
+      if (attribute.attributes && attribute.attributes.length) {
+        const nestedPoster = this.findPoster(attribute.attributes);
+        if (nestedPoster) {
+          return nestedPoster;
+        }
+      }
+    }
+    return null;
+  }
+
+  private static youtubePoster(url: string): string {
+    const id = this.youtubeId(url);
+    if (!id) {
+      return this.defaultVideoPoster();
+    }
+    return `https://img.youtube.com/vi/${id}/hqdefault.jpg`;
+  }
+
+  private static youtubeId(url: string): string | null {
+    const normalized = (url || '').trim();
+    const shortMatch = normalized.match(/youtu\.be\/([^?&]+)/i);
+    if (shortMatch?.[1]) {
+      return shortMatch[1];
+    }
+    const longMatch = normalized.match(/[?&]v=([^?&]+)/i);
+    if (longMatch?.[1]) {
+      return longMatch[1];
+    }
+    return null;
+  }
+
+  private static defaultVideoPoster(): string {
+    // Transparent 1x1 fallback keeps layout stable if no linked image is present.
+    return 'data:image/gif;base64,R0lGODlhAQABAIAAAAAAAP///ywAAAAAAQABAAACAUwAOw==';
   }
 }

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -1,5 +1,8 @@
 @import '~font-awesome/css/font-awesome.min.css';
 @import '~@angular/material/prebuilt-themes/indigo-pink.css';
+@import '~lightgallery/css/lightgallery.css';
+@import '~lightgallery/css/lg-thumbnail.css';
+@import '~lightgallery/css/lg-video.css';
 
 html, body, app-root, .body, .mat-drawer-container {
   height: 100%;
@@ -136,16 +139,6 @@ app-person-family-child-list mat-toolbar .mat-icon {
   padding: 0;
 }
 
-ngx-gallery-arrows.ngx-gallery-image-size-contain .fa {
-    background: white;
-    padding: 5px;
-    color: black;
-}
-
-.ngx-gallery-icon {
-    color: white;
-}
-
 div.ui-orderlist-controls {
     display: none !important;
 }
@@ -244,8 +237,9 @@ span.parent {
   min-width: 352px;
 }
 
-.ngx-gallery {
-  display: inline-block;
+.lg-outer .lg-thumb-item.active,
+.lg-outer .lg-thumb-item:hover {
+  border-color: #1976d2;
 }
 
 .mat-form-field {

--- a/gedbrowserng-frontend/yarn.lock
+++ b/gedbrowserng-frontend/yarn.lock
@@ -6236,6 +6236,11 @@ lie@3.1.1:
   dependencies:
     immediate "~3.0.5"
 
+lightgallery@^2.8.3:
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/lightgallery/-/lightgallery-2.9.0.tgz#b3b6e15169eb9b840f70e14d67b9ec0a213cc612"
+  integrity sha512-58Ud1DyhD2ao58t+kPEqSZrjFxg23tGd5ZKr75erm7q31g5xhUtWUJH3sTUkhHzlyJAKHj5eTrJ37HQRXG4Wbg==
+
 lines-and-columns@^1.1.6:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/lines-and-columns/-/lines-and-columns-1.2.4.tgz#eca284f75d2965079309dc0ad9255abb2ebc1632"
@@ -6712,13 +6717,6 @@ netmask@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/netmask/-/netmask-2.0.2.tgz#8b01a07644065d536383835823bc52004ebac5e7"
   integrity sha512-dBpDMdxv9Irdq66304OLfEmQ9tbNRFnFTuZiLo+bD+r332bBmMJ8GBLXklIXXgxd3+v9+KUnZaUR5PJMa75Gsg==
-
-ngx-gallery-15@^21.0.0:
-  version "21.0.7"
-  resolved "https://registry.yarnpkg.com/ngx-gallery-15/-/ngx-gallery-15-21.0.7.tgz#63418aa54379fe07b0ecad6346d6a591f3eb48c1"
-  integrity sha512-EYFt4BnTQ0k0YBTLB9UJXTgvUMRuOW9lLme70k82m8XReO3gml+6xZTzyVYhCisGhgLyRk6tXvOJCOvTpAr0+g==
-  dependencies:
-    tslib "^2.4.1"
 
 ngx-page-scroll-core@^15.0.1:
   version "15.0.1"
@@ -8577,7 +8575,7 @@ ts-node@~10.9.0:
     v8-compile-cache-lib "^3.0.1"
     yn "3.1.1"
 
-tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.4.1, tslib@^2.6.2, tslib@^2.8.1:
+tslib@2.8.1, tslib@^2.0.0, tslib@^2.0.1, tslib@^2.1.0, tslib@^2.3.0, tslib@^2.4.0, tslib@^2.6.2, tslib@^2.8.1:
   version "2.8.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
   integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/datamodel/ImageUtils.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/datamodel/ImageUtils.java
@@ -26,7 +26,7 @@ public class ImageUtils {
     public boolean isImage(final ApiAttribute attribute) {
         final String[] types = {
                 "bmp", "gif", "ico", "jpg", "jpeg", "png", "tiff",
-                "tif", "svg" };
+                "tif", "svg", "avi", "m4v", "mpg", "mp4", "mov", "youtube" };
         for (final String t : types) {
             if (attribute.getTail().toLowerCase(Locale.ENGLISH).endsWith(t)) {
                 return true;


### PR DESCRIPTION
## Summary
- replace  with  in the Angular frontend
- migrate multimedia gallery rendering and interactions to LightGallery
- add thumbnail overlay edit/delete controls with hover behavior
- add video support using LightGallery video plugin
- support YouTube external URLs and HTML5 videos with poster images
- update related multimedia utility/model handling and tests

## Validation
- frontend targeted tests pass
- yarn run v1.22.22
info Visit https://yarnpkg.com/en/docs/cli/run for documentation about this command. passes

## Notes
- keeps existing signed-in edit/delete workflow on gallery items