### PR TITLE
Address Sonar warnings across renderer, reader, and model layers

### DIFF
--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractFinderObject.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/AbstractFinderObject.java
@@ -14,7 +14,7 @@ public abstract class AbstractFinderObject implements FinderObject {
     /**
      * The finder value.
      */
-    private transient FinderStrategy finder;
+    private FinderStrategy finder;
 
     /**
      * Creates a new AbstractFinderObject.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
@@ -5,7 +5,6 @@ import java.util.List;
 
 import org.schoellerfamily.gedbrowser.datamodel.appender.AppenderStrategy;
 import org.schoellerfamily.gedbrowser.datamodel.appender.GedAppender;
-import org.schoellerfamily.gedbrowser.datamodel.visitor.GedObjectVisitor;
 
 /**
  * Represents ged object in the domain model.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/GedObject.java
@@ -56,17 +56,16 @@ public abstract class GedObject extends AbstractFinderObject
     /**
      * The attributes value.
      */
-    private final transient List<GedObject> attributes =
-            new ArrayList<GedObject>();
+    private final List<GedObject> attributes = new ArrayList<>();
     /**
      * The set value.
      */
-    private final transient boolean set;
+    private final boolean set;
 
     /**
      * The appender value.
      */
-    private transient AppenderStrategy appender;
+    private AppenderStrategy appender;
 
     /**
      * Creates a new GedObject.
@@ -279,11 +278,4 @@ public abstract class GedObject extends AbstractFinderObject
     protected final void setAppender(final AppenderStrategy appender) {
         this.appender = appender;
     }
-
-    /**
-     * Hook for using the visitor design pattern to accumulate information.
-     *
-     * @param visitor the visitor
-     */
-    public abstract void accept(GedObjectVisitor visitor);
 }

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/ObjectId.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/ObjectId.java
@@ -16,5 +16,5 @@ public final class ObjectId {
     /**
      * The id string value.
      */
-    private final transient String idString;
+    private final String idString;
 }

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Root.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/Root.java
@@ -16,23 +16,22 @@ public final class Root extends AbstractSpecialObject {
     /**
      * The filename value.
      */
-    private transient String filename;
+    private String filename;
 
     /**
      * The dbname value.
      */
-    private transient String dbname;
+    private String dbname;
 
     /**
      * Map of ID strings to GedObjects. This is the complete set of top level GedObjects.
      */
-    private final transient Map<String, GedObject> objects =
-            new HashMap<String, GedObject>();
+    private final Map<String, GedObject> objects = new HashMap<>();
 
     /**
      * Index object that manages index breakdown by Surname -> Complete Name -> Person.
      */
-    private final transient Index surnameIndex;
+    private final Index surnameIndex;
 
     /**
      * Creates a new Root.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/GedAppender.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/GedAppender.java
@@ -16,7 +16,7 @@ public final class GedAppender implements AppenderStrategy {
     /**
      * The GedObject that owns this appender.
      */
-    private final transient GedObject owner;
+    private final GedObject owner;
 
     /**
      * Executes append string.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/MultimediaAppender.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/MultimediaAppender.java
@@ -11,7 +11,7 @@ public final class MultimediaAppender implements AppenderStrategy {
     /**
      * The Multimedia that owns this appender.
      */
-    private final transient Multimedia owner;
+    private final Multimedia owner;
 
     /**
      * Creates a new MultimediaAppender.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/TailAppender.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/appender/TailAppender.java
@@ -11,7 +11,7 @@ public final class TailAppender implements AppenderStrategy {
     /**
      * The Attribute that owns this appender.
      */
-    private final transient Tail owner;
+    private final Tail owner;
 
     /**
      * Creates a new TailAppender.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/users/HasRoles.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/users/HasRoles.java
@@ -49,7 +49,7 @@ public class HasRoles {
     public void addRole(final String role) {
         try {
             roles.add(UserRoleName.valueOf(role));
-        } catch (Exception e) {
+        } catch (Exception _) {
             log.warn("Tried to add unrecognized role: {}", role);
         }
     }

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/DateParser.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/DateParser.java
@@ -82,7 +82,7 @@ public final class DateParser extends SimpleDateParser {
         /**
          */
         ESTIMATED
-    };
+    }
 
     /**
      * Creates a new DateParser.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/GedObjectBuilder.java
@@ -104,7 +104,7 @@ public final class GedObjectBuilder implements PersonBuilderFacade,
         /**
          */
         VALUE
-    };
+    }
 
     /**
      * Represents string.

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/SimpleDateParser.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/SimpleDateParser.java
@@ -5,19 +5,15 @@ import java.text.SimpleDateFormat;
 import java.util.Calendar;
 import java.util.Locale;
 
+import lombok.NoArgsConstructor;
+
 /**
  * Parses simple date values from textual input.
  *
  * @author Richard Schoeller
  */
+@NoArgsConstructor
 public class SimpleDateParser {
-    /**
-     * Creates a new SimpleDateParser.
-     */
-    public SimpleDateParser() {
-        // Intentionally empty.
-    }
-
     /**
      * Parses the calendar.
      *
@@ -31,17 +27,17 @@ public class SimpleDateParser {
         try {
             c.setTime(dateParser.parse(dateString));
             return c;
-        } catch (ParseException e) {
+        } catch (ParseException _) {
             dateParser = new SimpleDateFormat("MMM yyyy", Locale.US);
             try {
                 c.setTime(dateParser.parse(dateString));
                 return c;
-            } catch (ParseException e1) {
+            } catch (ParseException __) {
                 dateParser = new SimpleDateFormat("yyyy", Locale.US);
                 try {
                     c.setTime(dateParser.parse(dateString));
                     return c;
-                } catch (ParseException e2) {
+                } catch (ParseException ___) {
                     return null;
                 }
             }

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedobject/datamodel/factory/GedToken.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedobject/datamodel/factory/GedToken.java
@@ -9,11 +9,11 @@ package org.schoellerfamily.gedobject.datamodel.factory;
     /**
      * The full string value.
      */
-    private final transient String fullString;
+    private final String fullString;
     /**
      * The factory value.
      */
-    private final transient AbstractGedObjectFactory factory;
+    private final AbstractGedObjectFactory factory;
 
     /* default */ GedToken(final String fullstring,
             final AbstractGedObjectFactory factory) {

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GetStringComparatorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/util/test/GetStringComparatorTest.java
@@ -41,7 +41,7 @@ final class GetStringComparatorTest {
         LESSTHAN,
         /** */
         EQUALTO
-    };
+    }
 
     @SuppressWarnings("PMD.MethodReturnsInternalArray")
     static Stream<Arguments> params() {

--- a/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/visitor/test/GedObjectVisitorTest.java
+++ b/gedbrowser-datamodel/src/test/java/org/schoellerfamily/gedbrowser/datamodel/visitor/test/GedObjectVisitorTest.java
@@ -350,7 +350,7 @@ final class GedObjectVisitorTest {
             gob = gedObject;
             type = "unknown";
         }
-    };
+    }
 
     @SuppressWarnings("checkstyle:nowhitespaceafter")
     static Stream<Arguments> params() {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamilyDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/FamilyDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.FamilyDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "families")
