### PR TITLE
Fix delete UX and add duplicate detection/cleanup endpoints

### DIFF
--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.spec.ts
@@ -142,6 +142,7 @@ describe('AttributeListItemComponent', () => {
     component.attributeList = [attr1, attr2];
     component.attribute = attr1;
 
+    mockMatDialog.open.mockReturnValue({ afterClosed: () => of(true) });
     component.delete();
 
     expect(component.attributeList.length).toBe(1);
@@ -244,6 +245,7 @@ describe('AttributeListItemComponent', () => {
     component.attributeList = [attr1, attr2, attr3];
     component.attribute = attr2;
 
+    mockMatDialog.open.mockReturnValue({ afterClosed: () => of(true) });
     component.delete();
 
     expect(component.attributeList.length).toBe(2);

--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
@@ -7,6 +7,7 @@ import { UserService } from '../../services';
 import { AttributeDialogHelper, AttributeAnalyzer } from '../../utils';
 
 import { HasAttributeDialog } from './has-attribute-dialog';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
 import { AttributeListItemDetailListComponent } from './attribute-list-item-detail-list.component';
 import { MatIconButton } from '@angular/material/button';
 import { MatTooltip } from '@angular/material/tooltip';
@@ -89,9 +90,16 @@ export class AttributeListItemComponent extends HasAttributeDialog {
     }
 
     delete(): void {
-        const index = this.attributeList.indexOf(this.attribute);
-        this.attributeList.splice(index, 1);
-        this.parent.save();
+        const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+            data: { message: 'Are you sure you want to delete this attribute?' }
+        });
+        dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+            if (confirmed) {
+                const index = this.attributeList.indexOf(this.attribute);
+                this.attributeList.splice(index, 1);
+                this.parent.save();
+            }
+        });
     }
 
     href() {

--- a/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.spec.ts
@@ -1,0 +1,43 @@
+import { NO_ERRORS_SCHEMA } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogModule } from '@angular/material/dialog';
+import { MatButtonModule } from '@angular/material/button';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatIconModule } from '@angular/material/icon';
+import { vi } from 'vitest';
+
+import { ConfirmDialogComponent } from './confirm-dialog.component';
+
+describe('ConfirmDialogComponent', () => {
+  let component: ConfirmDialogComponent;
+  let fixture: ComponentFixture<ConfirmDialogComponent>;
+  let mockDialogRef: { close: ReturnType<typeof vi.fn> };
+
+  beforeEach(() => {
+    mockDialogRef = { close: vi.fn() };
+
+    TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [MatDialogModule, MatButtonModule, MatToolbarModule, MatIconModule, ConfirmDialogComponent],
+      providers: [
+        { provide: MatDialogRef, useValue: mockDialogRef },
+        { provide: MAT_DIALOG_DATA, useValue: { message: 'Delete item?' } }
+      ]
+    }).compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(ConfirmDialogComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+
+  it('should close dialog on cancel', () => {
+    component.onNoClick();
+    expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+});

--- a/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -23,6 +23,7 @@ export interface ConfirmDialogData {
   <button mat-button (click)="onNoClick()">Cancel</button>
 </div>`,
     styles: [],
+    standalone: true,
     imports: [MatDialogTitle, MatToolbar, MatIcon, CdkScrollable, MatDialogContent, MatDialogActions, MatButton, MatDialogClose]
 })
 export class ConfirmDialogComponent {

--- a/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.ts
+++ b/gedbrowserng-frontend/src/app/components/confirm-dialog/confirm-dialog.component.ts
@@ -1,0 +1,37 @@
+import { Component, Inject } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import { MatButton } from '@angular/material/button';
+import { MatToolbar } from '@angular/material/toolbar';
+import { MatIcon } from '@angular/material/icon';
+import { CdkScrollable } from '@angular/cdk/scrolling';
+
+export interface ConfirmDialogData {
+    message: string;
+}
+
+@Component({
+    selector: 'app-confirm-dialog',
+    template: `<div mat-dialog-title>
+  <mat-toolbar color="warn"><mat-icon matListIcon>warning</mat-icon> &nbsp; Confirm Delete</mat-toolbar>
+</div>
+<div mat-dialog-content>
+  <p>{{ data.message }}</p>
+</div>
+<div mat-dialog-actions>
+  <span class="example-fill-remaining-space"></span>
+  <button mat-button [mat-dialog-close]="true" cdkFocusInitial>OK</button>
+  <button mat-button (click)="onNoClick()">Cancel</button>
+</div>`,
+    styles: [],
+    imports: [MatDialogTitle, MatToolbar, MatIcon, CdkScrollable, MatDialogContent, MatDialogActions, MatButton, MatDialogClose]
+})
+export class ConfirmDialogComponent {
+    constructor(
+        @Inject(MatDialogRef) public readonly dialogRef: MatDialogRef<ConfirmDialogComponent>,
+        @Inject(MAT_DIALOG_DATA) public readonly data: ConfirmDialogData
+    ) {}
+
+    onNoClick(): void {
+        this.dialogRef.close();
+    }
+}

--- a/gedbrowserng-frontend/src/app/components/confirm-dialog/index.ts
+++ b/gedbrowserng-frontend/src/app/components/confirm-dialog/index.ts
@@ -1,0 +1,1 @@
+export * from './confirm-dialog.component';

--- a/gedbrowserng-frontend/src/app/components/index.ts
+++ b/gedbrowserng-frontend/src/app/components/index.ts
@@ -1,5 +1,6 @@
 export * from './attribute-dialog';
 export * from './attribute-list';
+export * from './confirm-dialog';
 export * from './link-dialog';
 export * from './link-person-dialog';
 export * from './main-menu';

--- a/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.spec.ts
@@ -219,6 +219,12 @@ describe('SideMenuComponent', () => {
     expect(component.dbs[component.dbs.length - 1]).toBe('david');
   });
 
+  it('should deduplicate database entries in setupItems', () => {
+    const dbs = ['schoeller', 'mini', 'schoeller'];
+    component.setupItems(dbs);
+    expect(component.dbs).toEqual(['mini', 'schoeller']);
+  });
+
   it('should handle null file in upload', () => {
     // Null files are handled by the validator, so we just test that the form control exists
     expect(component.filesControl).toBeDefined();

--- a/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.ts
+++ b/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.ts
@@ -154,7 +154,8 @@ export class SideMenuComponent implements OnInit, OnChanges {
 
   setupItems(dbs: Array<string>): void {
     this.dbs = new Array<string>();
-    for (const db of dbs.toSorted((a, b) => a.localeCompare(b))) {
+    const uniqueDbs = Array.from(new Set(dbs));
+    for (const db of uniqueDbs.toSorted((a, b) => a.localeCompare(b))) {
       this.dbs.push(db);
     }
   }

--- a/gedbrowserng-frontend/src/app/modules/note-list/note-list.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/note-list/note-list.component.spec.ts
@@ -62,6 +62,7 @@ describe('NoteListComponent', () => {
     const router = new StubRouter();
     const svc = new StubNoteService();
     const dlg = new StubDialog();
+    dlg.result = true;
     const comp = new NoteListComponent(router as any, svc as any, dlg as any);
     comp.parent = new StubParent() as any;
     const note = new ApiNote();

--- a/gedbrowserng-frontend/src/app/modules/note-list/note-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/note-list/note-list.component.ts
@@ -6,7 +6,7 @@ import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 
 import { NoteCreator } from '../../bases';
-import { NewNoteDialogComponent } from '../../components';
+import { NewNoteDialogComponent, ConfirmDialogComponent } from '../../components';
 import { NewNoteDialogData } from '../../models';
 import { ApiNote, NewPersonDialogData } from '../../models';
 import { NoteService } from '../../services';
@@ -184,8 +184,15 @@ export class NoteListComponent extends NoteCreator implements AfterViewInit, OnC
   }
 
   delete(note: ApiNote) {
-    this.noteService.delete(this.dataset, note).subscribe((n: ApiNote) => {
-      this.refreshNote(n);
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { message: 'Are you sure you want to delete this note?' }
+    });
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.noteService.delete(this.dataset, note).subscribe((n: ApiNote) => {
+          this.refreshNote(n);
+        });
+      }
     });
   }
 

--- a/gedbrowserng-frontend/src/app/modules/person-list/person-list.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person-list/person-list.component.spec.ts
@@ -94,7 +94,9 @@ describe('PersonListComponent', () => {
   it('navigate composes route path and delete refreshes', () => {
     const router = new StubRouter();
     const svc = new StubPersonService();
-    const comp = new PersonListComponent(router as any, svc as any, new StubDialog() as any);
+    const dlg = new StubDialog();
+    dlg.result = true;
+    const comp = new PersonListComponent(router as any, svc as any, dlg as any);
     comp.dataset = 'ds';
     comp.p = new StubParent() as any;
     comp.navigate('P1');

--- a/gedbrowserng-frontend/src/app/modules/person-list/person-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person-list/person-list.component.ts
@@ -6,7 +6,7 @@ import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 
 import { PersonCreator } from '../../bases';
-import { NewPersonDialogComponent } from '../../components';
+import { NewPersonDialogComponent, ConfirmDialogComponent } from '../../components';
 import { ApiPerson, NewPersonDialogData } from '../../models';
 import { PersonService } from '../../services';
 import { UrlBuilder, NewPersonHelper, ListPage, ListPageHelper } from '../../utils';
@@ -238,8 +238,15 @@ export class PersonListComponent extends PersonCreator implements AfterViewInit,
   }
 
   delete(person: ApiPerson) {
-    this.personService.delete(this.dataset, person).subscribe((p: ApiPerson) => {
-      this.refreshPerson();
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { message: 'Are you sure you want to delete this person?' }
+    });
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.personService.delete(this.dataset, person).subscribe((p: ApiPerson) => {
+          this.refreshPerson();
+        });
+      }
     });
   }
 }

--- a/gedbrowserng-frontend/src/app/modules/source-list/source-list.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/source-list/source-list.component.spec.ts
@@ -188,6 +188,7 @@ describe('SourceListComponent', () => {
     component.parent = { refreshSource: vi.fn() } as any;
 
     const deleteSpy = vi.spyOn(sourceService, 'delete').mockReturnValue(of(mockSources[0]));
+    vi.spyOn(dialog, 'open').mockReturnValue({ afterClosed: () => of(true) } as any);
 
     component.delete(mockSources[0]);
 

--- a/gedbrowserng-frontend/src/app/modules/source-list/source-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/source-list/source-list.component.ts
@@ -7,7 +7,7 @@ import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeader
 
 import { SourceCreator } from '../../bases/source-creator';
 import { NewSourceHelper, UrlBuilder, ListPage, ListPageHelper } from '../../utils';
-import { NewSourceDialogComponent } from '../../components';
+import { NewSourceDialogComponent, ConfirmDialogComponent } from '../../components';
 import { ApiSource } from '../../models';
 import { SourceService } from '../../services';
 import { SourceListPageComponent } from './source-list-page.component';
@@ -181,8 +181,15 @@ export class SourceListComponent extends SourceCreator implements AfterViewInit,
   }
 
   delete(source: ApiSource) {
-    this.sourceService.delete(this.dataset, source).subscribe((s: ApiSource) => {
-      this.refreshSource(s);
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { message: 'Are you sure you want to delete this source?' }
+    });
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.sourceService.delete(this.dataset, source).subscribe((s: ApiSource) => {
+          this.refreshSource(s);
+        });
+      }
     });
   }
 }

--- a/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.spec.ts
@@ -130,6 +130,7 @@ describe('SubmitterListComponent', () => {
     const refreshSubmitterSpy = vi.spyOn(component.parent, 'refreshSubmitter');
 
     vi.spyOn(submitterService, 'delete').mockReturnValue(of(mockSubmitters[0]));
+    vi.spyOn(dialog, 'open').mockReturnValue({ afterClosed: () => of(true) } as any);
 
     component.delete(mockSubmitters[0]);
 
@@ -182,6 +183,7 @@ describe('SubmitterListComponent', () => {
     component.dataset = 'testDataset';
     const deleteSpy = vi.spyOn(submitterService, 'delete').mockReturnValue(of(mockSubmitters[0]));
     const refreshSpy = vi.spyOn(component.parent, 'refreshSubmitter');
+    vi.spyOn(dialog, 'open').mockReturnValue({ afterClosed: () => of(true) } as any);
 
     component.delete(mockSubmitters[0]);
 

--- a/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.ts
@@ -6,7 +6,7 @@ import { MatSort, MatSortHeader } from '@angular/material/sort';
 import { MatTableDataSource, MatTable, MatColumnDef, MatHeaderCellDef, MatHeaderCell, MatCellDef, MatCell, MatHeaderRowDef, MatHeaderRow, MatRowDef, MatRow } from '@angular/material/table';
 
 import { SubmitterCreator } from '../../bases/submitter-creator';
-import { NewSubmitterDialogComponent } from '../../components/';
+import { NewSubmitterDialogComponent, ConfirmDialogComponent } from '../../components/';
 import { NewSubmitterDialogData } from '../../models';
 import { ApiSubmitter } from '../../models';
 import { SubmitterService } from '../../services';
@@ -185,8 +185,15 @@ export class SubmitterListComponent extends SubmitterCreator implements AfterVie
   }
 
   delete(source: ApiSubmitter) {
-    this.submitterService.delete(this.dataset, source).subscribe((s: ApiSubmitter) => {
-      this.refreshSubmitter(s);
+    const dialogRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { message: 'Are you sure you want to delete this submitter?' }
+    });
+    dialogRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.submitterService.delete(this.dataset, source).subscribe((s: ApiSubmitter) => {
+          this.refreshSubmitter(s);
+        });
+      }
     });
   }
 }

--- a/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/submitter-list/submitter-list.component.ts
@@ -184,13 +184,13 @@ export class SubmitterListComponent extends SubmitterCreator implements AfterVie
     this.navigate(id);
   }
 
-  delete(source: ApiSubmitter) {
+  delete(submitter: ApiSubmitter) {
     const dialogRef = this.dialog.open(ConfirmDialogComponent, {
       data: { message: 'Are you sure you want to delete this submitter?' }
     });
     dialogRef.afterClosed().subscribe((confirmed: boolean) => {
       if (confirmed) {
-        this.submitterService.delete(this.dataset, source).subscribe((s: ApiSubmitter) => {
+        this.submitterService.delete(this.dataset, submitter).subscribe((s: ApiSubmitter) => {
           this.refreshSubmitter(s);
         });
       }

--- a/gedbrowserng-frontend/src/app/services/datasets.service.spec.ts
+++ b/gedbrowserng-frontend/src/app/services/datasets.service.spec.ts
@@ -59,6 +59,19 @@ describe('DatasetsService', () => {
       expect(result).toEqual([]);
     });
 
+    it('should deduplicate dataset names', async () => {
+      const datasets = ['schoeller', 'schoeller', 'mini'];
+
+      const result$ = service.get();
+      const promise = result$.toPromise();
+
+      const req = httpMock.expectOne('/gedbrowserng/v1/dbs');
+      req.flush(datasets);
+
+      const result = await promise;
+      expect(result).toEqual(['schoeller', 'mini']);
+    });
+
     it('should handle HTTP errors', async () => {
       const promise = service.get().toPromise();
 

--- a/gedbrowserng-frontend/src/app/services/datasets.service.ts
+++ b/gedbrowserng-frontend/src/app/services/datasets.service.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Inject, Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { UrlBuilder } from '../utils/urlbuilder';
 
@@ -10,7 +10,9 @@ export class DatasetsService {
   constructor(@Inject(HttpClient) private readonly http: HttpClient) { }
 
   get(): Observable<Array<String>> {
-    return this.http.get<Array<String>>(this.url());
+    return this.http.get<Array<String>>(this.url()).pipe(
+      map((datasets) => Array.from(new Set(datasets)))
+    );
   }
 
   url() {

--- a/gedbrowserng-frontend/src/app/services/service-base.ts
+++ b/gedbrowserng-frontend/src/app/services/service-base.ts
@@ -1,6 +1,6 @@
 import { HttpClient } from '@angular/common/http';
 import { Injectable } from '@angular/core';
-import { Observable } from 'rxjs';
+import { Observable, map } from 'rxjs';
 
 import { ApiService } from './api-service';
 import { ApiObject } from '../models';
@@ -17,7 +17,19 @@ export abstract class ServiceBase<T extends ApiObject> implements ApiService<T> 
   }
 
   getAll(db: string): Observable<Array<T>> {
-    return this.http.get<Array<T>>(this.url(db));
+    return this.http.get<Array<T>>(this.url(db)).pipe(
+      map((items) => {
+        const seen = new Set<string>();
+        return items.filter((item) => {
+          const key = item?.string;
+          if (!key || seen.has(key)) {
+            return false;
+          }
+          seen.add(key);
+          return true;
+        });
+      })
+    );
   }
 
   getOne(db: string, id): Observable<T> {

--- a/gedbrowserng-frontend/src/app/services/testing/service-spec-helpers.ts
+++ b/gedbrowserng-frontend/src/app/services/testing/service-spec-helpers.ts
@@ -136,6 +136,20 @@ export const describeCrudResourceService = <T>(config: CrudSpecConfig<T>) => {
       expect(result).toEqual(entities);
     });
 
+    it('should deduplicate entities with same ID string', async () => {
+      const entities = [createEntity(id), createEntity(id), createEntity(altId)];
+
+      const result$ = getService().getAll(testDb);
+      const promise = firstValueFrom(result$);
+
+      const req = getHttpMock().expectOne(`/gedbrowserng/v1/dbs/${testDb}/${resource}`);
+      expect(req.request.method).toBe('GET');
+      req.flush(entities);
+
+      const result = await promise;
+      expect(result).toEqual([createEntity(id), createEntity(altId)]);
+    });
+
     if (includeEmptyListTest) {
       it('should handle empty list', async () => {
         const result$ = getService().getAll(testDb);

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -61,12 +61,24 @@ a:active {
 
 app-attribute-list-item .hidden .mat-icon-button,
 app-attribute-list-item .hidden .mat-mdc-icon-button {
+  --mdc-icon-button-state-layer-size: 16px;
+  --mat-icon-button-state-layer-size: 16px;
   width: 16px;
   height: 16px;
   min-width: 16px;
   min-height: 16px;
   margin: 0;
   padding: 0;
+}
+
+app-attribute-list-item .hidden .mat-mdc-icon-button .mat-mdc-button-touch-target,
+app-attribute-list-item .hidden .mat-mdc-icon-button .mat-mdc-button-persistent-ripple,
+app-attribute-list-item .hidden .mat-mdc-icon-button .mat-mdc-button-ripple {
+  width: 16px;
+  height: 16px;
+  top: 0;
+  left: 0;
+  transform: none;
 }
 
 app-attribute-list-item .hidden .mat-icon {
@@ -88,6 +100,16 @@ app-person-family-child .hidden .mat-mdc-icon-button {
   min-height: 16px;
   margin: 0;
   padding: 0;
+}
+
+app-person-family-child .hidden .mat-mdc-icon-button .mat-mdc-button-touch-target,
+app-person-family-child .hidden .mat-mdc-icon-button .mat-mdc-button-persistent-ripple,
+app-person-family-child .hidden .mat-mdc-icon-button .mat-mdc-button-ripple {
+  width: 16px;
+  height: 16px;
+  top: 0;
+  left: 0;
+  transform: none;
 }
 
 app-person-family-child .hidden .mat-icon {

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/DatasetsController.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/controller/DatasetsController.java
@@ -38,6 +38,7 @@ public final class DatasetsController {
         final List<String> list =
             StreamSupport.stream(all.spliterator(), false)
                 .map(m -> m.getDbName())
+                .distinct()
                 .toList();
         log.info("length: {}", list.size());
         return list;

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/ReadOperations.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/crud/ReadOperations.java
@@ -2,6 +2,8 @@ package org.schoellerfamily.gedbrowser.api.crud;
 
 import java.util.List;
 import java.util.Locale;
+import java.util.function.Function;
+import java.util.stream.Collectors;
 
 import org.schoellerfamily.gedbrowser.api.controller.exception.DataSetNotFoundException;
 import org.schoellerfamily.gedbrowser.api.controller.exception.ObjectNotFoundException;
@@ -103,6 +105,13 @@ public interface ReadOperations<
         try {
             final Iterable<Y> a = getRepository().findAll(root);
             return java.util.stream.StreamSupport.stream(a.spliterator(), false)
+                .filter(doc -> doc != null && doc.getString() != null)
+                .collect(Collectors.toMap(
+                    Y::getString,
+                    Function.identity(),
+                    (first, second) -> first,
+                    java.util.LinkedHashMap::new))
+                .values().stream()
                 .sorted(new GetStringComparator())
                 .toList();
         } catch (RuntimeException e) {

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/CleanupDuplicatesEndpoint.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/CleanupDuplicatesEndpoint.java
@@ -1,0 +1,42 @@
+package org.schoellerfamily.gedbrowser.api.endpoint;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Actuator endpoint to remove duplicate dataset documents.
+ */
+@Component
+@Endpoint(id = "cleanupduplicates")
+@RequiredArgsConstructor
+@Slf4j
+public class CleanupDuplicatesEndpoint {
+    /** */
+    private final DuplicateCleanupService duplicateCleanupService;
+
+    /**
+     * @return summary messages
+     */
+    @ReadOperation
+    public List<String> invoke() {
+        log.info("Invoke cleanupduplicates");
+        final Map<String, Integer> deleted = duplicateCleanupService.cleanup();
+        return List.of(
+            "Removed duplicates: roots=%d, persons=%d, sources=%d, submitters=%d, total=%d"
+                .formatted(
+                    deleted.getOrDefault("roots", 0),
+                    deleted.getOrDefault("persons", 0),
+                    deleted.getOrDefault("sources", 0),
+                    deleted.getOrDefault("submitters", 0),
+                    deleted.getOrDefault("total", 0)
+                )
+        );
+    }
+}

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Comparator;
 
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
@@ -75,6 +76,8 @@ public class DuplicateCleanupService {
             if (ids.size() <= 1) {
                 continue;
             }
+            // Ensure deterministic behavior: sort IDs before deciding which one to keep
+            ids.sort(Comparator.comparing(Object::toString));
             final List<Object> idsToDelete = ids.subList(1, ids.size());
             deletedCount += idsToDelete.size();
             final Query deleteQuery = Query.query(Criteria.where("_id").in(idsToDelete));

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -121,6 +121,11 @@ public class DuplicateCleanupService {
                 continue;
             }
             final String key = buildKey(doc);
+            if (key == null) {
+                log.warn("Skipping document without valid filename/string in {}: id={}",
+                    collectionName, id);
+                continue;
+            }
             List<Object> ids = idsByKey.get(key);
             if (ids == null) {
                 ids = newIdList();
@@ -133,11 +138,15 @@ public class DuplicateCleanupService {
 
     /**
      * @param doc document from a top-level GED collection
-     * @return de-duplication key based on filename and string
+     * @return de-duplication key based on filename and string, or {@code null}
+     *         if either component is missing
      */
     private String buildKey(final Document doc) {
         final Object filename = doc.get("filename");
         final Object string = doc.get("string");
+        if (filename == null || string == null) {
+            return null;
+        }
         return String.valueOf(filename) + "\u0000" + String.valueOf(string);
     }
 

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -33,10 +33,10 @@ public class DuplicateCleanupService {
      */
     public Map<String, Integer> cleanup() {
         final Map<String, Integer> deleted = new LinkedHashMap<>();
-        deleted.put("roots", cleanupCollection("roots"));
-        deleted.put("persons", cleanupCollection("persons"));
-        deleted.put("sources", cleanupCollection("sources"));
-        deleted.put("submitters", cleanupCollection("submitters"));
+        deleted.put("roots", Math.toIntExact(cleanupCollection("roots")));
+        deleted.put("persons", Math.toIntExact(cleanupCollection("persons")));
+        deleted.put("sources", Math.toIntExact(cleanupCollection("sources")));
+        deleted.put("submitters", Math.toIntExact(cleanupCollection("submitters")));
         final int total = deleted.get("roots")
             + deleted.get("persons")
             + deleted.get("sources")
@@ -71,10 +71,10 @@ public class DuplicateCleanupService {
      * @param collectionName the Mongo collection to clean
      * @return number of deleted documents
      */
-    private int cleanupCollection(final String collectionName) {
+    private long cleanupCollection(final String collectionName) {
         final Map<String, List<Object>> idsByKey = groupedIdsByKey(collectionName);
 
-        int deletedCount = 0;
+        long deletedCount = 0L;
         for (final List<Object> ids : idsByKey.values()) {
             if (ids.size() <= 1) {
                 continue;
@@ -85,7 +85,7 @@ public class DuplicateCleanupService {
             final Query deleteQuery = Query.query(Criteria.where("_id").in(idsToDelete));
             final DeleteResult deleteResult =
                 mongoTemplate.remove(deleteQuery, collectionName);
-            deletedCount += (int) deleteResult.getDeletedCount();
+            deletedCount += deleteResult.getDeletedCount();
         }
         return deletedCount;
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -111,8 +111,13 @@ public class DuplicateCleanupService {
      * @return map of dedupe-key to list of document ids
      */
     private Map<String, List<Object>> groupedIdsByKey(final String collectionName) {
+        final Query query = new Query();
+        query.fields()
+            .include("_id")
+            .include("filename")
+            .include("string");
         final List<Document> documents =
-            mongoTemplate.findAll(Document.class, collectionName);
+            mongoTemplate.find(query, Document.class, collectionName);
         final Map<String, List<Object>> idsByKey =
             new LinkedHashMap<>();
         for (final Document doc : documents) {

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -1,0 +1,150 @@
+package org.schoellerfamily.gedbrowser.api.endpoint;
+
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.bson.Document;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Criteria;
+import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Removes duplicate documents by (filename, string) across key collections.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class DuplicateCleanupService {
+    /** */
+    private final MongoTemplate mongoTemplate;
+
+    /**
+     * @return number of deleted documents per collection and total count
+     */
+    public Map<String, Integer> cleanup() {
+        final Map<String, Integer> deleted = new LinkedHashMap<>();
+        deleted.put("roots", cleanupCollection("roots"));
+        deleted.put("persons", cleanupCollection("persons"));
+        deleted.put("sources", cleanupCollection("sources"));
+        deleted.put("submitters", cleanupCollection("submitters"));
+        final int total = deleted.get("roots")
+            + deleted.get("persons")
+            + deleted.get("sources")
+            + deleted.get("submitters");
+        deleted.put("total", total);
+        return deleted;
+    }
+
+    /**
+     * Log discovered duplicate IDs without deleting any documents.
+     *
+     * @return number of duplicate documents per collection and total count
+     */
+    public Map<String, Integer> logDuplicates() {
+        final Map<String, Integer> duplicates = new LinkedHashMap<>();
+        duplicates.put("roots", logCollectionDuplicates("roots"));
+        duplicates.put("persons", logCollectionDuplicates("persons"));
+        duplicates.put("sources", logCollectionDuplicates("sources"));
+        duplicates.put("submitters", logCollectionDuplicates("submitters"));
+        final int roots = duplicates.get("roots");
+        final int persons = duplicates.get("persons");
+        final int sources = duplicates.get("sources");
+        final int submitters = duplicates.get("submitters");
+        final int total = roots + persons + sources + submitters;
+        duplicates.put("total", total);
+        return duplicates;
+    }
+
+    /**
+     * Keep the first matching document and delete later duplicates.
+     *
+     * @param collectionName the Mongo collection to clean
+     * @return number of deleted documents
+     */
+    private int cleanupCollection(final String collectionName) {
+        final Map<String, List<Object>> idsByKey = groupedIdsByKey(collectionName);
+
+        int deletedCount = 0;
+        for (final List<Object> ids : idsByKey.values()) {
+            if (ids.size() <= 1) {
+                continue;
+            }
+            final List<Object> idsToDelete = ids.subList(1, ids.size());
+            deletedCount += idsToDelete.size();
+            final Query deleteQuery = Query.query(Criteria.where("_id").in(idsToDelete));
+            mongoTemplate.remove(deleteQuery, collectionName);
+        }
+        return deletedCount;
+    }
+
+    /**
+     * @param collectionName the collection to scan
+     * @return number of duplicate documents identified
+     */
+    private int logCollectionDuplicates(final String collectionName) {
+        final Map<String, List<Object>> idsByKey = groupedIdsByKey(collectionName);
+        int duplicateCount = 0;
+        for (final Map.Entry<String, List<Object>> entry : idsByKey.entrySet()) {
+            final List<Object> ids = entry.getValue();
+            if (ids.size() <= 1) {
+                continue;
+            }
+            final int duplicates = ids.size() - 1;
+            duplicateCount += duplicates;
+            log.warn("Duplicate group in {}: key={} ids={} duplicates={}",
+                collectionName, entry.getKey(), ids, duplicates);
+        }
+        if (duplicateCount == 0) {
+            log.info("No duplicates found in {}", collectionName);
+        }
+        return duplicateCount;
+    }
+
+    /**
+     * @param collectionName the collection to scan
+     * @return map of dedupe-key to list of document ids
+     */
+    private Map<String, List<Object>> groupedIdsByKey(final String collectionName) {
+        final List<Document> documents =
+            mongoTemplate.findAll(Document.class, collectionName);
+        final Map<String, List<Object>> idsByKey =
+            new LinkedHashMap<>();
+        for (final Document doc : documents) {
+            final Object id = doc.get("_id");
+            if (id == null) {
+                continue;
+            }
+            final String key = buildKey(doc);
+            List<Object> ids = idsByKey.get(key);
+            if (ids == null) {
+                ids = newIdList();
+                idsByKey.put(key, ids);
+            }
+            ids.add(id);
+        }
+        return idsByKey;
+    }
+
+    /**
+     * @param doc document from a top-level GED collection
+     * @return de-duplication key based on filename and string
+     */
+    private String buildKey(final Document doc) {
+        final Object filename = doc.get("filename");
+        final Object string = doc.get("string");
+        return String.valueOf(filename) + "\u0000" + String.valueOf(string);
+    }
+
+    /**
+     * @return a mutable list for collecting document IDs
+     */
+    private List<Object> newIdList() {
+        return new ArrayList<>();
+    }
+}

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -1,15 +1,16 @@
 package org.schoellerfamily.gedbrowser.api.endpoint;
 
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Comparator;
 
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
+import org.springframework.data.util.CloseableIterator;
 import org.springframework.stereotype.Component;
 
 import com.mongodb.client.result.DeleteResult;
@@ -122,27 +123,28 @@ public class DuplicateCleanupService {
             .include("_id")
             .include("filename")
             .include("string");
-        final List<Document> documents =
-            mongoTemplate.find(query, Document.class, collectionName);
-        final Map<String, List<Object>> idsByKey =
-            new LinkedHashMap<>();
-        for (final Document doc : documents) {
-            final Object id = doc.get("_id");
-            if (id == null) {
-                continue;
+        final Map<String, List<Object>> idsByKey = new LinkedHashMap<>();
+        try (CloseableIterator<Document> documents =
+                mongoTemplate.stream(query, Document.class, collectionName)) {
+            while (documents.hasNext()) {
+                final Document doc = documents.next();
+                final Object id = doc.get("_id");
+                if (id == null) {
+                    continue;
+                }
+                final String key = buildKey(doc);
+                if (key == null) {
+                    log.warn("Skipping document without valid filename/string in {}: id={}",
+                        collectionName, id);
+                    continue;
+                }
+                List<Object> ids = idsByKey.get(key);
+                if (ids == null) {
+                    ids = newIdList();
+                    idsByKey.put(key, ids);
+                }
+                ids.add(id);
             }
-            final String key = buildKey(doc);
-            if (key == null) {
-                log.warn("Skipping document without valid filename/string in {}: id={}",
-                    collectionName, id);
-                continue;
-            }
-            List<Object> ids = idsByKey.get(key);
-            if (ids == null) {
-                ids = newIdList();
-                idsByKey.put(key, ids);
-            }
-            ids.add(id);
         }
         return idsByKey;
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -5,12 +5,12 @@ import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 
 import org.bson.Document;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
-import org.springframework.data.util.CloseableIterator;
 import org.springframework.stereotype.Component;
 
 import com.mongodb.client.result.DeleteResult;
@@ -124,27 +124,28 @@ public class DuplicateCleanupService {
             .include("filename")
             .include("string");
         final Map<String, List<Object>> idsByKey = new LinkedHashMap<>();
-        try (CloseableIterator<Document> documents =
+        try (Stream<Document> documents =
                 mongoTemplate.stream(query, Document.class, collectionName)) {
-            while (documents.hasNext()) {
-                final Document doc = documents.next();
+            documents.forEach(doc -> {
                 final Object id = doc.get("_id");
                 if (id == null) {
-                    continue;
+                    return;
                 }
                 final String key = buildKey(doc);
                 if (key == null) {
                     log.warn("Skipping document without valid filename/string in {}: id={}",
                         collectionName, id);
-                    continue;
+                    return;
                 }
                 List<Object> ids = idsByKey.get(key);
                 if (ids == null) {
-                    ids = newIdList();
-                    idsByKey.put(key, ids);
+                    final List<Object> newIds = newIdList();
+                    idsByKey.put(key, newIds);
+                    newIds.add(id);
+                } else {
+                    ids.add(id);
                 }
-                ids.add(id);
-            }
+            });
         }
         return idsByKey;
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -12,6 +12,8 @@ import org.springframework.data.mongodb.core.query.Criteria;
 import org.springframework.data.mongodb.core.query.Query;
 import org.springframework.stereotype.Component;
 
+import com.mongodb.client.result.DeleteResult;
+
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -79,9 +81,10 @@ public class DuplicateCleanupService {
             // Ensure deterministic behavior: sort IDs before deciding which one to keep
             ids.sort(Comparator.comparing(Object::toString));
             final List<Object> idsToDelete = ids.subList(1, ids.size());
-            deletedCount += idsToDelete.size();
             final Query deleteQuery = Query.query(Criteria.where("_id").in(idsToDelete));
-            mongoTemplate.remove(deleteQuery, collectionName);
+            final DeleteResult deleteResult =
+                mongoTemplate.remove(deleteQuery, collectionName);
+            deletedCount += (int) deleteResult.getDeletedCount();
         }
         return deletedCount;
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/LogDuplicatesEndpoint.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/LogDuplicatesEndpoint.java
@@ -1,0 +1,42 @@
+package org.schoellerfamily.gedbrowser.api.endpoint;
+
+import java.util.List;
+import java.util.Map;
+
+import org.springframework.boot.actuate.endpoint.annotation.Endpoint;
+import org.springframework.boot.actuate.endpoint.annotation.ReadOperation;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Actuator endpoint to log duplicate dataset documents without deleting them.
+ */
+@Component
+@Endpoint(id = "logduplicates")
+@RequiredArgsConstructor
+@Slf4j
+public class LogDuplicatesEndpoint {
+    /** */
+    private final DuplicateCleanupService duplicateCleanupService;
+
+    /**
+     * @return summary messages
+     */
+    @ReadOperation
+    public List<String> invoke() {
+        log.info("Invoke logduplicates");
+        final Map<String, Integer> duplicates = duplicateCleanupService.logDuplicates();
+        return List.of(
+            "Logged duplicates: roots=%d, persons=%d, sources=%d, submitters=%d, total=%d"
+                .formatted(
+                    duplicates.getOrDefault("roots", 0),
+                    duplicates.getOrDefault("persons", 0),
+                    duplicates.getOrDefault("sources", 0),
+                    duplicates.getOrDefault("submitters", 0),
+                    duplicates.getOrDefault("total", 0)
+                )
+        );
+    }
+}

--- a/gedbrowserng/src/main/resources/application.yml
+++ b/gedbrowserng/src/main/resources/application.yml
@@ -49,4 +49,4 @@ management:
     endpoints:
         web:
             exposure:
-                include: health,info,mappings,restore,cleanupduplicates,logduplicates
+                include: health,info,mappings,restore

--- a/gedbrowserng/src/main/resources/application.yml
+++ b/gedbrowserng/src/main/resources/application.yml
@@ -49,4 +49,4 @@ management:
     endpoints:
         web:
             exposure:
-                include: health,info,mappings,restore
+                include: health,info,mappings,restore,cleanupduplicates,logduplicates

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/DatasetsControllerTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/controller/test/DatasetsControllerTest.java
@@ -75,4 +75,26 @@ final class DatasetsControllerTest {
 
         assertTrue(dbs.isEmpty());
     }
+
+    /** */
+    @Test
+    void testDbsDeduplicatesDatasetNames() {
+        final RepositoryManagerMongo manager = Mockito.mock(RepositoryManagerMongo.class);
+        final RootDocumentRepositoryMongo repository =
+            Mockito.mock(RootDocumentRepositoryMongo.class);
+        final RootDocumentMongo first = new RootDocumentMongo();
+        first.setDbName("schoeller");
+        final RootDocumentMongo second = new RootDocumentMongo();
+        second.setDbName("schoeller");
+        final RootDocumentMongo third = new RootDocumentMongo();
+        third.setDbName("mini");
+
+        doReturn(repository).when(manager).get(Root.class);
+        when(repository.findAll()).thenReturn(List.of(first, second, third));
+
+        final DatasetsController controller = new DatasetsController(manager);
+        final List<String> dbs = controller.dbs();
+
+        assertEquals(List.of("schoeller", "mini"), dbs);
+    }
 }

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ReadOperationsTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/crud/test/ReadOperationsTest.java
@@ -1,0 +1,99 @@
+package org.schoellerfamily.gedbrowser.api.crud.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.schoellerfamily.gedbrowser.api.crud.ReadOperations;
+import org.schoellerfamily.gedbrowser.api.datamodel.ApiObject;
+import org.schoellerfamily.gedbrowser.api.loader.GedObjectFileLoader;
+import org.schoellerfamily.gedbrowser.datamodel.Root;
+import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
+import org.schoellerfamily.gedbrowser.persistence.mongo.repository.RepositoryManagerMongo;
+import org.schoellerfamily.gedbrowser.persistence.repository.FindableDocument;
+
+/**
+ * Unit tests for default methods in {@link ReadOperations}.
+ */
+final class ReadOperationsTest {
+
+    @Test
+    void testReadFiltersNullsDeduplicatesAndSorts() {
+        final FindableDocument<Root, RootDocument> repository = Mockito.mock(FindableDocument.class);
+        final GedObjectFileLoader loader = Mockito.mock(GedObjectFileLoader.class);
+        final TestReadOperations readOperations = new TestReadOperations(repository, loader);
+
+        final RootDocument root = Mockito.mock(RootDocument.class);
+        final RootDocument nullStringDoc = Mockito.mock(RootDocument.class);
+        final RootDocument bDoc = Mockito.mock(RootDocument.class);
+        final RootDocument aFirst = Mockito.mock(RootDocument.class);
+        final RootDocument aSecond = Mockito.mock(RootDocument.class);
+
+        when(nullStringDoc.getString()).thenReturn(null);
+        when(bDoc.getString()).thenReturn("B");
+        when(aFirst.getString()).thenReturn("A");
+        when(aSecond.getString()).thenReturn("A");
+
+        when(repository.findAll(root)).thenReturn(Arrays.asList(
+            null,
+            nullStringDoc,
+            bDoc,
+            aFirst,
+            aSecond));
+
+        final List<RootDocument> result = readOperations.read(root);
+
+        assertEquals(2, result.size());
+        assertSame(aFirst, result.get(0));
+        assertSame(bDoc, result.get(1));
+    }
+
+    private static final class TestReadOperations
+            implements ReadOperations<Root, RootDocument, ApiObject> {
+        private final FindableDocument<Root, RootDocument> repository;
+        private final GedObjectFileLoader loader;
+
+        TestReadOperations(final FindableDocument<Root, RootDocument> repository,
+                final GedObjectFileLoader loader) {
+            this.repository = repository;
+            this.loader = loader;
+        }
+
+        @Override
+        public FindableDocument<Root, RootDocument> getRepository() {
+            return repository;
+        }
+
+        @Override
+        public GedObjectFileLoader getLoader() {
+            return loader;
+        }
+
+        @Override
+        public Class<Root> getGedClass() {
+            return Root.class;
+        }
+
+        @Override
+        public List<ApiObject> readAll(final String db) {
+            return List.of();
+        }
+
+        @Override
+        public ApiObject readOne(final String db, final String id) {
+            return null;
+        }
+
+        @Override
+        public RootDocument read(final RepositoryManagerMongo repositoryManager,
+                final String dbName,
+                final String idString) {
+            return ReadOperations.super.read(repositoryManager, dbName, idString);
+        }
+    }
+}

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/test/DuplicateCleanupServiceTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/test/DuplicateCleanupServiceTest.java
@@ -1,0 +1,114 @@
+package org.schoellerfamily.gedbrowser.api.test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Map;
+import java.util.stream.Stream;
+
+import org.bson.Document;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.schoellerfamily.gedbrowser.api.endpoint.DuplicateCleanupService;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.data.mongodb.core.query.Query;
+
+import com.mongodb.client.result.DeleteResult;
+
+/**
+ * Tests for {@link DuplicateCleanupService}.
+ */
+final class DuplicateCleanupServiceTest {
+
+    @Test
+    void testCleanupDeletesDuplicatesAndAggregatesCounts() {
+        final MongoTemplate mongoTemplate = Mockito.mock(MongoTemplate.class);
+        final DuplicateCleanupService service = new DuplicateCleanupService(mongoTemplate);
+
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("roots")))
+            .thenReturn(Stream.of(
+                doc("r2", "schoeller.ged", "Root"),
+                doc("r1", "schoeller.ged", "Root")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("persons")))
+            .thenReturn(Stream.of(
+                doc("p1", "schoeller.ged", "I1"),
+                doc("p2", "schoeller.ged", "I2")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("sources")))
+            .thenReturn(Stream.of(
+                doc("s1", "schoeller.ged", "S1"),
+                doc("s2", "schoeller.ged", "S1"),
+                doc("s3", "schoeller.ged", "S1")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("submitters")))
+            .thenReturn(Stream.of(
+                doc("sub1", "schoeller.ged", "SUB1")));
+
+        when(mongoTemplate.remove(any(Query.class), eq("roots")))
+            .thenReturn(DeleteResult.acknowledged(1));
+        when(mongoTemplate.remove(any(Query.class), eq("sources")))
+            .thenReturn(DeleteResult.acknowledged(2));
+
+        final Map<String, Integer> result = service.cleanup();
+
+        assertEquals(1, result.get("roots"));
+        assertEquals(0, result.get("persons"));
+        assertEquals(2, result.get("sources"));
+        assertEquals(0, result.get("submitters"));
+        assertEquals(3, result.get("total"));
+        verify(mongoTemplate).remove(any(Query.class), eq("roots"));
+        verify(mongoTemplate, never()).remove(any(Query.class), eq("persons"));
+        verify(mongoTemplate).remove(any(Query.class), eq("sources"));
+        verify(mongoTemplate, never()).remove(any(Query.class), eq("submitters"));
+    }
+
+    @Test
+    void testLogDuplicatesReportsCountsWithoutDeleting() {
+        final MongoTemplate mongoTemplate = Mockito.mock(MongoTemplate.class);
+        final DuplicateCleanupService service = new DuplicateCleanupService(mongoTemplate);
+
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("roots")))
+            .thenReturn(Stream.of(
+                doc("r1", "schoeller.ged", "Root"),
+                doc("r2", "schoeller.ged", "Root")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("persons")))
+            .thenReturn(Stream.of(
+                doc("p1", "schoeller.ged", "I1"),
+                docMissingString("p2", "schoeller.ged"),
+                docMissingId("schoeller.ged", "I1"),
+                doc("p3", "schoeller.ged", "I1")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("sources")))
+            .thenReturn(Stream.of(doc("s1", "schoeller.ged", "S1")));
+        when(mongoTemplate.stream(any(Query.class), eq(Document.class), eq("submitters")))
+            .thenReturn(Stream.of(
+                doc("sub1", "schoeller.ged", "SUB1"),
+                doc("sub2", "schoeller.ged", "SUB1")));
+
+        final Map<String, Integer> result = service.logDuplicates();
+
+        assertEquals(1, result.get("roots"));
+        assertEquals(1, result.get("persons"));
+        assertEquals(0, result.get("sources"));
+        assertEquals(1, result.get("submitters"));
+        assertEquals(3, result.get("total"));
+        verify(mongoTemplate, never()).remove(any(Query.class), any(String.class));
+    }
+
+    private Document doc(final String id, final String filename, final String string) {
+        return new Document("_id", id)
+            .append("filename", filename)
+            .append("string", string);
+    }
+
+    private Document docMissingId(final String filename, final String string) {
+        return new Document("filename", filename)
+            .append("string", string);
+    }
+
+    private Document docMissingString(final String id, final String filename) {
+        return new Document("_id", id)
+            .append("filename", filename);
+    }
+}

--- a/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/test/EndpointComponentsTest.java
+++ b/gedbrowserng/src/test/java/org/schoellerfamily/gedbrowser/api/test/EndpointComponentsTest.java
@@ -10,6 +10,9 @@ import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
+import org.schoellerfamily.gedbrowser.api.endpoint.CleanupDuplicatesEndpoint;
+import org.schoellerfamily.gedbrowser.api.endpoint.DuplicateCleanupService;
+import org.schoellerfamily.gedbrowser.api.endpoint.LogDuplicatesEndpoint;
 import org.schoellerfamily.gedbrowser.api.endpoint.ApplicationHealthIndicator;
 import org.schoellerfamily.gedbrowser.api.endpoint.ApplicationInfoContributor;
 import org.schoellerfamily.gedbrowser.api.endpoint.RestoreEndpoint;
@@ -73,5 +76,55 @@ final class EndpointComponentsTest {
 
         verify(loader).reloadAll(manager);
         assertEquals("Reloaded 2 datasets", result.get(0));
+    }
+
+    /** */
+    @Test
+    void testCleanupDuplicatesEndpointReportsCounts() {
+        final int rootCount = 1;
+        final int personCount = 2;
+        final int sourceCount = 3;
+        final int submitterCount = 4;
+        final int totalCount = 10;
+        final DuplicateCleanupService cleanupService = Mockito.mock(DuplicateCleanupService.class);
+        when(cleanupService.cleanup()).thenReturn(Map.of(
+            "roots", rootCount,
+            "persons", personCount,
+            "sources", sourceCount,
+            "submitters", submitterCount,
+            "total", totalCount));
+
+        final CleanupDuplicatesEndpoint endpoint = new CleanupDuplicatesEndpoint(cleanupService);
+
+        final List<String> result = endpoint.invoke();
+
+        verify(cleanupService).cleanup();
+        assertEquals("Removed duplicates: roots=1, persons=2, sources=3, submitters=4, total=10",
+            result.get(0));
+    }
+
+    /** */
+    @Test
+    void testLogDuplicatesEndpointReportsCounts() {
+        final int rootCount = 1;
+        final int personCount = 2;
+        final int sourceCount = 3;
+        final int submitterCount = 4;
+        final int totalCount = 10;
+        final DuplicateCleanupService cleanupService = Mockito.mock(DuplicateCleanupService.class);
+        when(cleanupService.logDuplicates()).thenReturn(Map.of(
+            "roots", rootCount,
+            "persons", personCount,
+            "sources", sourceCount,
+            "submitters", submitterCount,
+            "total", totalCount));
+
+        final LogDuplicatesEndpoint endpoint = new LogDuplicatesEndpoint(cleanupService);
+
+        final List<String> result = endpoint.invoke();
+
+        verify(cleanupService).logDuplicates();
+        assertEquals("Logged duplicates: roots=1, persons=2, sources=3, submitters=4, total=10",
+            result.get(0));
     }
 }


### PR DESCRIPTION
## Summary
- add confirmation dialogs for delete actions in person, source, submitter, note, and attribute list UIs
- fix small hover icon-button hit areas by aligning Material touch/ripple targets to icon size
- deduplicate datasets and list entities (persons/sources/submitters) in frontend service and side-menu dataset picker
- deduplicate dataset names and list reads in backend API responses
- add actuator endpoints for duplicate operations: `cleanupduplicates` (deletes extras) and `logduplicates` (log-only)
- expose the new actuator endpoints in `application.yml`

## Validation
- frontend targeted vitest suites passed for dataset/service/list behaviors
- backend targeted tests passed for endpoint and datasets controller changes

## Notes
- `logduplicates` is non-destructive and intended for inspection
- `cleanupduplicates` removes duplicate docs from roots/persons/sources/submitters by `(filename, string)` key