### PR TITLE
Fix a bunch of Sonar warnings

### DIFF
--- a/gedbrowser-analytics/src/test/java/org/schoellerfamily/gedbrowser/analytics/calendar/test/CalendarProviderFacadeTest.java
+++ b/gedbrowser-analytics/src/test/java/org/schoellerfamily/gedbrowser/analytics/calendar/test/CalendarProviderFacadeTest.java
@@ -98,7 +98,7 @@ class CalendarProviderFacadeTest {
     }
 
     @Test
-    void testImplNow() throws InterruptedException {
+    void testImplNow() {
         final Calendar actual = implProvider.now();
         final long difference = actual.getTimeInMillis() - calendar.getTimeInMillis();
         final long expected = 10;

--- a/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/SimpleDateParser.java
+++ b/gedbrowser-datamodel/src/main/java/org/schoellerfamily/gedbrowser/datamodel/util/SimpleDateParser.java
@@ -32,12 +32,12 @@ public class SimpleDateParser {
             try {
                 c.setTime(dateParser.parse(dateString));
                 return c;
-            } catch (ParseException __) {
+            } catch (ParseException _) {
                 dateParser = new SimpleDateFormat("yyyy", Locale.US);
                 try {
                     c.setTime(dateParser.parse(dateString));
                     return c;
-                } catch (ParseException ___) {
+                } catch (ParseException _) {
                     return null;
                 }
             }

--- a/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/GedFileTest.java
+++ b/gedbrowser-reader/src/test/java/org/schoellerfamily/gedbrowser/reader/test/GedFileTest.java
@@ -106,13 +106,12 @@ final class GedFileTest {
         return errors;
     }
 
-    @SuppressWarnings("PMD.UseStringBufferForStringAppends")
     private String formatResult(final List<String> checkResults) {
-        String output = "";
+        final StringBuilder output = new StringBuilder();
         for (final String result : checkResults) {
-            output += "    " + result + "\n";
+            output.append("    ").append(result).append("\n");
         }
-        return output;
+        return output.toString();
     }
 
     private AbstractGedLine readFileTestSource() throws IOException {

--- a/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeTableRenderer.java
+++ b/gedbrowser-renderer/src/main/java/org/schoellerfamily/gedbrowser/renderer/TreeTableRenderer.java
@@ -13,9 +13,9 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public final class TreeTableRenderer {
     /** */
-    private final transient PersonRenderer top;
+    private final PersonRenderer top;
     /** */
-    private final transient int generations;
+    private final int generations;
 
     /**
      * Gets the tree rows.
@@ -51,7 +51,7 @@ public final class TreeTableRenderer {
         final Person person = personRenderer.getGedObject();
         final PersonNavigator navigator = new PersonNavigator(person);
 
-        final TreeNode<PersonRenderer> treeNode = new TreeNode<PersonRenderer>(
+        final TreeNode<PersonRenderer> treeNode = new TreeNode<>(
             personRenderer, currentDepth, currentDepth);
 
         int row = seedRow;

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GeoServiceClientStub.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/GeoServiceClientStub.java
@@ -42,30 +42,26 @@ public class GeoServiceClientStub extends GeoServiceClient {
             geometry.add(createBox()); // bounds
             geometry.add(createBox()); // viewport
             final GeoServiceGeocodingResult result =
-                    new GeoServiceGeocodingResult(
-                            null, placeName, null, geometry, null, false, null);
+                new GeoServiceGeocodingResult(null, placeName, null, geometry, null, false, null);
             return new GeoServiceItem(placeName, placeName, result);
         }
         if ("Needham, MA, USA".equals(placeName)) {
             final FeatureCollection geometry = new FeatureCollection();
             geometry.add(createLocation());
             final GeoServiceGeocodingResult result =
-                    new GeoServiceGeocodingResult(
-                            null, placeName, null, geometry, null, false, null);
+                new GeoServiceGeocodingResult(null, placeName, null, geometry, null, false, null);
             return new GeoServiceItem(placeName, placeName, result);
         }
         if ("Geometry Null, USA".equals(placeName)) {
             final GeoServiceGeocodingResult result =
-                    new GeoServiceGeocodingResult(
-                            null, placeName, null, null, null, false, null);
+                new GeoServiceGeocodingResult(null, placeName, null, null, null, false, null);
             return new GeoServiceItem(placeName, placeName, result);
         }
         if ("Polygon Only, USA".equals(placeName)) {
             final FeatureCollection geometry = new FeatureCollection();
             geometry.add(createBox());
             final GeoServiceGeocodingResult result =
-                    new GeoServiceGeocodingResult(
-                            null, placeName, null, geometry, null, false, null);
+                new GeoServiceGeocodingResult(null, placeName, null, geometry, null, false, null);
             return new GeoServiceItem(placeName, placeName, result);
         }
         return new GeoServiceItem(placeName, placeName, null);

--- a/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/IndexByPlaceRendererTest.java
+++ b/gedbrowser-renderer/src/test/java/org/schoellerfamily/gedbrowser/renderer/test/IndexByPlaceRendererTest.java
@@ -127,7 +127,7 @@ final class IndexByPlaceRendererTest {
     }
 
     @Test
-    void testIndexAsAdminSchoellerPlaceInfo() throws IOException {
+    void testIndexAsAdminSchoellerPlaceInfo() {
         // Have to build what the stub client can deal with.
         // Stub still doesn't return enough interesting things to work on
         // better algorithms.

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/AuthenticationController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/AuthenticationController.java
@@ -11,9 +11,10 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.servlet.http.Cookie;
@@ -66,7 +67,7 @@ public class AuthenticationController {
      * @param response the response
      * @return the resulting response entity
      */
-    @RequestMapping(value = "/refresh", method = RequestMethod.GET)
+    @GetMapping(value = "/refresh")
     public ResponseEntity<UserTokenState> refreshAuthenticationToken(
             final HttpServletRequest request,
             final HttpServletResponse response) {
@@ -105,7 +106,7 @@ public class AuthenticationController {
      * @param passwordChanger the password changer
      * @return the resulting string
      */
-    @RequestMapping(value = "/changePassword", method = RequestMethod.POST)
+    @PostMapping(value = "/changePassword")
     @PreAuthorize("hasRole('USER')")
     public ResponseEntity<Map<String, String>> changePassword(
             @RequestBody final PasswordChanger passwordChanger) {

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/PublicController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/PublicController.java
@@ -1,14 +1,13 @@
 package org.schoellerfamily.gedbrowser.security.controller;
 
-import lombok.NoArgsConstructor;
-
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-
 import java.util.Map;
 
 import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import lombok.NoArgsConstructor;
 
 
 
@@ -27,7 +26,7 @@ public class PublicController {
      *
      * @return map of foo to bar
      */
-    @RequestMapping(method = GET, value = "/foo")
+    @GetMapping(value = "/foo")
     public Map<String, String> getFoo() {
         return Map.of("foo", "bar");
     }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/UserController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/controller/UserController.java
@@ -1,8 +1,5 @@
 package org.schoellerfamily.gedbrowser.security.controller;
 
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
-import static org.springframework.web.bind.annotation.RequestMethod.POST;
-
 import java.util.List;
 import java.util.Map;
 
@@ -17,6 +14,7 @@ import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -48,7 +46,7 @@ public class UserController {
      * @param username the user name
      * @return the user object
      */
-    @RequestMapping(method = GET, value = "/users/{username:.+}")
+    @GetMapping(value = "/users/{username:.+}")
     @PreAuthorize("hasRole('ADMIN')")
     public SecurityUser loadById(final HttpServletRequest request,
             @PathVariable final String username) {
@@ -61,7 +59,7 @@ public class UserController {
      * @param request the http request
      * @return a list of all users
      */
-    @RequestMapping(method = GET, value = "/users")
+    @GetMapping(value = "/users")
     @PreAuthorize("hasRole('ADMIN')")
     public List<SecurityUser> loadAll(final HttpServletRequest request) {
         return userService.findAll();
@@ -72,7 +70,7 @@ public class UserController {
      *
      * @return a result map
      */
-    @RequestMapping(method = GET, value = "/reset-credentials")
+    @GetMapping(value = "/reset-credentials")
     public ResponseEntity<Map<String, String>> resetCredentials() {
       userService.resetCredentials();
       return ResponseEntity.accepted().body(Map.of("result", "success"));
@@ -85,7 +83,7 @@ public class UserController {
      * @param ucBuilder the URI components builder
      * @return the new user
      */
-    @RequestMapping(method = POST, value = "/signup")
+    @PostMapping(value = "/signup")
     public ResponseEntity<SecurityUser> addUser(
             @RequestBody final UserRequest userRequest,
             final UriComponentsBuilder ucBuilder) {
@@ -96,7 +94,7 @@ public class UserController {
                   1L, /* userRequest.getId(),*/ "Username already exists");
         }
         final SecurityUser user = this.userService.save(userRequest);
-        return new ResponseEntity<SecurityUser>(user, HttpStatus.CREATED);
+        return new ResponseEntity<>(user, HttpStatus.CREATED);
     }
 
     /**

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/exception/ExceptionHandlingController.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/exception/ExceptionHandlingController.java
@@ -29,7 +29,7 @@ public class ExceptionHandlingController {
             final ResourceConflictException ex) {
         final ExceptionResponse response =
                 new ExceptionResponse("Conflict", ex.getMessage());
-        return new ResponseEntity<ExceptionResponse>(response,
+        return new ResponseEntity<>(response,
                 HttpStatus.CONFLICT);
     }
 }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/model/HasRoles.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/model/HasRoles.java
@@ -46,7 +46,7 @@ public class HasRoles implements Serializable {
         try {
             final UserRoleName valueOf = UserRoleName.valueOf(role);
             roles.add(valueOf);
-        } catch (IllegalArgumentException e) {
+        } catch (IllegalArgumentException _) {
             log.warn("Tried to add an unknown role type: {}", role);
         }
     }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
@@ -212,12 +212,13 @@ public final class TokenHelper {
      * @return The cookie, or <code>null</code> if not found.
      */
     public Cookie getCookieValueByName(final HttpServletRequest request, final String name) {
-        if (request.getCookies() == null) {
+        final Cookie[] cookies = request.getCookies();
+        if (cookies == null) {
             return null;
         }
-        for (int i = 0; i < request.getCookies().length; i++) {
-            if (request.getCookies()[i].getName().equals(name)) {
-                return request.getCookies()[i];
+        for (int i = 0; i < cookies.length; i++) {
+            if (cookies[i].getName().equals(name)) {
+                return cookies[i];
             }
         }
         return null;

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
@@ -19,8 +19,6 @@ import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 
-
-
 /**
  * Represents token helper.
  *
@@ -87,7 +85,7 @@ public final class TokenHelper {
         } catch (io.jsonwebtoken.ExpiredJwtException eje) {
             // Let callers who care about expiration handle it explicitly
             throw eje;
-        } catch (Exception e_) {
+        } catch (Exception _) {
             return null;
         }
     }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
@@ -68,7 +68,7 @@ public final class TokenHelper {
                 keyBytes = sha512.digest(keyBytes);
             }
             return Keys.hmacShaKeyFor(keyBytes);
-        } catch (Exception e_) {
+        } catch (Exception _) {
             // Fallback: wrap raw bytes (may fail at runtime if too short)
             return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA512");
         }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
@@ -68,7 +68,7 @@ public final class TokenHelper {
                 keyBytes = sha512.digest(keyBytes);
             }
             return Keys.hmacShaKeyFor(keyBytes);
-        } catch (Exception e) {
+        } catch (Exception e_) {
             // Fallback: wrap raw bytes (may fail at runtime if too short)
             return new SecretKeySpec(secret.getBytes(StandardCharsets.UTF_8), "HmacSHA512");
         }
@@ -87,7 +87,7 @@ public final class TokenHelper {
         } catch (io.jsonwebtoken.ExpiredJwtException eje) {
             // Let callers who care about expiration handle it explicitly
             throw eje;
-        } catch (Exception e) {
+        } catch (Exception e_) {
             return null;
         }
     }
@@ -133,7 +133,7 @@ public final class TokenHelper {
         } catch (io.jsonwebtoken.ExpiredJwtException eje) {
             // Let callers who care about expiration handle it explicitly
             throw eje;
-        } catch (Exception e) {
+        } catch (Exception _) {
             return null;
         }
     }
@@ -148,7 +148,7 @@ public final class TokenHelper {
         try {
             final Date expirationDate = getClaimsFromToken(token).getExpiration();
             return expirationDate.compareTo(generateCurrentDate()) > 0;
-        } catch (Exception e) {
+        } catch (Exception _) {
             return false;
         }
     }
@@ -168,7 +168,7 @@ public final class TokenHelper {
                 .expiration(generateExpirationDate())
                 .signWith(getSigningKey())
                 .compact();
-        } catch (Exception e) {
+        } catch (Exception _) {
             return null;
         }
     }

--- a/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
+++ b/gedbrowser-security/src/main/java/org/schoellerfamily/gedbrowser/security/token/TokenHelper.java
@@ -4,6 +4,7 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
 import java.util.Date;
+import java.util.Objects;
 
 import javax.crypto.SecretKey;
 import javax.crypto.spec.SecretKeySpec;
@@ -216,9 +217,9 @@ public final class TokenHelper {
         if (cookies == null) {
             return null;
         }
-        for (int i = 0; i < cookies.length; i++) {
-            if (cookies[i].getName().equals(name)) {
-                return cookies[i];
+        for (final Cookie cookie : cookies) {
+            if (Objects.equals(cookie.getName(), name)) {
+                return cookie;
             }
         }
         return null;

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/TestConfiguration.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/TestConfiguration.java
@@ -43,7 +43,7 @@ public class TestConfiguration {
                 new UsersReader<>();
         return (SecurityUsers) usersReader.readUserFile(userFile,
                 () -> new SecurityUsers(userFile),
-                () -> new UserImpl()
+                UserImpl::new
         );
     }
 }

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/UsersConfigurationTest.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/UsersConfigurationTest.java
@@ -130,6 +130,6 @@ public final class UsersConfigurationTest {
     private SecurityUsers readUserFile(final String userFile) {
         final UsersReader<SecurityUser, SecurityUsers> usersReader = new UsersReader<>();
         return (SecurityUsers) usersReader.readUserFile(userFile, () -> new SecurityUsers(userFile),
-            () -> new UserImpl());
+            UserImpl::new);
     }
 }

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/WebSecurityConfig.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/WebSecurityConfig.java
@@ -95,7 +95,7 @@ public class WebSecurityConfig {
      * @return the security filter chain
      */
     @Bean
-    public SecurityFilterChain filterChain(final HttpSecurity http)  {
+    public SecurityFilterChain filterChain(final HttpSecurity http) {
         // Start with CSRF configuration (kept in helper)
         final HttpSecurity configured = handleCsrf(http);
 

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/WebSecurityConfig.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/test/WebSecurityConfig.java
@@ -93,10 +93,9 @@ public class WebSecurityConfig {
      *
      * @param http the http security object
      * @return the security filter chain
-     * @throws Exception if there is a problem
      */
     @Bean
-    public SecurityFilterChain filterChain(final HttpSecurity http) throws Exception {
+    public SecurityFilterChain filterChain(final HttpSecurity http)  {
         // Start with CSRF configuration (kept in helper)
         final HttpSecurity configured = handleCsrf(http);
 
@@ -122,7 +121,7 @@ public class WebSecurityConfig {
         return configured.build();
     }
 
-    private HttpSecurity handleCsrf(final HttpSecurity http) throws Exception {
+    private HttpSecurity handleCsrf(final HttpSecurity http) {
         if ("test".equals(activeProfile)) {
             // Use the lambda-based CsrfConfigurer to disable CSRF in test profile
             http.csrf(csrf -> csrf.disable());

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/token/test/TokenHelperTest.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/token/test/TokenHelperTest.java
@@ -2,6 +2,8 @@ package org.schoellerfamily.gedbrowser.security.token.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.time.Duration;
 
@@ -40,5 +42,34 @@ class TokenHelperTest {
             .atMost(Duration.ofSeconds(TOKEN_EXPIRY_TIMEOUT_SECONDS))
             .untilAsserted(() -> assertThatExceptionOfType(ExpiredJwtException.class)
                 .isThrownBy(() -> tokenHelper.parseClaimsOrThrow(token)));
+    }
+
+    @Test
+    void testGetUsernameFromMalformedToken() {
+        final String malformedToken = "not.a.valid.token";
+        assertNull(tokenHelper.getUsernameFromToken(malformedToken));
+    }
+
+    @Test
+    void testGetUsernameFromExpiredTokenThrows() {
+        final String token = tokenHelper.generateToken("fanjin");
+        await()
+            .atMost(Duration.ofSeconds(TOKEN_EXPIRY_TIMEOUT_SECONDS))
+            .untilAsserted(() -> assertThatExceptionOfType(ExpiredJwtException.class)
+                .isThrownBy(() -> tokenHelper.getUsernameFromToken(token)));
+    }
+
+    @Test
+    void testCanTokenBeRefreshedFromMalformedToken() {
+        final String malformedToken = "not even jwt";
+        assertFalse(tokenHelper.canTokenBeRefreshed(malformedToken));
+    }
+
+    @Test
+    void testRefreshExpiredTokenReturnsNull() {
+        final String token = tokenHelper.generateToken("fanjin");
+        await()
+            .atMost(Duration.ofSeconds(TOKEN_EXPIRY_TIMEOUT_SECONDS))
+            .untilAsserted(() -> assertNull(tokenHelper.refreshToken(token)));
     }
 }

--- a/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/token/test/TokenHelperTest.java
+++ b/gedbrowser-security/src/test/java/org/schoellerfamily/gedbrowser/security/token/test/TokenHelperTest.java
@@ -2,8 +2,11 @@ package org.schoellerfamily.gedbrowser.security.token.test;
 
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 import static org.awaitility.Awaitility.await;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.time.Duration;
 
@@ -13,6 +16,8 @@ import org.junit.jupiter.api.Test;
 import org.schoellerfamily.gedbrowser.security.token.TokenHelper;
 
 import io.jsonwebtoken.ExpiredJwtException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
  * Contains tests for token helper.
@@ -71,5 +76,29 @@ class TokenHelperTest {
         await()
             .atMost(Duration.ofSeconds(TOKEN_EXPIRY_TIMEOUT_SECONDS))
             .untilAsserted(() -> assertNull(tokenHelper.refreshToken(token)));
+    }
+
+    @Test
+    void testGetCookieValueByNameNullCookies() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        when(request.getCookies()).thenReturn(null);
+        assertNull(tokenHelper.getCookieValueByName(request, "AUTH-TOKEN"));
+    }
+
+    @Test
+    void testGetCookieValueByNameNoMatch() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final Cookie other = new Cookie("OTHER", "value");
+        when(request.getCookies()).thenReturn(new Cookie[]{other});
+        assertNull(tokenHelper.getCookieValueByName(request, "AUTH-TOKEN"));
+    }
+
+    @Test
+    void testGetCookieValueByNameFound() {
+        final HttpServletRequest request = mock(HttpServletRequest.class);
+        final Cookie target = new Cookie("AUTH-TOKEN", "mytoken");
+        final Cookie other = new Cookie("OTHER", "value");
+        when(request.getCookies()).thenReturn(new Cookie[]{other, target});
+        assertEquals(target, tokenHelper.getCookieValueByName(request, "AUTH-TOKEN"));
     }
 }

--- a/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
+++ b/gedbrowser-writer/src/test/java/org/schoellerfamily/gedbrowser/writer/test/UsersWriterTest.java
@@ -48,7 +48,7 @@ class UsersWriterTest {
 
     private Users<User> readUserFile(final String userFile) {
         final UsersReader<User, Users<User>> usersReader = new UsersReader<>();
-        return usersReader.readUserFile(userFile, () -> new UsersImpl<>(), () -> new UserImpl());
+        return usersReader.readUserFile(userFile, UsersImpl::new, UserImpl::new);
     }
 
     private void writeUserFile(final String userFile) {

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/UsersConfiguration.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/UsersConfiguration.java
@@ -19,7 +19,7 @@ import org.springframework.context.annotation.Configuration;
 public class UsersConfiguration {
     /** */
     @Value("${gedbrowser.home:/var/lib/gedbrowser}")
-    private transient String gedbrowserHome;
+    private String gedbrowserHome;
 
     /**
      * This is the bean to get the definitions of users that we need

--- a/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/endpoint/ApplicationHealthIndicator.java
+++ b/gedbrowser/src/main/java/org/schoellerfamily/gedbrowser/endpoint/ApplicationHealthIndicator.java
@@ -52,7 +52,7 @@ public class ApplicationHealthIndicator implements HealthIndicator {
                 Optional.ofNullable(loader.details(repositoryManager)).orElse(List.of());
             log.debug("    {} datasets", details.size());
             builder.withDetail("datasets", details);
-        } catch (Exception e) {
+        } catch (Exception _) {
             final List<Map<String, Object>> details = List.of();
             log.error("    0 datasets (could not connect to database)");
             builder.withDetail("datasets", details);

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/base/RemotePageWaiter.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/base/RemotePageWaiter.java
@@ -72,7 +72,7 @@ public final class RemotePageWaiter implements PageWaiter {
             Duration.ofSeconds(timeout * multiplier));
         try {
             wait.until(expectation);
-        } catch (Throwable error) {
+        } catch (Throwable _) {
             fail("Timeout waiting for Page Load Request to complete.");
         }
         log.debug("Waiting for maintainerMail");
@@ -80,7 +80,7 @@ public final class RemotePageWaiter implements PageWaiter {
             Duration.ofSeconds(timeout * multiplier));
         try {
             wait2.until(ExpectedConditions.presenceOfElementLocated(By.id("maintainerMail")));
-        } catch (Throwable error) {
+        } catch (Throwable _) {
             fail("Timeout waiting for maintainerMail.");
         }
     }
@@ -111,7 +111,7 @@ public final class RemotePageWaiter implements PageWaiter {
             Duration.ofSeconds(timeout * multiplier));
         try {
             wait3.until(ExpectedConditions.urlToBe(newUrl));
-        } catch (Throwable error) {
+        } catch (Throwable _) {
             fail("Timeout waiting for url.");
         }
         waitForPageLoaded(driver);

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/MenuPageImpl.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/MenuPageImpl.java
@@ -98,7 +98,7 @@ public final class MenuPageImpl implements MenuPage {
         try {
             getMenu(name);
             return true;
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return false;
         }
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PageBase.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PageBase.java
@@ -269,8 +269,8 @@ public class PageBase {
     protected void sleep(final long multiplier) {
         try {
             Thread.sleep(MEDIUM_SLEEP * multiplier);
-        } catch (InterruptedException _) {
-            // Do nothing
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
         }
     }
     /**

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PageBase.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PageBase.java
@@ -130,7 +130,7 @@ public class PageBase {
         try {
             getWebElement(by);
             return true;
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return false;
         }
     }
@@ -154,7 +154,7 @@ public class PageBase {
     public final boolean isElementPresentAndDisplayed(final By by) {
         try {
             return getWebElement(by).isDisplayed();
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return false;
         }
     }
@@ -269,7 +269,7 @@ public class PageBase {
     protected void sleep(final long multiplier) {
         try {
             Thread.sleep(MEDIUM_SLEEP * multiplier);
-        } catch (InterruptedException e) {
+        } catch (InterruptedException _) {
             // Do nothing
         }
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PersonPage.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/PersonPage.java
@@ -181,7 +181,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
                 return "";
             }
             return father.getText();
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return "";
         }
     }
@@ -193,7 +193,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
                 return "";
             }
             return mother.getText();
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return "";
         }
     }
@@ -205,7 +205,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
                 return null;
             }
             return father.findElement(By.tagName("a"));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return null;
         }
     }
@@ -213,7 +213,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
     private WebElement getFather() {
         try {
             return getWebElement(By.id("father"));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return null;
         }
     }
@@ -225,7 +225,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
                 return null;
             }
             return mother.findElement(By.tagName("a"));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return null;
         }
     }
@@ -233,7 +233,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
     private WebElement getMother() {
         try {
             return getWebElement(By.id("mother"));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return null;
         }
     }
@@ -313,7 +313,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
             final WebElement childLink = getChildLink(1, 1);
             final String childUrl = childLink.getAttribute("href");
             return childUrl.equals(url(childIdString));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return childIdString == null;
         }
     }
@@ -360,7 +360,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
             status.append("Leaf check failed\n");
         }
         println("        final status check");
-        if (status.length() != 0) {
+        if (!status.isEmpty()) {
             status.insert(0, "Id: " + id + "\n");
         }
         return status.toString();
@@ -462,7 +462,7 @@ public final class PersonPage extends PageBase implements MenuPageFacade {
             final WebElement link = leaf.findElement(By.tagName("a"));
             final String linkUrl = link.getAttribute("href");
             return linkUrl.equals(url(personId));
-        } catch (NoSuchElementException e) {
+        } catch (NoSuchElementException _) {
             return personId == null;
         }
     }

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/SourcePage.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/pageobjects/SourcePage.java
@@ -34,7 +34,7 @@ public final class SourcePage extends PageBase implements MenuPageFacade {
     static {
         TITLE_MAP.put("S33651",
                 "Births, Marriages & Deaths Register - S33651 - gl120368");
-    };
+    }
 
     /**
      * PageObject pattern for a page representing a person.

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/GedBrowserBasicIT.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/GedBrowserBasicIT.java
@@ -3,6 +3,7 @@ package org.schoellerfamily.gedbrowser.selenium.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Member;
 import java.net.MalformedURLException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -99,7 +100,7 @@ final class GedBrowserBasicIT {
 
     @BeforeEach
     void setUp(final TestInfo testInfo) throws MalformedURLException {
-        final String methodName = testInfo.getTestMethod().map(m -> m.getName()).orElse("unknown");
+        final String methodName = testInfo.getTestMethod().map(Member::getName).orElse("unknown");
         if (driver == null) {
             if (sauceExtension != null && sauceExtension.getDriver() != null) {
                 driver = (RemoteWebDriver) sauceExtension.getDriver();

--- a/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/MenuNavigationIT.java
+++ b/gedbrowser/src/test/java/org/schoellerfamily/gedbrowser/selenium/test/MenuNavigationIT.java
@@ -3,6 +3,7 @@ package org.schoellerfamily.gedbrowser.selenium.test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.lang.reflect.Member;
 import java.net.MalformedURLException;
 
 import org.junit.jupiter.api.AfterEach;
@@ -86,7 +87,7 @@ class MenuNavigationIT {
     @BeforeEach
     void setUp(final TestInfo testInfo) throws MalformedURLException {
         final String methodName = testInfo.getTestMethod()
-                .map(m -> m.getName()).orElse("unknown");
+                .map(Member::getName).orElse("unknown");
         if (driver == null) {
             // Try to use SauceBindingsExtension-managed driver first
             if (sauceExtension != null && sauceExtension.getDriver() != null) {

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
@@ -220,7 +220,7 @@ final class GeoCodeMongoIT {
     void testNotFounds() {
         log.info("Entering testNotFounds");
         testFixture.loadTestAddresses(gcc);
-        final List<String> expectList = Arrays .asList(testFixture.expectedNotFound());
+        final List<String> expectList = Arrays.asList(testFixture.expectedNotFound());
         final Collection<String> expected = new HashSet<>(expectList);
         final Collection<String> actual = gcc.notFoundKeys();
         assertTrue(compareNotFound(expected, actual), "Some differences in not found sets");

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
@@ -36,8 +36,6 @@ import com.google.maps.model.LatLng;
 
 import lombok.extern.slf4j.Slf4j;
 
-
-
 /**
  * Contains integration tests for geo code mongo.
  *
@@ -100,8 +98,7 @@ final class GeoCodeMongoIT {
     @Test
     void testOldHomeFound() {
         log.info("Entering testOldHomeFound");
-        final GeoCodeItem entry = gcc
-                .find("3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry = gcc.find("3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeocodingResult geocodingResult = entry.getGeocodingResult();
         assertNotNull(geocodingResult, "Should have found 3341 Chaucer Lane");
     }
@@ -143,8 +140,8 @@ final class GeoCodeMongoIT {
     void testCacheRefind() {
         log.info("Entering testCacheReplace");
         gcc.find("XYZZY");
-        final GeoCodeItem entry2 = gcc.find("XYZZY",
-                "3341 Chaucer Lane, Bethlehem, Pennsylvania, USA");
+        final GeoCodeItem entry2 = gcc
+            .find("XYZZY", "3341 Chaucer Lane, Bethlehem, Pennsylvania, USA");
         final GeoCodeItem entry3 = gcc.find("XYZZY");
         assertEquals(entry2, entry3, "Should be equal");
     }
@@ -152,8 +149,7 @@ final class GeoCodeMongoIT {
     @Test
     void testCacheOldHomeModern() {
         log.info("Entering testCacheOldHomeModern");
-        final GeoCodeItem entry1 = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry1 = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeoCodeItem entry2 = gcc.find("Old Home");
         assertEquals(entry1, entry2, "Should be equal");
     }
@@ -161,10 +157,8 @@ final class GeoCodeMongoIT {
     @Test
     void testCacheOldHomeModernBoth() {
         log.info("Entering testCacheOldHomeModernBoth");
-        final GeoCodeItem entry1 = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
-        final GeoCodeItem entry2 = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry1 = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry2 = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         assertEquals(entry1, entry2, "Should be equal");
     }
 
@@ -172,8 +166,7 @@ final class GeoCodeMongoIT {
     void testCacheOldHomeModernChange() {
         log.info("Entering testCacheOldHomeModernChange");
         final GeoCodeItem entry1 = gcc.find("Old Home");
-        final GeoCodeItem entry2 = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry2 = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         assertNotEquals(entry1, entry2, "Should NOT be equal");
     }
 
@@ -199,8 +192,7 @@ final class GeoCodeMongoIT {
     void testCacheOldHomeModernSet() {
         log.info("Entering testCacheOldHomeModernSet");
         gcc.find("Old Home");
-        final GeoCodeItem entry2 = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry2 = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeoCodeItem entry3 = gcc.find("Old Home");
         assertEquals(entry2, entry3, "Should be equal");
     }
@@ -208,8 +200,7 @@ final class GeoCodeMongoIT {
     @Test
     void testCacheOldHomeLocationResultNotNull() {
         log.info("Entering testCacheOldHomeLocation");
-        final GeoCodeItem entry = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         final GeocodingResult geocodingResult = entry.getGeocodingResult();
         assertNotNull(geocodingResult, "geocoding result should not be null");
     }
@@ -217,8 +208,7 @@ final class GeoCodeMongoIT {
     @Test
     void testCacheOldHomeLocationLatLngMatch() {
         log.info("Entering testCacheOldHomeLocation");
-        final GeoCodeItem entry = gcc.find("Old Home",
-                "3341 Chaucer Lane, Bethlehem, PA, USA");
+        final GeoCodeItem entry = gcc.find("Old Home", "3341 Chaucer Lane, Bethlehem, PA, USA");
         final LatLng expected = new LatLng(40.65800200, -75.40644300);
         final GeocodingResult geocodingResult = entry.getGeocodingResult();
         final LatLng actual = geocodingResult.geometry.location;
@@ -230,8 +220,7 @@ final class GeoCodeMongoIT {
     void testNotFounds() {
         log.info("Entering testNotFounds");
         testFixture.loadTestAddresses(gcc);
-        final List<String> expectList = Arrays
-                .asList(testFixture.expectedNotFound());
+        final List<String> expectList = Arrays .asList(testFixture.expectedNotFound());
         final Collection<String> expected = new HashSet<>(expectList);
         final Collection<String> actual = gcc.notFoundKeys();
         assertTrue(compareNotFound(expected, actual), "Some differences in not found sets");
@@ -242,8 +231,7 @@ final class GeoCodeMongoIT {
         log.info("Entering testNotFounds");
         try (InputStream fis = getTestFileAsStream()) {
             loader.load(fis);
-            final List<String> expectList = Arrays
-                .asList(testFixture.expectedNotFound());
+            final List<String> expectList = Arrays.asList(testFixture.expectedNotFound());
             final Collection<String> expected = new HashSet<>(expectList);
             final Collection<String> actual = gcc.notFoundKeys();
             assertTrue(compareNotFound(expected, actual), "Some differences in not found sets");
@@ -292,14 +280,13 @@ final class GeoCodeMongoIT {
 
     private boolean compareNotFound(final Collection<String> expected,
             final Collection<String> actual) {
-        boolean retval = true;
         for (final String check : expected) {
             if (!actual.contains(check)) {
                 log.info("Missing not found: {}", check);
-                retval = false;
+                return false;
             }
         }
-        return retval;
+        return true;
     }
 
     @Test
@@ -326,7 +313,7 @@ final class GeoCodeMongoIT {
         loader.load(dummyFileName);
         final int expected = 0;
         assertEquals(expected, gcc.size(),
-                "Should be 0 because of file not found, was: " + gcc.size());
+            "Should be 0 because of file not found, was: " + gcc.size());
     }
 
     @Test
@@ -402,9 +389,8 @@ final class GeoCodeMongoIT {
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "America");
-        assertTrue(input.getGeocodingResult() == null
-                        && output.getGeocodingResult() != null,
-                "Output should have result");
+        assertTrue(input.getGeocodingResult() == null && output.getGeocodingResult() != null,
+            "Output should have result");
     }
 
     @Test
@@ -413,7 +399,7 @@ final class GeoCodeMongoIT {
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "America");
         assertNotEquals(input.getModernPlaceName(), output.getModernPlaceName(),
-                "Items should not match");
+            "Items should not match");
     }
 
     @Test
@@ -421,9 +407,8 @@ final class GeoCodeMongoIT {
         final GeoCodeItem input = new GeoCodeItem("XYZZY", "XYZZY");
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "PLUGH");
-        assertTrue(input.getGeocodingResult() == null
-                        && output.getGeocodingResult() == null,
-                "Output should not have result");
+        assertTrue(input.getGeocodingResult() == null && output.getGeocodingResult() == null,
+            "Output should not have result");
     }
 
     @Test
@@ -432,7 +417,7 @@ final class GeoCodeMongoIT {
         gcc.add(input);
         final GeoCodeItem output = gcc.find("XYZZY", "PLUGH");
         assertNotEquals(input.getModernPlaceName(), output.getModernPlaceName(),
-                "Items should not match");
+            "Items should not match");
     }
 
     private InputStream getTestFileAsStream() {

--- a/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
+++ b/geoservice-persistence-mongo/src/test/java/org/schoellerfamily/geoservice/persistence/mongo/test/GeoCodeMongoIT.java
@@ -74,7 +74,7 @@ final class GeoCodeMongoIT {
     }
 
     @BeforeEach
-    void setUp() throws IOException {
+    void setUp() {
         testFixture.loadRepository();
     }
 


### PR DESCRIPTION
This pull request focuses on modernizing and simplifying the codebase, with particular emphasis on updating controller annotations to use the latest Spring conventions, improving code clarity, and making minor refactors for consistency and readability. The most significant updates involve replacing deprecated or verbose annotation usage in controller classes, standardizing exception variable naming, and using method references and `StringBuilder` where appropriate.

**Spring Controller Annotation Modernization:**

* Updated controller methods in `AuthenticationController`, `PublicController`, and `UserController` to use `@GetMapping` and `@PostMapping` instead of the older `@RequestMapping` with explicit HTTP methods. This change improves readability and aligns with current Spring best practices. [[1]](diffhunk://#diff-3af008c88659cd9ba8cb349bf171f03c0d968963c9db38b071cb7f9bd38ee23aR14-L16) [[2]](diffhunk://#diff-3af008c88659cd9ba8cb349bf171f03c0d968963c9db38b071cb7f9bd38ee23aL69-R70) [[3]](diffhunk://#diff-3af008c88659cd9ba8cb349bf171f03c0d968963c9db38b071cb7f9bd38ee23aL108-R109) [[4]](diffhunk://#diff-8ffba9ae97490194f1a36510c2165c1db94a8cb5e1e73e7b56d3892d77483477L3-R11) [[5]](diffhunk://#diff-8ffba9ae97490194f1a36510c2165c1db94a8cb5e1e73e7b56d3892d77483477L30-R29) [[6]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L3-L5) [[7]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421R17) [[8]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L51-R49) [[9]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L64-R62) [[10]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L75-R73) [[11]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L88-R86)

**Code Consistency and Readability Improvements:**

* Standardized exception variable naming by replacing unused exception variables with `_` in catch blocks across multiple files, clarifying intent and reducing noise. [[1]](diffhunk://#diff-9aca78754eff3da3f205b3903b2470128bfa0730b641cf75c5ce4ca9591996f0L35-R40) [[2]](diffhunk://#diff-d25328dd10f876976b66c40c1724c170ffdec28c33430e0265783637f28d275fL49-R49) [[3]](diffhunk://#diff-2ad9636531767585d07fbd321a1ebbca5925f8db1b4b2482bb7f6c85a3211c48L71-R71) [[4]](diffhunk://#diff-2ad9636531767585d07fbd321a1ebbca5925f8db1b4b2482bb7f6c85a3211c48L90-R90) [[5]](diffhunk://#diff-2ad9636531767585d07fbd321a1ebbca5925f8db1b4b2482bb7f6c85a3211c48L136-R136) [[6]](diffhunk://#diff-2ad9636531767585d07fbd321a1ebbca5925f8db1b4b2482bb7f6c85a3211c48L151-R151) [[7]](diffhunk://#diff-2ad9636531767585d07fbd321a1ebbca5925f8db1b4b2482bb7f6c85a3211c48L171-R171)
* Refactored code to use method references (e.g., `UserImpl::new`) instead of lambda expressions for constructors, making the code more concise and idiomatic. [[1]](diffhunk://#diff-fe7f7198503a6d1dea929a4ace921923db7b2155587f8d99a23218e524fbdb9bL46-R46) [[2]](diffhunk://#diff-337272bcd4663bca75f1e933abf35320f8af2c8a4934fcf109e3b7f5007c8db3L133-R133) [[3]](diffhunk://#diff-d3eea6db6ec6ff14e9610241f6509069fe3195b1341998aa1620b6600a17778aL51-R51)

**Test and Utility Code Refactoring:**

* Replaced string concatenation with `StringBuilder` in test utility methods to improve performance and code quality.
* Removed unnecessary `transient` modifiers from fields in `TreeTableRenderer` and used the diamond operator for type inference, simplifying the code. [[1]](diffhunk://#diff-3b073d362e5c45def90233c87e8d535d7aab820672e9f8c09dd506a4dd194c2fL16-R18) [[2]](diffhunk://#diff-3b073d362e5c45def90233c87e8d535d7aab820672e9f8c09dd506a4dd194c2fL54-R54)

**Minor Test and Exception Handling Updates:**

* Removed unnecessary `throws` declarations from test methods, reflecting that exceptions are no longer thrown. [[1]](diffhunk://#diff-9b88937e9011c1c74a148b035b9c1c5a043f700cddd8e4882438a181906316f2L101-R101) [[2]](diffhunk://#diff-713b86a63abc956f72e5828150a34a70c92bcbf708b2ae9ce6f9cb251342f3c7L130-R130)
* Simplified `ResponseEntity` instantiation by using the diamond operator. [[1]](diffhunk://#diff-2961e2a7794574775d44e3213425fa558bf64b1e8d2289876f4dc0f09a549421L99-R97) [[2]](diffhunk://#diff-e2050e29e51a06e1be901f98326ed85b9daec2d51fc50081c2dadae590c984e4L32-R32)
* Removed unnecessary `throws Exception` from test configuration methods. [[1]](diffhunk://#diff-b9cff6f39d20b2d7e847059b808046642bf8608d8f923cc33a104fa19ac2e6acL96-R98) [[2]](diffhunk://#diff-b9cff6f39d20b2d7e847059b808046642bf8608d8f923cc33a104fa19ac2e6acL125-R124)