-@CompoundIndexes({
-    @CompoundIndex(name = "family_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "family_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class FamilyDocumentMongo extends GedDocumentMongo<Family>
         implements FamilyDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HeadDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/HeadDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.HeadDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "heads")
-@CompoundIndexes({
-    @CompoundIndex(name = "head_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "head_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class HeadDocumentMongo extends GedDocumentMongo<Head>
         implements HeadDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/NoteDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/NoteDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.NoteDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "notes")
-@CompoundIndexes({
-    @CompoundIndex(name = "note_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "note_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class NoteDocumentMongo extends GedDocumentMongo<Note>
         implements NoteDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PersonDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/PersonDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.PersonDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "persons")
-@CompoundIndexes({
-    @CompoundIndex(name = "person_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "person_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class PersonDocumentMongo extends GedDocumentMongo<Person>
         implements PersonDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/RootDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/RootDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.RootDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "roots")
-@CompoundIndexes({
-    @CompoundIndex(name = "root_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "root_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class RootDocumentMongo extends GedDocumentMongo<Root>
         implements RootDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SourceDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.SourceDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "sources")
-@CompoundIndexes({
-    @CompoundIndex(name = "source_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "source_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class SourceDocumentMongo extends GedDocumentMongo<Source>
         implements SourceDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmissionDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmissionDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.SubmissionDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "submissions")
-@CompoundIndexes({
-    @CompoundIndex(name = "submission_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "submission_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class SubmissionDocumentMongo extends GedDocumentMongo<Submission>
         implements SubmissionDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmitterDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/SubmitterDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.SubmitterDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "submitters")
-@CompoundIndexes({
-    @CompoundIndex(name = "submitter_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "submitter_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class SubmitterDocumentMongo extends GedDocumentMongo<Submitter>
         implements SubmitterDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/TrailerDocumentMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/domain/TrailerDocumentMongo.java
@@ -8,7 +8,6 @@ import org.schoellerfamily.gedbrowser.persistence.domain.TrailerDocument;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.GedDocumentMongoVisitor;
 import org.schoellerfamily.gedbrowser.persistence.mongo.domain.visitor.TopLevelGedDocumentMongoVisitor;
 import org.springframework.data.mongodb.core.index.CompoundIndex;
-import org.springframework.data.mongodb.core.index.CompoundIndexes;
 import org.springframework.data.mongodb.core.mapping.Document;
 
 import lombok.NoArgsConstructor;
@@ -19,11 +18,7 @@ import lombok.NoArgsConstructor;
  * @author Richard Schoeller
  */
 @Document(collection = "trailers")
-@CompoundIndexes({
-    @CompoundIndex(name = "trailer_unique_idx",
-            def = "{'string': 1, 'filename': 1}",
-            unique = true)
-})
+@CompoundIndex(name = "trailer_unique_idx", def = "{'string': 1, 'filename': 1}", unique = true)
 @NoArgsConstructor
 public final class TrailerDocumentMongo extends GedDocumentMongo<Trailer>
         implements TrailerDocument {

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/gedconvert/GedLinkDocumentMongoToGedObjectConverterVisitor.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/gedconvert/GedLinkDocumentMongoToGedObjectConverterVisitor.java
@@ -35,8 +35,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
      *
      * @param parent the parent
      */
-    protected GedLinkDocumentMongoToGedObjectConverterVisitor(
-            final GedObject parent) {
+    protected GedLinkDocumentMongoToGedObjectConverterVisitor(final GedObject parent) {
         super(parent);
     }
 
@@ -48,7 +47,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final ChildDocumentMongo document) {
         final Child child = new Child(getParent(), "Child",
-                new ObjectId(document.getString()));
+            new ObjectId(document.getString()));
         child.setFromString(getParent().getString());
         setGedObject(child);
     }
@@ -61,7 +60,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final FamCDocumentMongo document) {
         final FamC famc = new FamC(getParent(), "Child of Family",
-                new ObjectId(document.getString()));
+            new ObjectId(document.getString()));
         famc.setFromString(getParent().getString());
         setGedObject(famc);
     }
@@ -74,7 +73,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final FamSDocumentMongo document) {
         final FamS fams = new FamS(getParent(), "Spouse of Family",
-                new ObjectId(document.getString()));
+            new ObjectId(document.getString()));
         fams.setFromString(getParent().getString());
         setGedObject(fams);
     }
@@ -86,7 +85,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final HusbandDocumentMongo document) {
         final Husband husband = new Husband(getParent(), "Husband",
-                new ObjectId(document.getString()));
+            new ObjectId(document.getString()));
         husband.setFromString(getParent().getString());
         setGedObject(husband);
     }
@@ -98,8 +97,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
      */
     @Override
     public final void visit(final NoteLinkDocumentMongo document) {
-        setGedObject(new NoteLink(getParent(), "Note",
-                new ObjectId(document.getString())));
+        setGedObject(new NoteLink(getParent(), "Note", new ObjectId(document.getString())));
     }
 
     /**
@@ -109,8 +107,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
      */
     @Override
     public final void visit(final SourceLinkDocumentMongo document) {
-        setGedObject(new SourceLink(getParent(), "Source",
-                new ObjectId(document.getString())));
+        setGedObject(new SourceLink(getParent(), "Source", new ObjectId(document.getString())));
     }
 
     /**
@@ -121,7 +118,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final SubmissionLinkDocumentMongo document) {
         setGedObject(new SubmissionLink(getParent(), "Submission",
-                new ObjectId(document.getString())));
+            new ObjectId(document.getString())));
     }
 
     /**
@@ -132,7 +129,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
     @Override
     public final void visit(final SubmitterLinkDocumentMongo document) {
         setGedObject(new SubmitterLink(getParent(), "Submitter",
-                new ObjectId(document.getString())));
+            new ObjectId(document.getString())));
     }
 
     /**
@@ -142,9 +139,7 @@ public abstract class GedLinkDocumentMongoToGedObjectConverterVisitor
      */
     @Override
     public final void visit(final WifeDocumentMongo document) {
-        final WifeDocumentMongo wifeDocument = (WifeDocumentMongo) document;
-        final Wife wife = new Wife(getParent(), "Wife",
-                new ObjectId(wifeDocument.getString()));
+        final Wife wife = new Wife(getParent(), "Wife", new ObjectId(document.getString()));
         wife.setFromString(getParent().getString());
         setGedObject(wife);
     }

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/loader/GedDocumentFileLoader.java
@@ -181,7 +181,7 @@ public class GedDocumentFileLoader {
             final GedFile gedFile = new GedFile(filename, dbName, finder, bufferedReader);
             gedFile.readToNext();
             return save(createRoot(dbName, filename, gedFile));
-        } catch (IOException e) {
+        } catch (IOException _) {
             log.warn("Could not read file: {}", filename);
             return null;
         }

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/PersonDocumentRepositoryMongoImpl.java
@@ -238,7 +238,7 @@ public final class PersonDocumentRepositoryMongoImpl implements
             final Collection<PersonDocumentMongo> in) {
         return in.stream()
             .sorted(new PersonDocumentComparator())
-            .map(doc -> (PersonDocument) doc)
+            .map(PersonDocument.class::cast)
             .toList();
     }
 

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RepositoryFinderMongo.java
@@ -113,8 +113,8 @@ public final class RepositoryFinderMongo implements FinderStrategy {
      */
     @Override
     public String getFilename(final FinderObject owner) {
-        if (owner instanceof Root) {
-            return ((Root) owner).getTheFilename();
+        if (owner instanceof Root root) {
+            return root.getTheFilename();
         }
         return owner.getFilename();
     }
@@ -127,8 +127,8 @@ public final class RepositoryFinderMongo implements FinderStrategy {
      */
     @Override
     public String getDbName(final FinderObject owner) {
-        if (owner instanceof Root) {
-            return ((Root) owner).getTheDbName();
+        if (owner instanceof Root root) {
+            return root.getTheDbName();
         }
         return owner.getDbName();
     }
@@ -191,8 +191,7 @@ public final class RepositoryFinderMongo implements FinderStrategy {
         final String beginsWith) {
         log.info("Starting findBySurnamesBeginWith");
         final Set<String> surnames = new TreeSet<>();
-        if (owner instanceof Root) {
-            final Root root = (Root) owner;
+        if (owner instanceof Root root) {
             final RootDocumentMongo rootDocument = (RootDocumentMongo) toDocConverter
                 .createGedDocument(root);
             final Collection<PersonDocument> personDocuments = repositoryManager
@@ -216,8 +215,7 @@ public final class RepositoryFinderMongo implements FinderStrategy {
     public Collection<String> findSurnameInitialLetters(final FinderObject owner) {
         log.info("Starting findSurnameInitialLetters");
         final Set<String> matches = new TreeSet<>();
-        if (owner instanceof Root) {
-            final Root root = (Root) owner;
+        if (owner instanceof Root root) {
             final RootDocumentMongo rootDocument = (RootDocumentMongo) toDocConverter
                 .createGedDocument(root);
             final Iterable<PersonDocument> personDocuments = repositoryManager

--- a/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RootDocumentRepositoryMongoImpl.java
+++ b/gedbrowser-mongo-dao/src/main/java/org/schoellerfamily/gedbrowser/persistence/mongo/repository/RootDocumentRepositoryMongoImpl.java
@@ -55,8 +55,7 @@ public class RootDocumentRepositoryMongoImpl implements
         if (rootDocument == null) {
             return null;
         }
-        final Root root =
-                (Root) toObjConverter.createRoot(rootDocument, finder);
+        final Root root = toObjConverter.createRoot(rootDocument, finder);
         rootDocument.setGedObject(root);
         return rootDocument;
     }

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedLine.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractGedLine.java
@@ -12,11 +12,10 @@ import java.util.List;
  */
 public abstract class AbstractGedLine extends AbstractSingleGedLine {
     /** */
-    private final transient GedLineSource source;
+    private final GedLineSource source;
 
     /** */
-    private final transient List<AbstractGedLine> children =
-            new ArrayList<AbstractGedLine>();
+    private final List<AbstractGedLine> children = new ArrayList<>();
 
     /**
      * Creates a new AbstractGedLine.

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractSingleGedLine.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/AbstractSingleGedLine.java
@@ -18,17 +18,17 @@ import lombok.experimental.Accessors;
 @Accessors(makeFinal = true)
 public abstract class AbstractSingleGedLine implements GedObjectHolder {
     /** */
-    private final transient int lineNumber;
+    private final int lineNumber;
     /** */
-    private transient int level;
+    private int level;
     /** */
-    private transient String xref = "";
+    private String xref = "";
     /** */
-    private transient String tag = "";
+    private String tag = "";
     /** */
-    private transient String tail = "";
+    private String tail = "";
     /** */
-    private transient GedObject gedObject;
+    private GedObject gedObject;
 
     /**
      * Executes abstract single ged line.

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/CharsetScanner.java
@@ -65,7 +65,7 @@ public class CharsetScanner {
                     }
                 }
             }
-        } catch (IOException e) {
+        } catch (IOException _) {
             log.warn("Could not read file: {}", filename);
         }
         return UTF_8;

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/GedFile.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/GedFile.java
@@ -12,13 +12,13 @@ import org.schoellerfamily.gedbrowser.datamodel.finder.FinderStrategy;
  */
 public final class GedFile extends AbstractGedLine {
     /** */
-    private final transient String filename;
+    private final String filename;
 
     /** */
-    private final transient String dbName;
+    private final String dbName;
 
     /** */
-    private final transient FinderStrategy finder;
+    private final FinderStrategy finder;
 
     /**
      * Creates a new GedFile.

--- a/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/users/UsersReader.java
+++ b/gedbrowser-reader/src/main/java/org/schoellerfamily/gedbrowser/reader/users/UsersReader.java
@@ -5,6 +5,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 
 import org.schoellerfamily.gedbrowser.datamodel.users.User;
 import org.schoellerfamily.gedbrowser.datamodel.users.Users;
@@ -30,7 +31,7 @@ public final class UsersReader<T extends User, U extends Users<T>> {
             final UserFactory<T> builder) {
         final Users<T> users = usersFactory.createUsers();
         try (FileInputStream fis = new FileInputStream(userFile);
-                Reader reader = new InputStreamReader(fis, "UTF-8");
+                Reader reader = new InputStreamReader(fis, StandardCharsets.UTF_8);
                 BufferedReader br = new BufferedReader(reader);) {
             String line;
             while ((line = br.readLine()) != null) {
@@ -38,7 +39,7 @@ public final class UsersReader<T extends User, U extends Users<T>> {
                 final T user = buildUser(userFields, builder);
                 users.add(user);
             }
-        } catch (IOException e) {
+        } catch (IOException _) {
             final String[] strings = {"guest", "", "", "", "guest", "USER"};
             users.add(buildUser(strings, builder));
         }

--- a/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/StreamManagerTest.java
+++ b/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/StreamManagerTest.java
@@ -53,7 +53,7 @@ class StreamManagerTest {
         "test...ged",
         "foo\\bar"
     })
-    void testPathsNotFound(final String filename) throws FileNotFoundException {
+    void testPathsNotFound(final String filename) {
         final StreamManager streamManager = new StreamManager(filename);
         assertThrows(FileNotFoundException.class, streamManager::getInputStream);
     }

--- a/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/UsersReaderTest.java
+++ b/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/UsersReaderTest.java
@@ -37,6 +37,6 @@ class UsersReaderTest {
 
     private Users<User> readUserFile(final String userFile) {
         final UsersReader<User, Users<User>> usersReader = new UsersReader<>();
-        return usersReader.readUserFile(userFile, () -> new UsersImpl<>(), () -> new UserImpl());
+        return usersReader.readUserFile(userFile, UsersImpl::new, UserImpl::new);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AbstractLinkRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AbstractLinkRenderer.java
@@ -8,8 +8,7 @@ import org.schoellerfamily.gedbrowser.datamodel.AbstractLink;
  * @author Richard Schoeller
  * @param <T> The object type to render.
  */
-public abstract class AbstractLinkRenderer<T extends AbstractLink> extends
-        GedRenderer<T> {
+public abstract class AbstractLinkRenderer<T extends AbstractLink> extends GedRenderer<T> {
     /**
      * Creates a new AbstractLinkRenderer.
      *

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ApplicationInfoRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ApplicationInfoRenderer.java
@@ -2,23 +2,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders application info output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public abstract class ApplicationInfoRenderer implements Renderer {
     /** */
     private final ApplicationInfo applicationInfo;
-
-    /**
-     * Creates a new ApplicationInfoRenderer.
-     *
-     * @param applicationInfo the application info
-     */
-    protected ApplicationInfoRenderer(final ApplicationInfo applicationInfo) {
-        this.applicationInfo = applicationInfo;
-    }
 
     /**
      * Gets the application name.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListItemRenderer.java
@@ -3,26 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Attribute;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders attribute list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class AttributeListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the AttributeRenderer that is using this helper.
      */
-    private final transient AttributeRenderer attributeRenderer;
-
-    /**
-     * Creates a new AttributeListItemRenderer.
-     *
-     * @param attributeRenderer the attribute renderer
-     */
-    public AttributeListItemRenderer(
-            final AttributeRenderer attributeRenderer) {
-        this.attributeRenderer = attributeRenderer;
-    }
+    private final AttributeRenderer attributeRenderer;
 
     /**
      * Executes render as list item.
@@ -76,8 +69,7 @@ public class AttributeListItemRenderer implements ListItemRenderer {
                     attributeRenderer.createGedRenderer(subAttr);
             final String html = renderer.renderAsPhrase();
             final boolean currentIsFull = !html.isEmpty();
-            final String separator = renderer.getSeparator(currentIsFull
-                    && previousIsFull);
+            final String separator = renderer.getSeparator(currentIsFull && previousIsFull);
             if (currentIsFull) {
                 previousIsFull = true;
             }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListOpenRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributeListOpenRenderer.java
@@ -15,6 +15,5 @@ public interface AttributeListOpenRenderer {
      * @param pad the amount of indentation we need.
      * @param subObject a subobject.
      */
-    void renderAttributeListOpen(StringBuilder builder, int pad,
-            GedObject subObject);
+    void renderAttributeListOpen(StringBuilder builder, int pad, GedObject subObject);
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributePhraseRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders attribute phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public final class AttributePhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the AttributeRenderer that is using this helper.
      */
-    private final transient AttributeRenderer attributeRenderer;
-
-    /**
-     * Creates a new AttributePhraseRenderer.
-     *
-     * @param attributeRenderer the attribute renderer
-     */
-    protected AttributePhraseRenderer(
-            final AttributeRenderer attributeRenderer) {
-        this.attributeRenderer = attributeRenderer;
-    }
+    private final AttributeRenderer attributeRenderer;
 
     /**
      * Returns the string.
@@ -28,7 +21,6 @@ public final class AttributePhraseRenderer implements PhraseRenderer {
      */
     @Override
     public String renderAsPhrase() {
-        return RenderingContextRenderer.escapeString(attributeRenderer.getGedObject()
-                .getTail());
+        return RenderingContextRenderer.escapeString(attributeRenderer.getGedObject().getTail());
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributesRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/AttributesRenderer.java
@@ -1,8 +1,9 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
+import org.apache.commons.lang3.StringUtils;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 
 
@@ -33,15 +34,10 @@ public interface AttributesRenderer<T extends GedObject> {
      * @return the list of attribute renderers.
      */
     default List<GedRenderer<?>> getAttributes() {
-        final List<GedRenderer<?>> list = new ArrayList<GedRenderer<?>>();
-        final T gob = getGedObject();
-        for (final GedObject attribute : gob.getAttributes()) {
-            final GedRenderer<?> renderer = createGedRenderer(attribute);
-            if (!renderer.getListItemContents().isEmpty()) {
-                list.add(renderer);
-            }
-        }
-        return list.stream().toList();
+        return getGedObject().getAttributes().stream()
+            .map(attribute -> (GedRenderer<?>) createGedRenderer(attribute))
+            .filter(renderer -> StringUtils.isNotEmpty(renderer.getListItemContents()))
+            .collect(Collectors.toUnmodifiableList());
     }
 
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/CellRow.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/CellRow.java
@@ -10,7 +10,7 @@ import java.util.List;
  */
 public final class CellRow {
     /** */
-    private final transient List<CellRenderer> renderers;
+    private final List<CellRenderer> renderers;
 
     /**
      * Creates a new CellRow.
@@ -18,7 +18,7 @@ public final class CellRow {
      * @param columns the columns
      */
     public CellRow(final int columns) {
-        renderers = new ArrayList<CellRenderer>(columns);
+        renderers = new ArrayList<>(columns);
         for (int i = 0; i < columns; i++) {
             renderers.add(createNullCellRenderer());
         }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DateListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DateListItemRenderer.java
@@ -1,24 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders date list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public final class DateListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the DateRenderer that is using this helper.
      */
-    private final transient DateRenderer dateRenderer;
-
-    /**
-     * Creates a new DateListItemRenderer.
-     *
-     * @param dateRenderer the date renderer
-     */
-    protected DateListItemRenderer(final DateRenderer dateRenderer) {
-        this.dateRenderer = dateRenderer;
-    }
+    private final DateRenderer dateRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DatePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/DatePhraseRenderer.java
@@ -3,25 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Date;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.GetDateVisitor;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders date phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class DatePhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the DateRenderer that is using this helper.
      */
-    private final transient DateRenderer dateRenderer;
-
-    /**
-     * Creates a new DatePhraseRenderer.
-     *
-     * @param dateRenderer the date renderer
-     */
-    protected DatePhraseRenderer(final DateRenderer dateRenderer) {
-        this.dateRenderer = dateRenderer;
-    }
+    private final DateRenderer dateRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/FamilyRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/FamilyRenderer.java
@@ -35,8 +35,7 @@ public final class FamilyRenderer extends GedRenderer<Family>
      * @param personRenderer the person renderer
      * @return the spouse
      */
-    public PersonRenderer getSpouse(
-            final PersonRenderer personRenderer) {
+    public PersonRenderer getSpouse(final PersonRenderer personRenderer) {
         final Family family = getGedObject();
         final Person person = personRenderer.getGedObject();
         final Person spouse = (new FamilyNavigator(family)).getSpouse(person);
@@ -53,10 +52,11 @@ public final class FamilyRenderer extends GedRenderer<Family>
         final FamilyNavigator navigator = new FamilyNavigator(family);
         final List<Person> children = navigator.getChildren();
         return children.stream()
-                .map(this::createGedRenderer)
-                .map(renderer -> (PersonRenderer) renderer)
-                .toList();
+            .map(this::createGedRenderer)
+            .map(PersonRenderer.class::cast)
+            .toList();
     }
+
     /**
      * Get the standard amount of indent for this construct.
      *

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRenderer.java
@@ -12,18 +12,17 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
  * @param <G> the GedObject type to render.
  */
 @SuppressWarnings({ "PMD.AbstractClassWithoutAbstractMethod" })
-public abstract class GedRenderer<G extends GedObject>
-        extends SectionedRenderer {
+public abstract class GedRenderer<G extends GedObject> extends SectionedRenderer {
     /**
      * Beginning of common anchor.
      */
     private static final String A_HREF = "\n    <a href=\"?";
 
     /** */
-    private final transient G gedObject;
+    private final G gedObject;
 
     /** */
-    private final transient GedRendererFactory rendererFactory;
+    private final GedRendererFactory rendererFactory;
 
     /**
      * Executes ged renderer.
@@ -177,16 +176,13 @@ public abstract class GedRenderer<G extends GedObject>
         final StringBuilder builder = new StringBuilder();
         builder.append("\n    <p>");
         if ("Header".equals(omit)) {
-            builder.append(A_HREF + gedObject.getDbName()
-                    + "+Header\">Header</a><br>");
+            builder.append(A_HREF + gedObject.getDbName() + "+Header\">Header</a><br>");
         }
         if ("Surnames".equals(omit)) {
-            builder.append(A_HREF + gedObject.getDbName()
-                    + "+Surnames\">Surnames</a><br>");
+            builder.append(A_HREF + gedObject.getDbName() + "+Surnames\">Surnames</a><br>");
         }
         if ("Index".equals(omit)) {
-            builder.append(A_HREF + gedObject.getDbName()
-                    + "+Index\">Index</a><br>");
+            builder.append(A_HREF + gedObject.getDbName() + "+Index\">Index</a><br>");
         }
         builder.append("\n    </p>");
         return builder.toString();

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRendererFactory.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedRendererFactory.java
@@ -40,7 +40,7 @@ import org.schoellerfamily.gedbrowser.renderer.application.ApplicationInfo;
 @SuppressWarnings({ "java:S1452" })
 public final class GedRendererFactory {
     /** */
-    private static Map<Class<?>, RendererBuilder> builders = Map.ofEntries(
+    private static final Map<Class<?>, RendererBuilder> BUILDERS = Map.ofEntries(
         Map.entry((Class<?>) Husband.class,
             (RendererBuilder) (g, f, r) -> new HusbandRenderer((Husband) g, f, r)),
         Map.entry((Class<?>) Wife.class,
@@ -133,7 +133,7 @@ public final class GedRendererFactory {
     public GedRenderer<? extends GedObject> create(final GedObject gedObject,
         final RenderingContext renderingContext) {
         if (gedObject != null) {
-            final RendererBuilder builder = builders.get(gedObject.getClass());
+            final RendererBuilder builder = BUILDERS.get(gedObject.getClass());
             if (builder != null) {
                 return builder.build(gedObject, this, renderingContext);
             }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedResourceNotFoundRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/GedResourceNotFoundRenderer.java
@@ -41,9 +41,8 @@ public class GedResourceNotFoundRenderer extends RenderingContextRenderer {
     public String getMessage() {
         if (throwable == null) {
             return "Null exception";
-        } else {
-            return throwable.getMessage();
         }
+        return throwable.getMessage();
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/IndexByPlaceRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/IndexByPlaceRenderer.java
@@ -189,7 +189,13 @@ public final class IndexByPlaceRenderer extends GedRenderer<Root>
             .collect(Collectors.toMap(
                 entry -> client.get(entry.getKey()),
                 Map.Entry::getValue,
-                (v1, v2) -> v1,
+                (v1, v2) -> {
+                    final Set<PersonRenderer> merged =
+                        new TreeSet<>(new PersonRendererComparator());
+                    merged.addAll(v1);
+                    merged.addAll(v2);
+                    return merged;
+                },
                 () -> new TreeMap<>(new GeoServiceItemComparator())
             ));
     }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/IndexByPlaceRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/IndexByPlaceRenderer.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
+import java.util.stream.Collectors;
 
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.Root;
@@ -122,8 +123,7 @@ public final class IndexByPlaceRenderer extends GedRenderer<Root>
      */
     private void placePerson(final Map<String, Set<PersonRenderer>> aMap,
             final PersonRenderer renderer, final String place) {
-        final Set<PersonRenderer> locatedPersons =
-                personRendererSet(aMap, place);
+        final Set<PersonRenderer> locatedPersons = personRendererSet(aMap, place);
         locatedPersons.add(renderer);
     }
 
@@ -145,8 +145,7 @@ public final class IndexByPlaceRenderer extends GedRenderer<Root>
         if (getRenderingContext().isAdmin()) {
             return false;
         }
-        final PersonConfidentialVisitor visitor =
-                new PersonConfidentialVisitor();
+        final PersonConfidentialVisitor visitor = new PersonConfidentialVisitor();
         person.accept(visitor);
         return visitor.isConfidential() || !getRenderingContext().isUser();
     }
@@ -186,14 +185,12 @@ public final class IndexByPlaceRenderer extends GedRenderer<Root>
      * @return the resulting set
      */
     public Map<GeoServiceItem, Set<PersonRenderer>> render() {
-        final Map<GeoServiceItem, Set<PersonRenderer>> aMap = new TreeMap<>(
-                new GeoServiceItemComparator());
-        final Map<String, Set<PersonRenderer>> map = getWholeIndex();
-        for (final Map.Entry<String, Set<PersonRenderer>> entry
-                : map.entrySet()) {
-            final GeoServiceItem item = client.get(entry.getKey());
-            aMap.put(item, entry.getValue());
-        }
-        return aMap;
+        return getWholeIndex().entrySet().stream()
+            .collect(Collectors.toMap(
+                entry -> client.get(entry.getKey()),
+                Map.Entry::getValue,
+                (v1, v2) -> v1,
+                () -> new TreeMap<>(new GeoServiceItemComparator())
+            ));
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/LineCellRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/LineCellRenderer.java
@@ -1,22 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders line cell output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
+@Getter
 public final class LineCellRenderer implements CellRenderer {
     /** */
-    private final transient String classString;
-
-    /**
-     * Executes line cell renderer.
-     *
-     * @param classString the class string
-     */
-    public LineCellRenderer(final String classString) {
-        this.classString = classString;
-    }
+    private final String cellClass;
 
     /**
      * Returns the name html.
@@ -26,15 +22,5 @@ public final class LineCellRenderer implements CellRenderer {
     @Override
     public String getNameHtml() {
         return "&nbsp;&nbsp;&nbsp;";
-    }
-
-    /**
-     * Returns the cell class.
-     *
-     * @return the cell class
-     */
-    @Override
-    public String getCellClass() {
-        return classString;
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/LivingRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/LivingRenderer.java
@@ -45,8 +45,7 @@ public final class LivingRenderer extends GedRenderer<Root>
      * @param root the root
      * @param renderingContext the rendering context
      */
-    public LivingRenderer(final Root root,
-            final RenderingContext renderingContext) {
+    public LivingRenderer(final Root root, final RenderingContext renderingContext) {
         super(root, new GedRendererFactory(), renderingContext);
     }
 

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaListItemRenderer.java
@@ -3,26 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Multimedia;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.MultimediaVisitor;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders multimedia list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public final class MultimediaListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the MultimediaRenderer that is using this helper.
      */
-    private final transient MultimediaRenderer multimediaRenderer;
-
-    /**
-     * Creates a new MultimediaListItemRenderer.
-     *
-     * @param multimediaRenderer the multimedia renderer
-     */
-    public MultimediaListItemRenderer(
-            final MultimediaRenderer multimediaRenderer) {
-        this.multimediaRenderer = multimediaRenderer;
-    }
+    private final MultimediaRenderer multimediaRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaPhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/MultimediaPhraseRenderer.java
@@ -3,26 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Multimedia;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.MultimediaVisitor;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders multimedia phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public final class MultimediaPhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the MultimediaRenderer that is using this helper.
      */
-    private final transient MultimediaRenderer multimediaRenderer;
-
-    /**
-     * Creates a new MultimediaPhraseRenderer.
-     *
-     * @param multimediaRenderer the multimedia renderer
-     */
-    protected MultimediaPhraseRenderer(
-            final MultimediaRenderer multimediaRenderer) {
-        this.multimediaRenderer = multimediaRenderer;
-    }
+    private final MultimediaRenderer multimediaRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameListItemRenderer.java
@@ -1,24 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders name list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class NameListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the NameRenderer that is using this helper.
      */
-    private final transient NameRenderer nameRenderer;
-
-    /**
-     * Creates a new NameListItemRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    protected NameListItemRenderer(final NameRenderer nameRenderer) {
-        this.nameRenderer = nameRenderer;
-    }
+    private final NameRenderer nameRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameHtmlRenderer.java
@@ -2,26 +2,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders name name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class NameNameHtmlRenderer implements NameHtmlRenderer {
     /**
      * Holder for the NameRenderer that is using this helper.
      */
-    private final transient NameRenderer nameRenderer;
-
-    /**
-     * Creates a new NameNameHtmlRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    public NameNameHtmlRenderer(final NameRenderer nameRenderer) {
-        this.nameRenderer = nameRenderer;
-    }
-
+    private final NameRenderer nameRenderer;
 
     /**
      * Returns the name html.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NameNameIndexRenderer.java
@@ -2,24 +2,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders name name index output for display.
  *
  * @author Richard Schoeller
  */
-public final class NameNameIndexRenderer
-    implements NameIndexRenderer, ComplexRenderer {
+@RequiredArgsConstructor
+public final class NameNameIndexRenderer implements NameIndexRenderer, ComplexRenderer {
     /** */
-    private final transient NameRenderer nameRenderer;
-
-    /**
-     * Creates a new NameNameIndexRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    public NameNameIndexRenderer(final NameRenderer nameRenderer) {
-        this.nameRenderer = nameRenderer;
-    }
+    private final NameRenderer nameRenderer;
 
     /**
      * Returns the index name.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NamePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NamePhraseRenderer.java
@@ -2,25 +2,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders name phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class NamePhraseRenderer implements PhraseRenderer, ComplexRenderer {
     /**
      * The renderer that we are associated with.
      */
-    private final transient NameRenderer nameRenderer;
-
-    /**
-     * Creates a new NamePhraseRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    public NamePhraseRenderer(final NameRenderer nameRenderer) {
-        this.nameRenderer = nameRenderer;
-    }
+    private final NameRenderer nameRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NodeCellRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NodeCellRenderer.java
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 @Getter
 public final class NodeCellRenderer implements CellRenderer {
     /** */
-    private final transient PersonRenderer personRenderer;
+    private final PersonRenderer personRenderer;
 
     /**
      * Gets the name html.
@@ -29,8 +29,8 @@ public final class NodeCellRenderer implements CellRenderer {
         if (StringUtils.isBlank(nameHtml)) {
             nameHtml = "&nbsp;&nbsp;&nbsp;";
         }
-        return "<table class=\"bbox\"><tr><td class=\"tree bbox\">"
-                + nameHtml + "</td></tr></table>";
+        return "<table class=\"bbox\"><tr><td class=\"tree bbox\">%s</td></tr></table>"
+            .formatted(nameHtml);
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkListItemRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders note link list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class NoteLinkListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the NoteLinkRenderer that is using this helper.
      */
-    private final transient NoteLinkRenderer noteLinkRenderer;
-
-    /**
-     * Creates a new NoteLinkListItemRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected NoteLinkListItemRenderer(
-            final NoteLinkRenderer renderer) {
-        this.noteLinkRenderer = renderer;
-    }
+    private final NoteLinkRenderer noteLinkRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkNameIndexRenderer.java
@@ -3,23 +3,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Note;
 import org.schoellerfamily.gedbrowser.datamodel.NoteLink;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders note link name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class NoteLinkNameIndexRenderer implements NameIndexRenderer {
     /** */
     private final NoteLinkRenderer noteLinkRenderer;
-
-    /**
-     * Creates a new NoteLinkNameIndexRenderer.
-     *
-     * @param noteLinkRenderer the note link renderer
-     */
-    public NoteLinkNameIndexRenderer(final NoteLinkRenderer noteLinkRenderer) {
-        this.noteLinkRenderer = noteLinkRenderer;
-    }
 
     /**
      * Returns the index name.
@@ -40,8 +34,8 @@ public class NoteLinkNameIndexRenderer implements NameIndexRenderer {
             return noteLink.getToString();
         }
         final NoteRenderer noteRenderer =
-                (NoteRenderer) new GedRendererFactory().create(note,
-                        noteLinkRenderer.getRenderingContext());
+            (NoteRenderer) new GedRendererFactory().create(note,
+                noteLinkRenderer.getRenderingContext());
         return noteRenderer.getIndexNameHtml();
     }
 

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkPhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteLinkPhraseRenderer.java
@@ -1,23 +1,16 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders note link phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public final class NoteLinkPhraseRenderer implements PhraseRenderer {
     /** */
-    private final transient NoteLinkRenderer nlRenderer;
-
-    /**
-     * Creates a new NoteLinkPhraseRenderer.
-     *
-     * @param renderer the renderer
-     */
-    public NoteLinkPhraseRenderer(
-            final NoteLinkRenderer renderer) {
-        this.nlRenderer = renderer;
-    }
+    private final NoteLinkRenderer nlRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteNameIndexRenderer.java
@@ -2,23 +2,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Note;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders note name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class NoteNameIndexRenderer implements NameIndexRenderer {
     /** */
-    private final transient NoteRenderer noteRenderer;
-
-    /**
-     * Creates a new NoteNameIndexRenderer.
-     *
-     * @param noteRenderer the note renderer
-     */
-    public NoteNameIndexRenderer(final NoteRenderer noteRenderer) {
-        this.noteRenderer = noteRenderer;
-    }
+    private final NoteRenderer noteRenderer;
 
     /**
      * Returns the index name.
@@ -35,8 +29,8 @@ public class NoteNameIndexRenderer implements NameIndexRenderer {
         final String nameHtml = noteRenderer.getTitleString();
 
         return "<a href=\"note?db=" + note.getDbName() + "&amp;id="
-                + note.getString() + "\" class=\"name\" id=\"note-"
-                + note.getString() + "\">" + nameHtml + " ("
-                + note.getString() + ")</a>";
+            + note.getString() + "\" class=\"name\" id=\"note-"
+            + note.getString() + "\">" + nameHtml + " ("
+            + note.getString() + ")</a>";
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/NoteRenderer.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.apache.commons.lang3.StringUtils;
 import org.schoellerfamily.gedbrowser.datamodel.Note;
 import org.schoellerfamily.gedbrowser.renderer.href.HeaderHrefRenderer;
 import org.schoellerfamily.gedbrowser.renderer.href.IndexHrefRenderer;
@@ -71,16 +71,10 @@ public final class NoteRenderer extends GedRenderer<Note>
      */
     @SuppressWarnings("java:S1452")
     public List<GedRenderer<?>> getAttributes() {
-        final Note source = getGedObject();
-        final List<GedRenderer<?>> list = new ArrayList<GedRenderer<?>>();
-        for (final GedObject attribute : source.getAttributes()) {
-            final GedRenderer<?> attributeRenderer =
-                    createGedRenderer(attribute);
-            if (!attributeRenderer.getListItemContents().isEmpty()) {
-                list.add(attributeRenderer);
-            }
-        }
-        return list.stream().toList();
+        return getGedObject().getAttributes().stream()
+            .map(this::createGedRenderer)
+            .filter(renderer -> StringUtils.isNotEmpty(renderer.getListItemContents()))
+            .collect(Collectors.toUnmodifiableList());
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ParentsRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/ParentsRenderer.java
@@ -70,9 +70,8 @@ public class ParentsRenderer {
 
         GedRenderer.renderPad(builder, pad, true);
         builder.append(
-                " <span class=\"parent label\">" + parentLabel
-                + ":</span> ").append(
-                        parentHtml);
+            " <span class=\"parent label\">" + parentLabel
+            + ":</span> ").append(parentHtml);
 
         GedRenderer.renderPad(builder, pad, true);
         builder.append("</p>");
@@ -87,8 +86,7 @@ public class ParentsRenderer {
         final StringBuilder builder = new StringBuilder();
         final Person father = navigator.getFather();
         if (father != null) {
-            renderParent(builder, 0,
-                    createGedRenderer(father).getNameHtml(), "Father");
+            renderParent(builder, 0, createGedRenderer(father).getNameHtml(), "Father");
         }
         return builder.toString();
     }
@@ -102,8 +100,7 @@ public class ParentsRenderer {
         final StringBuilder builder = new StringBuilder();
         final Person mother = navigator.getMother();
         if (mother != null) {
-            renderParent(builder, 0,
-                    createGedRenderer(mother).getNameHtml(), "Mother");
+            renderParent(builder, 0, createGedRenderer(mother).getNameHtml(), "Mother");
         }
         return builder.toString();
     }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameHtmlRenderer.java
@@ -4,25 +4,19 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.GetDateVisitor;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders person name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class PersonNameHtmlRenderer implements NameHtmlRenderer {
     /**
      * Holder for the PersonRenderer that is using this helper.
      */
-    private final transient PersonRenderer personRenderer;
-
-    /**
-     * Creates a new PersonNameHtmlRenderer.
-     *
-     * @param personRenderer the person renderer
-     */
-    protected PersonNameHtmlRenderer(final PersonRenderer personRenderer) {
-        this.personRenderer = personRenderer;
-    }
+    private final PersonRenderer personRenderer;
 
     /**
      * Returns the name html.
@@ -48,9 +42,9 @@ public class PersonNameHtmlRenderer implements NameHtmlRenderer {
         final String spanString = spanString(person);
 
         return "<a href=\"person?db="
-                + person.getDbName() + "&amp;id=" + person.getString()
-                + "\" class=\"name\">" + nameHtml + spanString + " ["
-                + person.getString() + "]" + "</a>";
+            + person.getDbName() + "&amp;id=" + person.getString()
+            + "\" class=\"name\">" + nameHtml + spanString + " ["
+            + person.getString() + "]" + "</a>";
     }
 
     private String spanString(final Person person) {

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameIndexRenderer.java
@@ -4,23 +4,17 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.GetDateVisitor;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders person name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class PersonNameIndexRenderer implements NameIndexRenderer {
     /** */
-    private final transient PersonRenderer personRenderer;
-
-    /**
-     * Creates a new PersonNameIndexRenderer.
-     *
-     * @param personRenderer the person renderer
-     */
-    public PersonNameIndexRenderer(final PersonRenderer personRenderer) {
-        this.personRenderer = personRenderer;
-    }
+    private final PersonRenderer personRenderer;
 
     /**
      * Returns the index name.
@@ -50,9 +44,9 @@ public class PersonNameIndexRenderer implements NameIndexRenderer {
         final String deathYear = deathVisitor.getYear();
 
         return "<a href=\"person?db=" + person.getDbName() + "&amp;id="
-                + person.getString() + "\" class=\"name\">" + nameHtml
-                + dateRangeString(birthYear, deathYear) + " ("
-                + person.getString() + ")</a>";
+            + person.getString() + "\" class=\"name\">" + nameHtml
+            + dateRangeString(birthYear, deathYear) + " ("
+            + person.getString() + ")</a>";
     }
 
     private String dateRangeString(final String birthYear,

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonNameRenderer.java
@@ -36,15 +36,14 @@ public interface PersonNameRenderer {
      * @return the name string in title format.
      */
     default String getTitleName() {
-        final Name name = getGedObject().getName();
         if (isConfidential()) {
             return "Confidential";
         } else if (isHiddenLiving()) {
             return "Living";
-        } else {
-            final GedRenderer<?> nameRenderer = createGedRenderer(name);
-            return nameRenderer.getNameHtml();
         }
+        final Name name = getGedObject().getName();
+        final GedRenderer<?> nameRenderer = createGedRenderer(name);
+        return nameRenderer.getNameHtml();
     }
 
     /**
@@ -74,9 +73,8 @@ public interface PersonNameRenderer {
     default String getSurname() {
         if (isConfidential() || isHiddenLiving()) {
             return "?";
-        } else {
-            return getGedObject().getSurname();
         }
+        return getGedObject().getSurname();
     }
 
     /**
@@ -85,8 +83,7 @@ public interface PersonNameRenderer {
     default String getSurnameLetter() {
         if (isConfidential() || isHiddenLiving()) {
             return "?";
-        } else {
-            return getGedObject().getSurnameLetter();
         }
+        return getGedObject().getSurnameLetter();
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PersonRenderer.java
@@ -113,8 +113,8 @@ public final class PersonRenderer extends GedRenderer<Person>
      * @return the tree rows
      */
     public CellRow[] getTreeRows(final int generations) {
-        final TreeTableRenderer ttr = new TreeTableRenderer(this,
-            confidentialGenCount(generations));
+        final TreeTableRenderer ttr =
+            new TreeTableRenderer(this, confidentialGenCount(generations));
         return ttr.getTreeRows();
     }
 
@@ -125,9 +125,8 @@ public final class PersonRenderer extends GedRenderer<Person>
     private int confidentialGenCount(final int generations) {
         if (isConfidential() || isHiddenLiving()) {
             return 1;
-        } else {
-            return generations;
         }
+        return generations;
     }
 
     /**
@@ -163,6 +162,6 @@ public final class PersonRenderer extends GedRenderer<Person>
         final String surnameLetter = getSurnameLetter();
         final String surname = getSurname();
         return "surnames?db=" + getGedObject().getDbName() + "&letter="
-                + surnameLetter + "#" + surname;
+            + surnameLetter + "#" + surname;
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceInfo.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceInfo.java
@@ -11,8 +11,6 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import lombok.Getter;
 
-
-
 /**
  * Represents place info.
  *

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceListItemRenderer.java
@@ -1,24 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders place list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class PlaceListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the PlaceRenderer that is using this helper.
      */
-    private final transient PlaceRenderer placeRenderer;
-
-    /**
-     * Creates a new PlaceListItemRenderer.
-     *
-     * @param placeRenderer the place renderer
-     */
-    protected PlaceListItemRenderer(final PlaceRenderer placeRenderer) {
-        this.placeRenderer = placeRenderer;
-    }
+    private final PlaceRenderer placeRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceListRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlaceListRenderer.java
@@ -20,8 +20,6 @@ import org.schoellerfamily.geoservice.model.GeoServiceItem;
 
 import lombok.extern.slf4j.Slf4j;
 
-
-
 /**
  * Renders place list output for display.
  *
@@ -74,12 +72,12 @@ public final class PlaceListRenderer {
 
     private List<PlaceInfo> geoCodePlaces(final Collection<String> places) {
         return places.stream()
-                .map(client::get)
-                .filter(Objects::nonNull)
-                .filter(item -> item.getResult() != null)
-                .map(this::createPlaceInfo)
-                .filter(Objects::nonNull)
-                .toList();
+            .map(client::get)
+            .filter(Objects::nonNull)
+            .filter(item -> item.getResult() != null)
+            .map(this::createPlaceInfo)
+            .filter(Objects::nonNull)
+            .toList();
     }
 
     private PlaceInfo createPlaceInfo(final GeoServiceItem item) {

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlacePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/PlacePhraseRenderer.java
@@ -2,25 +2,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Place;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders place phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class PlacePhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the PlaceRenderer that is using this helper.
      */
-    private final transient PlaceRenderer placeRenderer;
-
-    /**
-     * Creates a new PlacePhraseRenderer.
-     *
-     * @param placeRenderer the place renderer
-     */
-    protected PlacePhraseRenderer(final PlaceRenderer placeRenderer) {
-        this.placeRenderer = placeRenderer;
-    }
+    private final PlaceRenderer placeRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/Renderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/Renderer.java
@@ -46,9 +46,8 @@ public interface Renderer {
     default String getSeparator(final boolean separate) {
         if (separate) {
             return ", ";
-        } else {
-            return "";
         }
+        return "";
     }
 
     /**
@@ -61,21 +60,21 @@ public interface Renderer {
      */
     default String getHeaderHtml(final String title, final String keywords) {
         return "Content-type: text/html\n\n"
-                + "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\n"
-                + "  \"http://www.w3.org/TR/html4/strict.dtd\">\n"
-                + "<html>\n  <head>\n"
-                + "    <meta http-equiv=\"Content-Type\" "
-                + "content=\"text/html; charset=utf-8\">\n"
-                + "    <meta name=\"Author\" content=\"gedbrowser\">\n"
-                + "    <meta name=\"Description\" content=\"genealogy\">\n"
-                + "    <meta name=\"Keywords\" content=\"genealogy gedbrowser "
-                + keywords + "\">\n"
-                + "    <meta http-equiv=\"Content-Style-Type\" "
-                + "content=\"text/css\">\n"
-                + "    <link href=\"/gedbrowser/gedbrowser.css\" "
-                + "rel=\"stylesheet\" type=\"text/css\">\n"
-                + "    <title>" + title + "</title>\n"
-                + "  </head>\n  <body>\n";
+            + "<!DOCTYPE HTML PUBLIC \"-//W3C//DTD HTML 4.01//EN\"\n"
+            + "  \"http://www.w3.org/TR/html4/strict.dtd\">\n"
+            + "<html>\n  <head>\n"
+            + "    <meta http-equiv=\"Content-Type\" "
+            + "content=\"text/html; charset=utf-8\">\n"
+            + "    <meta name=\"Author\" content=\"gedbrowser\">\n"
+            + "    <meta name=\"Description\" content=\"genealogy\">\n"
+            + "    <meta name=\"Keywords\" content=\"genealogy gedbrowser "
+            + keywords + "\">\n"
+            + "    <meta http-equiv=\"Content-Style-Type\" "
+            + "content=\"text/css\">\n"
+            + "    <link href=\"/gedbrowser/gedbrowser.css\" "
+            + "rel=\"stylesheet\" type=\"text/css\">\n"
+            + "    <title>" + title + "</title>\n"
+            + "  </head>\n  <body>\n";
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/RenderingContextRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/RenderingContextRenderer.java
@@ -4,6 +4,7 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.users.UserRoleName;
 
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 
 
@@ -12,22 +13,14 @@ import lombok.Getter;
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 @Getter
 public abstract class RenderingContextRenderer implements Renderer {
 
     /** */
     private final RenderingContext renderingContext;
 
-    /**
-     * Creates a new RenderingContextRenderer.
-     *
-     * @param renderingContext the rendering context
-     */
-    protected RenderingContextRenderer(final RenderingContext renderingContext) {
-        this.renderingContext = renderingContext;
-    }
-
-    /**
+        /**
      * Gets the application name.
      *
      * @return the application name
@@ -113,8 +106,10 @@ public abstract class RenderingContextRenderer implements Renderer {
      * @return the escaped string.
      */
     public static final String escapeString(final String input) {
-        return input.replace("&", "&amp;").replace("<", "&lt;")
-                .replace(">", "&gt;").replace("\n", "<br/>\n");
+        return input.replace("&", "&amp;")
+            .replace("<", "&lt;")
+            .replace(">", "&gt;")
+            .replace("\n", "<br/>\n");
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SectionedRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SectionedRenderer.java
@@ -1,24 +1,33 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.Getter;
+import lombok.Setter;
+
 /**
  * Renders sectioned output for display.
  *
  * @author Richard Schoeller
  */
+@Getter
 public class SectionedRenderer extends RenderingContextRenderer {
     /** */
+    @Setter(lombok.AccessLevel.PROTECTED)
     private NameHtmlRenderer nameHtmlRenderer;
 
     /** */
+    @Setter(lombok.AccessLevel.PROTECTED)
     private NameIndexRenderer nameIndexRenderer;
 
     /** */
+    @Setter(lombok.AccessLevel.PROTECTED)
     private ListItemRenderer listItemRenderer;
 
     /** */
+    @Setter(lombok.AccessLevel.PROTECTED)
     private PhraseRenderer phraseRenderer;
 
     /** */
+    @Setter(lombok.AccessLevel.PROTECTED)
     private AttributeListOpenRenderer attributeListOpenRenderer;
 
     /**
@@ -33,109 +42,5 @@ public class SectionedRenderer extends RenderingContextRenderer {
         this.listItemRenderer = new NullListItemRenderer();
         this.phraseRenderer = new NullPhraseRenderer();
         this.attributeListOpenRenderer = new SimpleAttributeListOpenRenderer();
-    }
-
-    /**
-     * Sets the name html renderer.
-     *
-     * @param nameHtmlRenderer the name html renderer to use
-     */
-    protected final void setNameHtmlRenderer(
-            final NameHtmlRenderer nameHtmlRenderer) {
-        this.nameHtmlRenderer = nameHtmlRenderer;
-    }
-
-    /**
-     * This method is public for testing purposes only. Do
-     * not try to call it outside of the context of the rendering
-     * engine.
-     *
-     * @return the renderer.
-     */
-    public final NameHtmlRenderer getNameHtmlRenderer() {
-        return this.nameHtmlRenderer;
-    }
-
-    /**
-     * Sets the list item renderer.
-     *
-     * @param listItemRenderer the list item renderer
-     */
-    protected final void setListItemRenderer(
-            final ListItemRenderer listItemRenderer) {
-        this.listItemRenderer = listItemRenderer;
-    }
-
-    /**
-     * This method is public for testing purposes only. Do not try to call it
-     * outside of the context of the rendering engine.
-     *
-     * @return the renderer.
-     */
-    public final ListItemRenderer getListItemRenderer() {
-        return this.listItemRenderer;
-    }
-
-    /**
-     * Sets the phrase renderer.
-     *
-     * @param phraseRenderer the phrase renderer
-     */
-    protected final void setPhraseRenderer(
-            final PhraseRenderer phraseRenderer) {
-        this.phraseRenderer = phraseRenderer;
-    }
-
-    /**
-     * This method is public for testing purposes only. Do not try to call it
-     * outside of the context of the rendering engine.
-     *
-     * @return the renderer.
-     */
-    public final PhraseRenderer getPhraseRenderer() {
-        return this.phraseRenderer;
-    }
-
-    /**
-     * Sets the attribute list open renderer.
-     *
-     * @param attributeListOpenRenderer the attribute list open renderer
-     */
-    protected final void setAttributeListOpenRenderer(
-            final AttributeListOpenRenderer
-                attributeListOpenRenderer) {
-        this.attributeListOpenRenderer = attributeListOpenRenderer;
-    }
-
-    /**
-     * This method is public for testing purposes only. Do
-     * not try to call it outside of the context of the rendering
-     * engine.
-     *
-     * @return the renderer.
-     */
-    public final AttributeListOpenRenderer getAttributeListOpenRenderer() {
-        return this.attributeListOpenRenderer;
-    }
-
-    /**
-     * Sets the name index renderer.
-     *
-     * @param nameIndexRenderer the zero-based name index renderer
-     */
-    protected final void setNameIndexRenderer(
-            final NameIndexRenderer nameIndexRenderer) {
-        this.nameIndexRenderer = nameIndexRenderer;
-    }
-
-    /**
-     * This method is public for testing purposes only. Do
-     * not try to call it outside of the context of the rendering
-     * engine.
-     *
-     * @return the renderer.
-     */
-    public final NameIndexRenderer getNameIndexRenderer() {
-        return this.nameIndexRenderer;
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleAttributeListOpenRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleAttributeListOpenRenderer.java
@@ -7,8 +7,7 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
  *
  * @author Richard Schoeller
  */
-public class SimpleAttributeListOpenRenderer implements
-        AttributeListOpenRenderer {
+public class SimpleAttributeListOpenRenderer implements AttributeListOpenRenderer {
     /**
      * Executes render attribute list open.
      *

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameListItemRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders simple name list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SimpleNameListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the SimpleNameRenderer that is using this helper.
      */
-    private final transient SimpleNameRenderer simpleNameRenderer;
-
-    /**
-     * Creates a new SimpleNameListItemRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    protected SimpleNameListItemRenderer(
-            final SimpleNameRenderer nameRenderer) {
-        this.simpleNameRenderer = nameRenderer;
-    }
+    private final SimpleNameRenderer simpleNameRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameNameHtmlRenderer.java
@@ -2,28 +2,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders simple name name html output for display.
  *
  * @author Richard Schoeller
  */
-public class SimpleNameNameHtmlRenderer
-    implements NameHtmlRenderer, SimpleRenderer {
+@RequiredArgsConstructor
+public class SimpleNameNameHtmlRenderer implements NameHtmlRenderer, SimpleRenderer {
     /**
      * Holder for the SimpleNameRenderer that is using this helper.
      */
-    private final transient SimpleNameRenderer simpleNameRenderer;
-
-    /**
-     * Creates a new SimpleNameNameHtmlRenderer.
-     *
-     * @param simpleNameRenderer the simple name renderer to use
-     */
-    public SimpleNameNameHtmlRenderer(
-            final SimpleNameRenderer simpleNameRenderer) {
-        this.simpleNameRenderer = simpleNameRenderer;
-    }
-
+    private final SimpleNameRenderer simpleNameRenderer;
 
     /**
      * Returns the name html.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNameNameIndexRenderer.java
@@ -4,24 +4,18 @@ import java.util.Arrays;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders simple name name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public final class SimpleNameNameIndexRenderer
     implements NameIndexRenderer, SimpleRenderer {
     /** */
-    private final transient SimpleNameRenderer nameRenderer;
-
-    /**
-     * Creates a new SimpleNameNameIndexRenderer.
-     *
-     * @param nameRenderer the name renderer to use
-     */
-    public SimpleNameNameIndexRenderer(final SimpleNameRenderer nameRenderer) {
-        this.nameRenderer = nameRenderer;
-    }
+    private final SimpleNameRenderer nameRenderer;
 
     /**
      * Returns the index name.
@@ -39,9 +33,7 @@ public final class SimpleNameNameIndexRenderer
         final String surname = escapeString(name.getSurname());
         final String suffix = escapeString(name.getSuffix());
 
-        return " " + separate(
-                wrap("<span class=\"surname\">", surname, "</span>"),
-                prefix, suffix);
+        return " " + separate(wrap("<span class=\"surname\">", surname, "</span>"), prefix, suffix);
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNamePhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SimpleNamePhraseRenderer.java
@@ -2,27 +2,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Name;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders simple name phrase output for display.
  *
  * @author Richard Schoeller
  */
-public class SimpleNamePhraseRenderer
-    implements PhraseRenderer, SimpleRenderer {
+@RequiredArgsConstructor
+public class SimpleNamePhraseRenderer implements PhraseRenderer, SimpleRenderer {
     /**
      * The renderer that we are associated with.
      */
-    private final transient SimpleNameRenderer simpleNameRenderer;
-
-    /**
-     * Creates a new SimpleNamePhraseRenderer.
-     *
-     * @param simpleNameRenderer the simple name renderer to use
-     */
-    public SimpleNamePhraseRenderer(
-            final SimpleNameRenderer simpleNameRenderer) {
-        this.simpleNameRenderer = simpleNameRenderer;
-    }
+    private final SimpleNameRenderer simpleNameRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkListItemRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders source link list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SourceLinkListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the SourceLinkRenderer that is using this helper.
      */
-    private final transient SourceLinkRenderer sourceLinkRenderer;
-
-    /**
-     * Creates a new SourceLinkListItemRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected SourceLinkListItemRenderer(
-            final SourceLinkRenderer renderer) {
-        this.sourceLinkRenderer = renderer;
-    }
+    private final SourceLinkRenderer sourceLinkRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkNameHtmlRenderer.java
@@ -3,26 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
 import org.schoellerfamily.gedbrowser.datamodel.SourceLink;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders source link name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SourceLinkNameHtmlRenderer implements NameHtmlRenderer {
     /**
      * Holder for the SourceLinkRenderer that is using this helper.
      */
-    private final transient SourceLinkRenderer sourceLinkRenderer;
-
-    /**
-     * Creates a new SourceLinkNameHtmlRenderer.
-     *
-     * @param sourceLinkRenderer the source link renderer
-     */
-    protected SourceLinkNameHtmlRenderer(
-            final SourceLinkRenderer sourceLinkRenderer) {
-        this.sourceLinkRenderer = sourceLinkRenderer;
-    }
+    private final SourceLinkRenderer sourceLinkRenderer;
 
     /**
      * Returns the name html.
@@ -31,20 +24,18 @@ public class SourceLinkNameHtmlRenderer implements NameHtmlRenderer {
      */
     @Override
     public String getNameHtml() {
-        final SourceLink sourceLink = sourceLinkRenderer
-                .getGedObject();
+        final SourceLink sourceLink = sourceLinkRenderer.getGedObject();
         if (!sourceLink.isSet()) {
             return "";
         }
-        final Source source =
-                (Source) sourceLink.find(sourceLink.getToString());
+        final Source source = (Source) sourceLink.find(sourceLink.getToString());
         if (source == null) {
             // Necessary because header can have embedded source
             return sourceLink.getToString();
         }
         final SourceRenderer sourceRenderer =
-                (SourceRenderer) new GedRendererFactory().create(source,
-                        sourceLinkRenderer.getRenderingContext());
+            (SourceRenderer) new GedRendererFactory().create(source,
+                sourceLinkRenderer.getRenderingContext());
         return sourceRenderer.getIndexNameHtml();
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkPhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceLinkPhraseRenderer.java
@@ -1,23 +1,16 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders source link phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public final class SourceLinkPhraseRenderer implements PhraseRenderer {
     /** */
-    private final transient SourceLinkRenderer slRenderer;
-
-    /**
-     * Creates a new SourceLinkPhraseRenderer.
-     *
-     * @param renderer the renderer
-     */
-    public SourceLinkPhraseRenderer(
-            final SourceLinkRenderer renderer) {
-        this.slRenderer = renderer;
-    }
+    private final SourceLinkRenderer slRenderer;
 
     /**
      * Executes render as phrase.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceNameIndexRenderer.java
@@ -2,23 +2,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 
 import org.schoellerfamily.gedbrowser.datamodel.Source;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders source name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class SourceNameIndexRenderer implements NameIndexRenderer {
     /** */
-    private final transient SourceRenderer sourceRenderer;
-
-    /**
-     * Creates a new SourceNameIndexRenderer.
-     *
-     * @param sourceRenderer the source renderer
-     */
-    public SourceNameIndexRenderer(final SourceRenderer sourceRenderer) {
-        this.sourceRenderer = sourceRenderer;
-    }
+    private final SourceRenderer sourceRenderer;
 
     /**
      * Returns the index name.
@@ -35,8 +29,8 @@ public class SourceNameIndexRenderer implements NameIndexRenderer {
         final String nameHtml = sourceRenderer.getTitleString();
 
         return "<a href=\"source?db=" + source.getDbName() + "&amp;id="
-                + source.getString() + "\" class=\"name\" id=\"source-"
-                + source.getString() + "\">" + nameHtml + " ("
-                + source.getString() + ")</a>";
+            + source.getString() + "\" class=\"name\" id=\"source-"
+            + source.getString() + "\">" + nameHtml + " ("
+            + source.getString() + ")</a>";
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SourceRenderer.java
@@ -1,9 +1,9 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
-import org.schoellerfamily.gedbrowser.datamodel.GedObject;
+import org.apache.commons.lang3.StringUtils;
 import org.schoellerfamily.gedbrowser.datamodel.Source;
 import org.schoellerfamily.gedbrowser.datamodel.visitor.SourceVisitor;
 import org.schoellerfamily.gedbrowser.renderer.href.HeaderHrefRenderer;
@@ -63,19 +63,11 @@ public final class SourceRenderer extends GedRenderer<Source>
      */
     @SuppressWarnings("java:S1452")
     public List<GedRenderer<?>> getAttributes() {
-        final Source source = getGedObject();
-        final List<GedRenderer<?>> list = new ArrayList<GedRenderer<?>>();
-        for (final GedObject attribute : source.getAttributes()) {
-            final GedRenderer<?> attributeRenderer =
-                    createGedRenderer(attribute);
-            if ("Title".equals(attribute.getString())) {
-                continue;
-            }
-            if (!attributeRenderer.getListItemContents().isEmpty()) {
-                list.add(attributeRenderer);
-            }
-        }
-        return list.stream().toList();
+        return getGedObject().getAttributes().stream()
+            .filter(attribute -> !"Title".equals(attribute.getString()))
+            .map(this::createGedRenderer)
+            .filter(renderer -> StringUtils.isNotEmpty(renderer.getListItemContents()))
+            .collect(Collectors.toUnmodifiableList());
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkListItemRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submission link list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SubmissionLinkListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the SubmissionLinkRenderer that is using this helper.
      */
-    private final transient SubmissionLinkRenderer submissionLinkRenderer;
-
-    /**
-     * Creates a new SubmissionLinkListItemRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected SubmissionLinkListItemRenderer(
-            final SubmissionLinkRenderer renderer) {
-        this.submissionLinkRenderer = renderer;
-    }
+    private final SubmissionLinkRenderer submissionLinkRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkNameHtmlRenderer.java
@@ -1,22 +1,16 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submission link name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class SubmissionLinkNameHtmlRenderer implements NameHtmlRenderer {
     /** */
     private final SubmissionLinkRenderer submissionLinkRenderer;
-    /**
-     * Creates a new SubmissionLinkNameHtmlRenderer.
-     *
-     * @param submissionLinkRenderer the submission link renderer
-     */
-    public SubmissionLinkNameHtmlRenderer(
-            final SubmissionLinkRenderer submissionLinkRenderer) {
-        this.submissionLinkRenderer = submissionLinkRenderer;
-    }
 
     /**
      * Returns the name html.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkPhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmissionLinkPhraseRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submission link phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SubmissionLinkPhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the SubmissionLinkRenderer that is using this helper.
      */
-    private final transient SubmissionLinkRenderer slRenderer;
-
-    /**
-     * Creates a new SubmissionLinkPhraseRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected SubmissionLinkPhraseRenderer(
-            final SubmissionLinkRenderer renderer) {
-        this.slRenderer = renderer;
-    }
+    private final SubmissionLinkRenderer slRenderer;
 
     /**
      * Returns the string.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkListItemRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkListItemRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submitter link list item output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SubmitterLinkListItemRenderer implements ListItemRenderer {
     /**
      * Holder for the SubmitterLinkRenderer that is using this helper.
      */
-    private final transient SubmitterLinkRenderer submitterLinkRenderer;
-
-    /**
-     * Creates a new SubmitterLinkListItemRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected SubmitterLinkListItemRenderer(
-            final SubmitterLinkRenderer renderer) {
-        this.submitterLinkRenderer = renderer;
-    }
+    private final SubmitterLinkRenderer submitterLinkRenderer;
 
     /**
      * Executes render as list item.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkNameHtmlRenderer.java
@@ -4,26 +4,19 @@ import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Submitter;
 import org.schoellerfamily.gedbrowser.datamodel.SubmitterLink;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submitter link name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public final class SubmitterLinkNameHtmlRenderer implements NameHtmlRenderer {
     /**
      * Holder for the SubmitterLinkRenderer that is using this helper.
      */
-    private final transient SubmitterLinkRenderer submitterLinkRenderer;
-
-    /**
-     * Creates a new SubmitterLinkNameHtmlRenderer.
-     *
-     * @param submitterLinkRenderer the submitter link renderer
-     */
-    protected SubmitterLinkNameHtmlRenderer(
-            final SubmitterLinkRenderer submitterLinkRenderer) {
-        this.submitterLinkRenderer = submitterLinkRenderer;
-    }
+    private final SubmitterLinkRenderer submitterLinkRenderer;
 
     /**
      * Returns the name html.
@@ -38,16 +31,16 @@ public final class SubmitterLinkNameHtmlRenderer implements NameHtmlRenderer {
             return "";
         }
         final Submitter submitter =
-                (Submitter) submitterLink.find(submitterLink.getToString());
+            (Submitter) submitterLink.find(submitterLink.getToString());
         final GedRenderer<? extends GedObject> renderer =
-                new SimpleNameRenderer(submitter.getName(),
-                        submitterLinkRenderer.getRendererFactory(),
-                        submitterLinkRenderer.getRenderingContext());
+            new SimpleNameRenderer(submitter.getName(),
+                submitterLinkRenderer.getRendererFactory(),
+                submitterLinkRenderer.getRenderingContext());
         final String nameHtml = renderer.getNameHtml();
 
         return "<a class=\"name\" href=\"submitter?db="
-                + submitterLink.getDbName() + "&amp;id="
-                + submitterLink.getToString() + "\">" + nameHtml
-                + " [" + submitterLink.getToString() + "]" + "</a>";
+            + submitterLink.getDbName() + "&amp;id="
+            + submitterLink.getToString() + "\">" + nameHtml
+            + " [" + submitterLink.getToString() + "]" + "</a>";
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkPhraseRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterLinkPhraseRenderer.java
@@ -1,25 +1,18 @@
 package org.schoellerfamily.gedbrowser.renderer;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submitter link phrase output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor(access = lombok.AccessLevel.PROTECTED)
 public class SubmitterLinkPhraseRenderer implements PhraseRenderer {
     /**
      * Holder for the SubmitterLinkRenderer that is using this helper.
      */
-    private final transient SubmitterLinkRenderer slRenderer;
-
-    /**
-     * Creates a new SubmitterLinkPhraseRenderer.
-     *
-     * @param renderer the renderer
-     */
-    protected SubmitterLinkPhraseRenderer(
-            final SubmitterLinkRenderer renderer) {
-        this.slRenderer = renderer;
-    }
+    private final SubmitterLinkRenderer slRenderer;
 
     /**
      * Returns the string.

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterNameHtmlRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterNameHtmlRenderer.java
@@ -3,24 +3,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Submitter;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submitter name html output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class SubmitterNameHtmlRenderer implements NameHtmlRenderer {
     /** */
-    private final transient SubmitterRenderer submitterRenderer;
-
-    /**
-     * Creates a new SubmitterNameHtmlRenderer.
-     *
-     * @param submitterRenderer the submitter renderer
-     */
-    public SubmitterNameHtmlRenderer(
-            final SubmitterRenderer submitterRenderer) {
-        this.submitterRenderer = submitterRenderer;
-    }
+    private final SubmitterRenderer submitterRenderer;
 
     /**
      * Returns the name html.
@@ -34,9 +27,9 @@ public class SubmitterNameHtmlRenderer implements NameHtmlRenderer {
             return "";
         }
         final GedRenderer<? extends GedObject> renderer =
-                new SimpleNameRenderer(submitter.getName(),
-                        submitterRenderer.getRendererFactory(),
-                        submitterRenderer.getRenderingContext());
+            new SimpleNameRenderer(submitter.getName(),
+                submitterRenderer.getRendererFactory(),
+                submitterRenderer.getRenderingContext());
         return renderer.getNameHtml();
     }
 

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterNameIndexRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmitterNameIndexRenderer.java
@@ -3,24 +3,17 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.GedObject;
 import org.schoellerfamily.gedbrowser.datamodel.Submitter;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders submitter name index output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public class SubmitterNameIndexRenderer implements NameIndexRenderer {
     /** */
-    private final transient SubmitterRenderer submitterRenderer;
-
-    /**
-     * Creates a new SubmitterNameIndexRenderer.
-     *
-     * @param submitterRenderer the submitter renderer
-     */
-    public SubmitterNameIndexRenderer(
-            final SubmitterRenderer submitterRenderer) {
-        this.submitterRenderer = submitterRenderer;
-    }
+    private final SubmitterRenderer submitterRenderer;
 
     /**
      * Returns the index name.
@@ -36,15 +29,15 @@ public class SubmitterNameIndexRenderer implements NameIndexRenderer {
         final String nameHtml = getNameHtml(submitter);
 
         return "<a class=\"name\" href=\"submitter?db=" + submitter.getDbName()
-                + "&amp;id=" + submitter.getString() + "\">" + nameHtml + " ["
-                + submitter.getString() + "]" + "</a>";
+            + "&amp;id=" + submitter.getString() + "\">" + nameHtml + " ["
+            + submitter.getString() + "]" + "</a>";
     }
 
     private String getNameHtml(final Submitter submitter) {
         final GedRenderer<? extends GedObject> renderer =
-                new SimpleNameRenderer(submitter.getName(),
-                        submitterRenderer.getRendererFactory(),
-                        submitterRenderer.getRenderingContext());
+            new SimpleNameRenderer(submitter.getName(),
+                submitterRenderer.getRendererFactory(),
+                submitterRenderer.getRenderingContext());
         return renderer.getNameHtml();
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmittersRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/SubmittersRenderer.java
@@ -32,8 +32,7 @@ public class SubmittersRenderer extends GedRenderer<Root>
      * @param root the root
      * @param renderingContext the rendering context
      */
-    public SubmittersRenderer(final Root root,
-            final RenderingContext renderingContext) {
+    public SubmittersRenderer(final Root root, final RenderingContext renderingContext) {
         super(root, new GedRendererFactory(), renderingContext);
     }
 

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TrailerRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TrailerRenderer.java
@@ -16,8 +16,8 @@ public final class TrailerRenderer extends GedRenderer<Trailer> {
      * @param renderingContext the rendering context
      */
     public TrailerRenderer(final Trailer gedObject,
-            final GedRendererFactory rendererFactory,
-            final RenderingContext renderingContext) {
+        final GedRendererFactory rendererFactory,
+        final RenderingContext renderingContext) {
         super(gedObject, rendererFactory, renderingContext);
     }
 }

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeNode.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeNode.java
@@ -8,11 +8,11 @@ package org.schoellerfamily.gedbrowser.renderer;
  */
 public final class TreeNode<N> {
     /** */
-    private final transient N node;
+    private final N node;
     /** */
-    private transient TreeNode<N> left;
+    private TreeNode<N> left;
     /** */
-    private transient TreeNode<N> right;
+    private TreeNode<N> right;
     /** */
     private int row;
     /** */
@@ -75,9 +75,8 @@ public final class TreeNode<N> {
     public int getHighestRowInTree() {
         if (right == null) {
             return row;
-        } else {
-            return right.getHighestRowInTree();
         }
+        return right.getHighestRowInTree();
     }
 
     /**

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeTableRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeTableRenderer.java
@@ -3,28 +3,19 @@ package org.schoellerfamily.gedbrowser.renderer;
 import org.schoellerfamily.gedbrowser.datamodel.Person;
 import org.schoellerfamily.gedbrowser.datamodel.navigator.PersonNavigator;
 
+import lombok.RequiredArgsConstructor;
+
 /**
  * Renders tree table output for display.
  *
  * @author Richard Schoeller
  */
+@RequiredArgsConstructor
 public final class TreeTableRenderer {
     /** */
-    private final transient int generations;
-
-    /** */
     private final transient PersonRenderer top;
-
-    /**
-     * Creates a new TreeTableRenderer.
-     *
-     * @param top the top
-     * @param generations the generations
-     */
-    public TreeTableRenderer(final PersonRenderer top, final int generations) {
-        this.top = top;
-        this.generations = generations;
-    }
+    /** */
+    private final transient int generations;
 
     /**
      * Gets the tree rows.
@@ -61,15 +52,15 @@ public final class TreeTableRenderer {
         final PersonNavigator navigator = new PersonNavigator(person);
 
         final TreeNode<PersonRenderer> treeNode = new TreeNode<PersonRenderer>(
-                personRenderer, currentDepth, currentDepth);
+            personRenderer, currentDepth, currentDepth);
 
         int row = seedRow;
         if (currentDepth < depthLimit) {
             final Person father = navigator.getFather();
             final PersonRenderer fatherRenderer =
-                    (PersonRenderer) personRenderer.createGedRenderer(father);
+                (PersonRenderer) personRenderer.createGedRenderer(father);
             final TreeNode<PersonRenderer> fatherTreeNode = buildTree(
-                    fatherRenderer, currentDepth + 1, depthLimit, row);
+                fatherRenderer, currentDepth + 1, depthLimit, row);
             treeNode.addLeft(fatherTreeNode);
             row = fatherTreeNode.getHighestRowInTree() + 1;
         }
@@ -79,9 +70,9 @@ public final class TreeTableRenderer {
         if (currentDepth < depthLimit) {
             final Person mother = navigator.getMother();
             final PersonRenderer motherRenderer =
-                    (PersonRenderer) personRenderer.createGedRenderer(mother);
-            final TreeNode<PersonRenderer> motherTreeNode = buildTree(
-                    motherRenderer, currentDepth + 1, depthLimit, row);
+                (PersonRenderer) personRenderer.createGedRenderer(mother);
+            final TreeNode<PersonRenderer> motherTreeNode =
+                buildTree(motherRenderer, currentDepth + 1, depthLimit, row);
             treeNode.addRight(motherTreeNode);
         }
         return treeNode;

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GeoServiceClientStub.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GeoServiceClientStub.java
@@ -14,7 +14,7 @@ import org.schoellerfamily.geoservice.model.GeoServiceItem;
  *
  * @author Richard Schoeller
  */
-public final class GeoServiceClientStub extends GeoServiceClient {
+public class GeoServiceClientStub extends GeoServiceClient {
     /** */
     private static final int PORT = 8080;
 

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/IndexByPlaceRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/IndexByPlaceRendererTest.java
@@ -154,6 +154,35 @@ final class IndexByPlaceRendererTest {
         assertEquals(1, map.size(), "map is empty");
     }
 
+    @Test
+    void testRenderMergesCollisionsOnSameModernPlaceName() {
+        final Person person = builder.createPerson("I1", "J. Random/Schoeller/");
+        final Attribute birth = builder.createPersonEvent(person, "Birth", "01 JAN 2000");
+        builder.addPlaceToEvent(birth, "Place Variant A, USA");
+
+        final Person person2 = builder.createPerson("I2", "Anonymous/Schoeller/");
+        final Attribute birth2 = builder.createPersonEvent(person2, "Birth", "01 JAN 2001");
+        builder.addPlaceToEvent(birth2, "Place Variant B, USA");
+
+        // Client that maps both place variants to the same modern place name
+        final GeoServiceClient collidingClient = new GeoServiceClientStub() {
+            @Override
+            public GeoServiceItem get(final String placeName) {
+                return new GeoServiceItem(placeName, "Same Modern Place, USA", null);
+            }
+        };
+
+        final IndexByPlaceRenderer ir = new IndexByPlaceRenderer(
+            builder.getRoot(), collidingClient, adminContext);
+        final Map<GeoServiceItem, Set<PersonRenderer>> map = ir.render();
+
+        assertEquals(1, map.size(),
+            "Two place variants mapping to the same modern name should produce 1 entry");
+        final Set<PersonRenderer> persons = map.values().iterator().next();
+        assertEquals(2, persons.size(),
+            "Both persons should be present after merging colliding sets");
+    }
+
     private void assertRenderMatches(final int[] sizes, final RenderingContext context)
         throws IOException {
         final Root root = reader.readBigTestSource();

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/service/test/UserServiceTest.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/service/test/UserServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.util.List;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -47,19 +46,14 @@ final class UserServiceTest extends AbstractTest {
     @Test
     void testFindAllWithoutUser() throws AccessDeniedException {
         assertThatExceptionOfType(AccessDeniedException.class)
-        .isThrownBy(() -> findAllIgnoreAnswer());
+        .isThrownBy(userService::findAll);
     }
 
     @Test
     void testFindAllWithUser() throws AccessDeniedException {
         mockAuthenticatedUser(buildTestUser());
         assertThatExceptionOfType(AccessDeniedException.class)
-            .isThrownBy(() -> findAllIgnoreAnswer());
-    }
-
-    @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-    private void findAllIgnoreAnswer() {
-        userService.findAll();
+            .isThrownBy(userService::findAll);
     }
 
     @Test

--- a/gedbrowserng-frontend/src/app/services/datasets.service.spec.ts
+++ b/gedbrowserng-frontend/src/app/services/datasets.service.spec.ts
@@ -2,6 +2,7 @@ import { HttpTestingController, provideHttpClientTesting } from '@angular/common
 import { provideHttpClient } from '@angular/common/http';
 import { TestBed } from '@angular/core/testing';
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { firstValueFrom } from 'rxjs';
 
 import { DatasetsService } from './datasets.service';
 
@@ -37,7 +38,7 @@ describe('DatasetsService', () => {
       const datasets = ['db1', 'db2', 'db3'];
 
       const result$ = service.get();
-      const promise = result$.toPromise();
+      const promise = firstValueFrom(result$);
 
       const req = httpMock.expectOne('/gedbrowserng/v1/dbs');
       expect(req.request.method).toBe('GET');
@@ -50,7 +51,7 @@ describe('DatasetsService', () => {
 
     it('should handle empty dataset list', async () => {
       const result$ = service.get();
-      const promise = result$.toPromise();
+      const promise = firstValueFrom(result$);
 
       const req = httpMock.expectOne('/gedbrowserng/v1/dbs');
       req.flush([]);
@@ -63,7 +64,7 @@ describe('DatasetsService', () => {
       const datasets = ['schoeller', 'schoeller', 'mini'];
 
       const result$ = service.get();
-      const promise = result$.toPromise();
+      const promise = firstValueFrom(result$);
 
       const req = httpMock.expectOne('/gedbrowserng/v1/dbs');
       req.flush(datasets);
@@ -73,7 +74,7 @@ describe('DatasetsService', () => {
     });
 
     it('should handle HTTP errors', async () => {
-      const promise = service.get().toPromise();
+      const promise = firstValueFrom(service.get());
 
       const req = httpMock.expectOne('/gedbrowserng/v1/dbs');
       req.flush('Server error', { status: 500, statusText: 'Internal Server Error' });

--- a/gedbrowserng-frontend/src/app/utils/image-util.ts
+++ b/gedbrowserng-frontend/src/app/utils/image-util.ts
@@ -187,11 +187,11 @@ export class ImageUtil {
 
   private static youtubeId(url: string): string | null {
     const normalized = (url || '').trim();
-    const shortMatch = normalized.match(/youtu\.be\/([^?&]+)/i);
+    const shortMatch = /youtu\.be\/([^?&]+)/i.exec(normalized);
     if (shortMatch?.[1]) {
       return shortMatch[1];
     }
-    const longMatch = normalized.match(/[?&]v=([^?&]+)/i);
+    const longMatch = /[?&]v=([^?&]+)/i.exec(normalized);
     if (longMatch?.[1]) {
       return longMatch[1];
     }

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/datamodel/ApiExtraLists.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/datamodel/ApiExtraLists.java
@@ -62,7 +62,7 @@ public class ApiExtraLists extends ApiHasImages {
         ApiExtraListsBuilder<
             C extends ApiExtraLists,
             B extends ApiExtraLists.ApiExtraListsBuilder<C, B>>
-        extends ApiExtraLists.ApiHasImagesBuilder<C, B> {
+        extends ApiHasImages.ApiHasImagesBuilder<C, B> {
 
         /**
          * Jackson creator to obtain a concrete Lombok builder implementation.

--- a/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
+++ b/gedbrowserng/src/main/java/org/schoellerfamily/gedbrowser/api/endpoint/DuplicateCleanupService.java
@@ -148,7 +148,7 @@ public class DuplicateCleanupService {
         if (filename == null || string == null) {
             return null;
         }
-        return String.valueOf(filename) + "\u0000" + String.valueOf(string);
+        return String.valueOf(filename) + "\u0000" + string;
     }
 
     private List<Object> newIdList() {

--- a/geoservice-client/src/main/java/org/schoellerfamily/geoservice/client/GeoServiceResilientCaller.java
+++ b/geoservice-client/src/main/java/org/schoellerfamily/geoservice/client/GeoServiceResilientCaller.java
@@ -36,7 +36,7 @@ public class GeoServiceResilientCaller {
      * @return parsed geoservice item.
      */
     @CircuitBreaker(
-        include = ResourceAccessException.class,
+        retryFor = ResourceAccessException.class,
         maxAttemptsExpression = "#{${geoservice.retry.max-attempts:3}}",
         openTimeoutExpression = "#{${geoservice.circuit-breaker.open-timeout-millis:30000}}",
         resetTimeoutExpression = "#{${geoservice.circuit-breaker.reset-timeout-millis:30000}}")

--- a/geoservice/src/main/java/org/schoellerfamily/geoservice/backup/GeoCodeBackup.java
+++ b/geoservice/src/main/java/org/schoellerfamily/geoservice/backup/GeoCodeBackup.java
@@ -1,7 +1,6 @@
 package org.schoellerfamily.geoservice.backup;
 
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import org.schoellerfamily.geoservice.model.GeoServiceItem;
@@ -10,10 +9,10 @@ import org.schoellerfamily.geoservice.persistence.GeoCode;
 import org.springframework.stereotype.Component;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect.Visibility;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
 
 import lombok.RequiredArgsConstructor;
-
-import com.fasterxml.jackson.annotation.PropertyAccessor;
+import tools.jackson.core.JacksonException;
 import tools.jackson.core.type.TypeReference;
 import tools.jackson.databind.DeserializationFeature;
 import tools.jackson.databind.ObjectMapper;
@@ -43,8 +42,9 @@ public class GeoCodeBackup {
      * Executes backup.
      *
      * @param resultFile the result file to use
+     * @throws JacksonException if a JSON processing error occurs
      */
-    public void backup(final File resultFile) throws IOException {
+    public void backup(final File resultFile) throws JacksonException {
         final GeocodeResultBuilder builder = new GeocodeResultBuilder();
         final List<GeoServiceItem> list = gcd.allKeys().stream()
             .map(gcd::find)
@@ -57,8 +57,9 @@ public class GeoCodeBackup {
      * Executes recover.
      *
      * @param src the src
+     * @throws JacksonException if a JSON processing error occurs
      */
-    public void recover(final File src) throws IOException {
+    public void recover(final File src) throws JacksonException {
         final List<GeoServiceItem> list = mapper.readValue(src,
                 new TypeReference<List<GeoServiceItem>>() {
                 });


### PR DESCRIPTION
## Summary
- clean up Sonar-reported issues across renderer, reader, datamodel, mongo, security, ng, and geoservice modules
- refactor several renderer attribute and place-building paths to use streams and Apache Commons StringUtils where appropriate
- replace deprecated frontend promise and regexp usage, simplify casts and pattern matches, and modernize a number of constructors and annotations

## Notes
- this branch contains a mix of manual edits and Copilot-assisted changes
- pushed from branch `sonar-warnings`