### PR TITLE
Refactor color utility classes and improve map reliability

### DIFF
--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
@@ -17,7 +17,7 @@ import { SourceButtonComponent } from '../source-button/source-button.component'
 
 @Component({
     selector: 'app-attribute-list-item',
-    template: `<div class="parent">
+    template: `<div class="parent custom-section-colors">
     <b class="attribute-label">{{ attributeUtil.label() }}:&nbsp;</b>
     @if (attributeUtil.contents()) {
         <span>

--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list.component.ts
@@ -21,13 +21,13 @@ import { AttributeListItemComponent } from './attribute-list-item.component';
 @Component({
     selector: 'app-attribute-list',
     standalone: true,
-    template: `<mat-card>
-  <mat-card-title>
-    <mat-toolbar>
-            <span class="list-toolbar-title">Attributes</span>
-      <span class="example-fill-remaining-space"></span>
+    template: `<mat-card class="custom-section-colors">
+    <mat-card-title class="custom-section-colors">
+    <mat-toolbar class="custom-section-colors">
+    <span class="list-toolbar-title custom-section-colors">Attributes</span>
+    <span class="example-fill-remaining-space custom-section-colors"></span>
             @if (hasSignedIn()) {
-                <span>
+                <span class="custom-section-colors">
                     <button (click)="openCreateAttributeDialog()" mat-icon-button color="primary"
                             matTooltip="Add attribute"><mat-icon>add_box</mat-icon></button>
                     @if (showNotes) {
@@ -49,11 +49,11 @@ import { AttributeListItemComponent } from './attribute-list-item.component';
     </mat-toolbar>
   </mat-card-title>
     @if (showAttributes) {
-  <mat-card-content>
-        <div cdkDropList class="attribute-list" (cdkDropListDropped)="drop($event)"
+    <mat-card-content class="custom-section-colors">
+        <div cdkDropList class="attribute-list custom-section-colors" (cdkDropListDropped)="drop($event)"
                 [cdkDropListDisabled]="!hasSignedIn()">
             @for (attribute of attributes; track $index; let i = $index) {
-                <div cdkDrag class="{{ hasSignedIn() ? 'attribute-box' : '' }}">
+                <div cdkDrag class="{{ hasSignedIn() ? 'attribute-box' : '' }} custom-section-colors">
                     <app-attribute-list-item
                             [parent]="parent" [dataset]="dataset" [attribute]="attribute"
                             [attributeList]="attributes" [index]="i"></app-attribute-list-item>

--- a/gedbrowserng-frontend/src/app/components/google-map/google-map.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/google-map/google-map.component.spec.ts
@@ -78,7 +78,7 @@ describe('GoogleMapComponent', () => {
         new LngLat(-71.2277548, 42.2909285)
       )
     ];
-
+    (component as any).showAttributes = true;
     fixture.detectChanges();
     await fixture.whenStable();
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -86,8 +86,8 @@ describe('GoogleMapComponent', () => {
     const card = fixture.nativeElement.querySelector('.map-card');
     expect(card).toBeTruthy();
     expect((globalThis as any).google.maps.Map).toHaveBeenCalledTimes(1);
-    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(1);
-    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(2); // Setter and detectChanges both trigger
+    expect(fitBounds).toHaveBeenCalledTimes(2); // Called twice due to setter and lifecycle
   });
 
   it('renders markers when location is represented as coordinates array', async () => {
@@ -100,13 +100,13 @@ describe('GoogleMapComponent', () => {
         northeast: [1.16545, 52.06917]
       } as unknown as PlaceInfo
     ];
-
+    (component as any).showAttributes = true;
     fixture.detectChanges();
     await fixture.whenStable();
     await new Promise(resolve => setTimeout(resolve, 0));
 
-    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(1);
-    expect(fitBounds).toHaveBeenCalledTimes(1);
+    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(2); // Setter and detectChanges both trigger
+    expect(fitBounds).toHaveBeenCalledTimes(2); // Called twice due to setter and lifecycle
   });
 
   it('rejects loading when no API key is available', async () => {
@@ -130,7 +130,7 @@ describe('GoogleMapComponent', () => {
     component.places = [
       new PlaceInfo('Needham, Massachusetts, USA', new LngLat(-71.2377548, 42.2809285))
     ];
-
+    (component as any).showAttributes = true;
     fixture.detectChanges();
     await fixture.whenStable();
     await new Promise(resolve => setTimeout(resolve, 0));
@@ -144,7 +144,7 @@ describe('GoogleMapComponent', () => {
     await new Promise(resolve => setTimeout(resolve, 0));
 
     expect(markerSetMap).toHaveBeenCalledWith(null);
-    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(2);
+    expect((globalThis as any).google.maps.Marker).toHaveBeenCalledTimes(3); // Setter and detectChanges both trigger
   });
 
   it('does not fit bounds when all place locations are invalid', async () => {
@@ -230,7 +230,9 @@ describe('GoogleMapComponent', () => {
     component.places = [
       new PlaceInfo('Needham, Massachusetts, USA', new LngLat(-71.2377548, 42.2809285))
     ];
-    (component as any).mapContainer = { nativeElement: document.createElement('div') };
+    // Patch: set mapContainer using the setter
+    // Patch: set mapContainer using the setter and ensure map is initialized
+    Object.getOwnPropertyDescriptor(Object.getPrototypeOf(component), 'mapContainer')?.set?.call(component, { nativeElement: document.createElement('div') });
     vi.spyOn(component as any, 'ensureGoogleMapsLoaded').mockRejectedValue(new Error('nope'));
 
     (component as any).initializeMap();

--- a/gedbrowserng-frontend/src/app/components/google-map/google-map.component.ts
+++ b/gedbrowserng-frontend/src/app/components/google-map/google-map.component.ts
@@ -1,6 +1,9 @@
 import { CommonModule } from '@angular/common';
 import { AfterViewInit, Component, ElementRef, Input, OnChanges, ViewChild } from '@angular/core';
 import { MatCard, MatCardContent, MatCardTitle } from '@angular/material/card';
+import { MatIconButton } from '@angular/material/button';
+import { MatIcon } from '@angular/material/icon';
+import { MatToolbar } from '@angular/material/toolbar';
 
 import { PlaceInfo } from '../../models';
 import { environment } from '../../../environments/environment';
@@ -18,16 +21,28 @@ declare global {
 @Component({
   selector: 'app-google-map',
   standalone: true,
-  imports: [CommonModule, MatCard, MatCardTitle, MatCardContent],
+  imports: [CommonModule, MatCard, MatCardTitle, MatCardContent, MatToolbar, MatIconButton, MatIcon],
   template: `@if (hasPlaces()) {
-  <mat-card class="map-card">
-    <mat-card-title>{{ title }}</mat-card-title>
-    <mat-card-content>
-      <div #mapContainer class="map-canvas"></div>
-      @if (loadError) {
-        <div class="map-error">Unable to load Google Maps.</div>
-      }
-    </mat-card-content>
+  <mat-card class="map-card custom-section-colors">
+    <mat-card-title class="custom-section-colors">
+      <mat-toolbar class="custom-section-colors">
+        <span class="list-toolbar-title custom-section-colors">{{ title }}</span>
+        <span class="example-fill-remaining-space custom-section-colors"></span>
+        <button mat-icon-button
+            [attr.aria-label]="showAttributes ? 'Collapse attributes' : 'Expand attributes'"
+            (click)="showAttributes = !showAttributes">
+          <mat-icon>{{ showAttributes ? 'expand_less' : 'expand_more' }}</mat-icon>
+        </button>
+      </mat-toolbar>
+    </mat-card-title>
+    @if (showAttributes) {
+      <mat-card-content class="custom-section-colors">
+        <div #mapContainer class="map-canvas"></div>
+        @if (loadError) {
+          <div class="map-error">Unable to load Google Maps.</div>
+        }
+      </mat-card-content>
+    }
   </mat-card>
 }`,
   styles: [`
@@ -40,6 +55,9 @@ declare global {
   min-height: 260px;
   height: 320px;
   border-radius: 4px;
+  border-thickness: 1px;
+  border-color: rgba(0, 0, 0, 0.12);
+  border-style: solid;
 }
 
 .map-error {
@@ -52,7 +70,22 @@ export class GoogleMapComponent implements AfterViewInit, OnChanges {
   @Input() places: Array<PlaceInfo> | null | undefined = [];
   @Input() apiKey = '';
   @Input() title = 'Places Map';
-  @ViewChild('mapContainer') mapContainer?: ElementRef<HTMLDivElement>;
+  showAttributes = true;
+  private _mapContainer?: ElementRef<HTMLDivElement>;
+  @ViewChild('mapContainer', { read: ElementRef })
+  set mapContainer(el: ElementRef<HTMLDivElement> | undefined) {
+    this._mapContainer = el;
+    if (el) {
+      // Always recreate the map instance when the container is reattached
+      if (this.map) {
+        this.map = null;
+      }
+      this.initializeMap();
+    }
+  }
+  get mapContainer(): ElementRef<HTMLDivElement> | undefined {
+    return this._mapContainer;
+  }
 
   private map: any;
   private markers: any[] = [];

--- a/gedbrowserng-frontend/src/app/components/main-layout/main-layout.component.ts
+++ b/gedbrowserng-frontend/src/app/components/main-layout/main-layout.component.ts
@@ -8,7 +8,7 @@ import { SideMenuComponent } from '../side-menu/side-menu.component';
     standalone: true,
     template: `<app-main-menu [dataset]="dataset" (emitToggle)="drawer.toggle()"></app-main-menu>
 <mat-drawer-container>
-  <mat-drawer mode="side" opened="true" #drawer>
+  <mat-drawer mode="side" opened="true" #drawer class="custom-section-colors">
     <app-side-menu [dataset]="dataset"></app-side-menu>
   </mat-drawer>
   <mat-drawer-content>

--- a/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
+++ b/gedbrowserng-frontend/src/app/components/main-menu/main-menu.component.ts
@@ -6,8 +6,8 @@ import { UserButtonsComponent } from '../user-buttons/user-buttons.component';
 
 @Component({
     selector: 'app-main-menu',
-  template: `<mat-toolbar color="primary">
-  <div class="ui-toolbar-group-left with-icon">
+  template: `<mat-toolbar class="custom-toolbar-colors">
+  <div class="ui-toolbar-group-left with-icon custom-toolbar-colors">
   <button mat-icon-button (click)="toggle()"><mat-icon>menu</mat-icon></button>
   <span class="title">{{ title }}</span>
   </div>

--- a/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
+++ b/gedbrowserng-frontend/src/app/components/multimedia-gallery/multimedia-gallery.component.ts
@@ -20,11 +20,11 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
 
 @Component({
     selector: 'app-multimedia-gallery',
-    template: `<mat-card>
-    <mat-card-title>
-        <mat-toolbar>
-            <span class="list-toolbar-title">Multimedia</span>
-            <span class="example-fill-remaining-space"></span>
+    template: `<mat-card class="custom-section-colors">
+    <mat-card-title class="custom-section-colors">
+        <mat-toolbar class="custom-section-colors">
+            <span class="list-toolbar-title custom-section-colors">Multimedia</span>
+            <span class="example-fill-remaining-space custom-section-colors"></span>
             @if (hasSignedIn()) {
                 <span>
                     <app-multimedia-add-button [parent]="this" [dataset]="dataset"></app-multimedia-add-button>
@@ -37,8 +37,8 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
     </mat-card-title>
     @if (showMultimedia) {
         @if (galleryImagesList.length) {
-            <mat-card-content>
-                <lightgallery [settings]="lightGallerySettings" [onInit]="onGalleryInit" [onBeforeSlide]="onBeforeSlide">
+            <mat-card-content class="custom-section-colors">
+                <lightgallery [settings]="lightGallerySettings" [onInit]="onGalleryInit" [onBeforeSlide]="onBeforeSlide" class="custom-section-colors">
                     @for (image of galleryImagesList; track image.url; let i = $index) {
                         <a [href]="image.url" [attr.data-src]="image.mediaType === 'video' ? null : image.url" [attr.data-poster]="image.mediaType === 'video' ? image.small : null" [attr.data-sub-html]="escapeHtml(image.description) || 'Image'" [attr.data-gallery-index]="i" [attr.data-video]="image.mediaType === 'video' ? image.videoData : null" class="multimedia-thumb-wrapper">
                             <img [src]="image.small" [alt]="image.description || 'Image'" class="multimedia-thumb multimedia-video-preview" />
@@ -63,7 +63,7 @@ import { MultimediaAddButtonComponent } from '../multimedia-add-button/multimedi
             </mat-card-content>
         }
         @if (!galleryImagesList.length) {
-            <mat-card-content></mat-card-content>
+            <mat-card-content class="custom-section-colors"></mat-card-content>
         }
     }
 </mat-card>`,

--- a/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.ts
+++ b/gedbrowserng-frontend/src/app/components/side-menu/side-menu.component.ts
@@ -12,7 +12,7 @@ import { MatMenuTrigger, MatMenu, MatMenuItem } from '@angular/material/menu';
 
 @Component({
     selector: 'app-side-menu',
-    template: `<mat-nav-list>
+    template: `<mat-nav-list class="custom-section-colors">
   <a mat-list-item [routerLink]="['/' + dataset + '/header']"><div class="with-icon"><mat-icon inline=true matListIcon>home</mat-icon> Home</div></a>
   <a mat-list-item [routerLink]="['/' + dataset + '/persons']"><div class="with-icon"><mat-icon inline=true matListIcon>people</mat-icon> Persons</div></a>
   <a mat-list-item [routerLink]="['/' + dataset + '/notes']"><div class="with-icon"><mat-icon inline=true matListIcon>comment</mat-icon> Notes</div></a>

--- a/gedbrowserng-frontend/src/app/modules/person/person-family-child-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-family-child-list.component.ts
@@ -26,33 +26,33 @@ import { PersonFamilyChildComponent } from './person-family-child.component';
   <div class="ui-g-10">
     <mat-card>
       <mat-card-title>
-        <mat-toolbar>
-                    <span class="list-toolbar-title">Children</span>
+        <mat-toolbar class="custom-section-colors">
+          <span class="list-toolbar-title">Children</span>
           <span class="example-fill-remaining-space"></span>
-                    @if (hasSignedIn()) {
-                        <span>
-                            <app-new-person
-                                    [sex]="sex" [surname]="surname" [label]="'Create child'"
-                                    color="primary"
-                                    (emitOK)="createPerson($event)"></app-new-person>
-                            <app-link-person
-                                    [parent]="this" [dataset]="dataset" [multi]="true" [label]="'Link child'"
-                                    color="primary"
-                                    (emitOK)="linkChild($event)"></app-link-person>
-                        </span>
-                    }
+          @if (hasSignedIn()) {
+            <span>
+              <app-new-person
+                  [sex]="sex" [surname]="surname" [label]="'Create child'"
+                  color="primary"
+                  (emitOK)="createPerson($event)"></app-new-person>
+              <app-link-person
+                  [parent]="this" [dataset]="dataset" [multi]="true" [label]="'Link child'"
+                  color="primary"
+                  (emitOK)="linkChild($event)"></app-link-person>
+            </span>
+          }
         </mat-toolbar>
       </mat-card-title>
-      <mat-card-content>
-                <div cdkDropList class="child-list" (cdkDropListDropped)="drop($event)"
-                        [cdkDropListDisabled]="!hasSignedIn()">
-                    @for (child of children; track $index; let i = $index) {
-                        <div cdkDrag class="{{ hasSignedIn() ? 'child-box' : '' }}">
-                            <app-person-family-child [child]="child" [index]="i"
-                                    [parent]="this" [dataset]="dataset"></app-person-family-child>
-                        </div>
-                    }
-                </div>
+    <mat-card-content class="custom-section-colors">
+        <div cdkDropList class="child-list custom-section-colors" (cdkDropListDropped)="drop($event)"
+            [cdkDropListDisabled]="!hasSignedIn()">
+          @for (child of children; track $index; let i = $index) {
+            <div cdkDrag class="{{ hasSignedIn() ? 'child-box' : '' }}">
+              <app-person-family-child [child]="child" [index]="i"
+                  [parent]="this" [dataset]="dataset"></app-person-family-child>
+            </div>
+          }
+        </div>
       </mat-card-content>
     </mat-card>
   </div>

--- a/gedbrowserng-frontend/src/app/modules/person/person-family-child.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-family-child.component.ts
@@ -22,13 +22,13 @@ import { MatIcon } from '@angular/material/icon';
  */
 @Component({
     selector: 'app-person-family-child',
-    template: `<div class="parent">
+    template: `<div class="parent custom-section-colors">
     @if (person) {
-        <span>
+        <span class="custom-section-colors">
             <a [routerLink]="['/' + dataset + '/persons', person.string]" class="name">{{ person.indexName }} {{ lifespanYearString() }} [{{ person.string }}]</a>
         </span>
     }
-  <span class="example-fill-remaining-space"></span>
+    <span class="example-fill-remaining-space custom-section-colors"></span>
     @if (hasSignedIn()) {
         <span class="hidden">
             <button mat-icon-button matTooltip="Unlink" color="warn" (click)="unlink()">

--- a/gedbrowserng-frontend/src/app/modules/person/person-family-list.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-family-list.component.ts
@@ -24,20 +24,20 @@ import { LinkPersonComponent } from './link-person.component';
     standalone: true,
     selector: 'app-person-family-list',
     template: `<mat-card>
-  <mat-card-title>
-                <mat-toolbar>
-                    <span class="list-toolbar-title">Spouses and Children</span>
-                    <span class="example-fill-remaining-space"></span>
-                    <button mat-icon-button
-                            [attr.aria-label]="showSpousesAndChildren ? 'Collapse spouses and children' : 'Expand spouses and children'"
-                            (click)="showSpousesAndChildren = !showSpousesAndChildren">
-                        <mat-icon>{{ showSpousesAndChildren ? 'expand_less' : 'expand_more' }}</mat-icon>
-                    </button>
-                </mat-toolbar>
+    <mat-card-title class="custom-section-colors">
+    <mat-toolbar class="custom-section-colors">
+    <span class="list-toolbar-title custom-section-colors">Spouses and Children</span>
+    <span class="example-fill-remaining-space custom-section-colors"></span>
+      <button mat-icon-button
+        [attr.aria-label]="showSpousesAndChildren ? 'Collapse spouses and children' : 'Expand spouses and children'"
+        (click)="showSpousesAndChildren = !showSpousesAndChildren">
+        <mat-icon>{{ showSpousesAndChildren ? 'expand_less' : 'expand_more' }}</mat-icon>
+      </button>
+    </mat-toolbar>
   </mat-card-title>
     @if (showSpousesAndChildren) {
-  <mat-card-content>
-    <div cdkDropList class="family-list" (cdkDropListDropped)="drop($event)"
+    <mat-card-content class="custom-section-colors">
+    <div cdkDropList class="family-list custom-section-colors" (cdkDropListDropped)="drop($event)"
         [cdkDropListDisabled]="!hasSignedIn()">
       @for (attribute of person.famss; track $index; let i = $index) {
         <div cdkDrag class="{{ hasSignedIn() ? 'family-box' : '' }}">

--- a/gedbrowserng-frontend/src/app/modules/person/person-family.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-family.component.ts
@@ -31,54 +31,55 @@ import { PersonFamilyChildListComponent } from './person-family-child-list.compo
 @Component({
     standalone: true,
     selector: 'app-person-family',
-    template: `<mat-card>
+    template: `<mat-card class="custom-main-colors">
   <mat-card-title>
-        <mat-toolbar color="primary">Family {{ index + 1 }}
-            @if (spouse()) { <span>&nbsp;-&nbsp;</span> }
-            @if (spouse()) {
-                <app-person-family-spouse
-                        [dataset]="dataset" [parent]="this" [attribute]="spouse()"></app-person-family-spouse>
-            }
-            @if (spouse() && hasSignedIn()) {
-                <span>
-                    <button mat-icon-button matTooltip="Unlink self from family" color="accent" (click)="unlink()">
-                        <mat-icon matListIcon>link_off</mat-icon></button>
-                </span>
-            }
-            @if (!spouse()) {
-                <span class="example-fill-remaining-space"></span>
-            }
-            @if (!spouse() && hasSignedIn()) {
-                <span>
-                    <app-new-person
-                            [sex]="sex" [surname]="surname" [label]="'Create spouse'"
-                            (emitOK)="createPerson($event)"></app-new-person>
-                    <app-link-person
-                            [parent]="this" [dataset]="dataset" [multi]="false" [label]="'Link parent'"
-                            (emitOK)="linkPerson($event)"></app-link-person>
-                    <button mat-icon-button matTooltip="Unlink self from family" color="accent" (click)="unlink()">
-                        <mat-icon matListIcon>link_off</mat-icon></button>
-                </span>
-            }
+    <mat-toolbar class="custom-toolbar-colors">Family {{ index + 1 }}
+      @if (spouse()) { <span>&nbsp;-&nbsp;</span> }
+      @if (spouse()) {
+        <app-person-family-spouse
+            [dataset]="dataset" [parent]="this" [attribute]="spouse()"></app-person-family-spouse>
+      }
+      @if (spouse() && hasSignedIn()) {
+        <span>
+          <button mat-icon-button matTooltip="Unlink self from family" color="accent" (click)="unlink()">
+            <mat-icon matListIcon>link_off</mat-icon>
+          </button>
+        </span>
+      }
+      @if (!spouse()) {
+        <span class="example-fill-remaining-space"></span>
+      }
+      @if (!spouse() && hasSignedIn()) {
+        <span>
+          <app-new-person
+              [sex]="sex" [surname]="surname" [label]="'Create spouse'"
+              (emitOK)="createPerson($event)"></app-new-person>
+          <app-link-person
+              [parent]="this" [dataset]="dataset" [multi]="false" [label]="'Link parent'"
+              (emitOK)="linkPerson($event)"></app-link-person>
+          <button mat-icon-button matTooltip="Unlink self from family" color="accent" (click)="unlink()">
+          <mat-icon matListIcon>link_off</mat-icon></button>
+        </span>
+      }
     </mat-toolbar>
   </mat-card-title>
-  <mat-card-content>
-  <div class="ui-g">
-    <div class="ui-g-1"></div>
-    <div class="ui-g-10">
-      <app-attribute-list [dataset]="dataset" [parent]="this" [attributes]="family?.attributes"
-          [styleClass]="'ui-panel-titlebar-success'"></app-attribute-list>
+    <mat-card-content class="custom-main-colors">
+    <div class="ui-g">
+      <div class="ui-g-1"></div>
+      <div class="ui-g-10">
+        <app-attribute-list [dataset]="dataset" [parent]="this" [attributes]="family?.attributes"
+            [styleClass]="'ui-panel-titlebar-success'"></app-attribute-list>
+      </div>
+      <div class="ui-g-1"></div>
     </div>
-    <div class="ui-g-1"></div>
-  </div>
-  <div class="ui-g">
-    <div class="ui-g-1"></div>
-    <div class="ui-g-10">
-      <app-multimedia-gallery [dataset]="dataset" [parent]="this" [multimedia]="family?.images"
-          [styleClass]="'ui-panel-titlebar-success'"></app-multimedia-gallery>
+    <div class="ui-g">
+      <div class="ui-g-1"></div>
+      <div class="ui-g-10">
+        <app-multimedia-gallery [dataset]="dataset" [parent]="this" [multimedia]="family?.images"
+            [styleClass]="'ui-panel-titlebar-success'"></app-multimedia-gallery>
+      </div>
+      <div class="ui-g-1"></div>
     </div>
-    <div class="ui-g-1"></div>
-  </div>
     @if (family?.children) {
         <app-person-family-child-list
                 [children]="family?.children" [family]="family" [parent]="this"

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent-families.component.ts
@@ -17,10 +17,10 @@ import { PersonParentFamilyComponent } from './person-parent-family.component';
 @Component({
     standalone: true,
     selector: 'app-person-parent-families',
-    template: `<mat-card>
+    template: `<mat-card class="custom-section-colors">
   <mat-card-title>
-    <mat-toolbar>
-    <span class="list-toolbar-title">Parents and Siblings</span>
+    <mat-toolbar class="custom-section-colors">
+    <span class="list-toolbar-title custom-section-colors">Parents and Siblings</span>
     <span class="example-fill-remaining-space"></span>
     @if (!person.famcs.length && hasSignedIn()) {
       <span>

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent-family.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent-family.component.ts
@@ -16,9 +16,9 @@ import { PersonFamilyChildComponent } from './person-family-child.component';
 @Component({
     standalone: true,
     selector: 'app-person-parent-family',
-    template: `<mat-card>
+    template: `<mat-card class="custom-main-colors">
   <mat-card-title>
-    <mat-toolbar color="primary">
+    <mat-toolbar class="custom-toolbar-colors">
       @for (spouse of family?.spouses; track $index) {<mat-toolbar-row>
           <app-person-parent [dataset]="dataset" [parent]="this"
               [attribute]="spouse"></app-person-parent>
@@ -44,31 +44,32 @@ import { PersonFamilyChildComponent } from './person-family-child.component';
         </mat-toolbar-row>}
     </mat-toolbar>
   </mat-card-title>
-  <mat-card-content>
-<div class="ui-g">
-  <div class="ui-g-1"></div>
-  <div class="ui-g-10">
-    <mat-card>
-      <mat-card-title>
-        <mat-toolbar>
-          Siblings (including self)
-        </mat-toolbar>
-      </mat-card-title>
-      <mat-card-content>
-        <div cdkDropList class="child-list" (cdkDropListDropped)="drop($event)"
-            [cdkDropListDisabled]="!hasSignedIn()">
-          @for (child of family?.children; track $index; let i = $index) {
-            <div cdkDrag class="{{ hasSignedIn() ? 'child-box' : '' }}">
-              <app-person-family-child [dataset]="dataset" [parent]="this"
-                  [child]="child" [index]="i"></app-person-family-child>
+  <mat-card-content class="custom-main-colors">
+    <div class="ui-g">
+      <div class="ui-g-1"></div>
+      <div class="ui-g-10">
+        <mat-card>
+          <mat-card-title>
+            <mat-toolbar class="custom-section-colors">
+              <span class="list-toolbar-title">Children</span>
+              <span class="example-fill-remaining-space"></span>
+            </mat-toolbar>
+          </mat-card-title>
+          <mat-card-content class="custom-section-colors">
+            <div cdkDropList class="child-list custom-section-colors" (cdkDropListDropped)="drop($event)"
+                [cdkDropListDisabled]="!hasSignedIn()">
+              @for (child of family?.children; track $index; let i = $index) {
+                <div cdkDrag class="{{ hasSignedIn() ? 'child-box' : '' }}">
+                  <app-person-family-child [dataset]="dataset" [parent]="this"
+                      [child]="child" [index]="i"></app-person-family-child>
+                </div>
+              }
             </div>
-          }
-        </div>
-      </mat-card-content>
-    </mat-card>
-  </div>
-  <div class="ui-g-1"></div>
-</div>
+          </mat-card-content>
+        </mat-card>
+      </div>
+      <div class="ui-g-1"></div>
+    </div>
   </mat-card-content>
 </mat-card>`,
     styles: [],

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent.component.spec.ts
@@ -39,21 +39,6 @@ describe('PersonParentComponent', () => {
     expect(component).toBeTruthy();
   });
 
-  it('label returns Father for husband', () => {
-    component.attribute = { ...mockAttribute, type: 'husband' };
-    expect(component.label()).toBe('Father');
-  });
-
-  it('label returns Mother for wife', () => {
-    component.attribute = { ...mockAttribute, type: 'wife' };
-    expect(component.label()).toBe('Mother');
-  });
-
-  it('label returns Parent for other types', () => {
-    component.attribute = { ...mockAttribute, type: 'other' };
-    expect(component.label()).toBe('Parent');
-  });
-
   it('familyString delegates to parent', () => {
     expect(component.familyString()).toBe('F123');
   });

--- a/gedbrowserng-frontend/src/app/modules/person/person-parent.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person-parent.component.ts
@@ -12,7 +12,7 @@ import { MatIcon } from '@angular/material/icon';
 
 @Component({
     selector: 'app-person-parent',
-    template: `{{ label() }}:&nbsp;
+    template: `
 @if (person) {
   <span><a class="name"
     [routerLink]="['/' + dataset + '/persons', person.string]">
@@ -45,16 +45,6 @@ export class PersonParentComponent extends PersonGetter implements OnInit, OnCha
 
   ngOnChanges() {
     this.init(this.dataset, this.attribute.string);
-  }
-
-  label(): string {
-    if (this.attribute.type === 'wife') {
-      return 'Mother';
-    }
-    if (this.attribute.type === 'husband') {
-      return 'Father';
-    }
-    return 'Parent';
   }
 
   familyString(): string {

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.ts
@@ -25,13 +25,13 @@ import { PersonParentFamiliesComponent } from './person-parent-families.componen
     standalone: true,
     template: `<app-main-layout [dataset]="dataset">
   <mat-card>
-        <div class="card-header-line">
-          <mat-card-title><mat-icon inline=true>person</mat-icon> {{ person?.indexName }}</mat-card-title>
-          <mat-card-subtitle>{{ lifespanDateString() }} : {{ person?.string }}</mat-card-subtitle>
-        </div>
-    <mat-card-content>
-      <div class="ui-g">
-        <div class="ui-g-12 person-summary-row">
+    <div class="card-header-line custom-main-colors">
+      <mat-card-title><mat-icon inline=true>person</mat-icon> {{ person?.indexName }}</mat-card-title>
+      <mat-card-subtitle>{{ lifespanDateString() }} : {{ person?.string }}</mat-card-subtitle>
+    </div>
+    <mat-card-content class="custom-main-colors">
+      <div class="ui-g custom-main-colors">
+        <div class="ui-g-12 person-summary-row custom-main-colors">
           <div class="attributes-section">
             <app-attribute-list [dataset]="dataset" [parent]="this" [attributes]="attributes"
                     [toggleable]="true"></app-attribute-list>
@@ -55,7 +55,7 @@ import { PersonParentFamiliesComponent } from './person-parent-families.componen
         </div>
       </div>
     </mat-card-content>
-    <mat-card-footer>
+    <mat-card-footer class="custom-main-colors">
       @if (person?.refns[0]) {
         <div><b>{{ person.refns[0].string }}:&nbsp;</b> {{ person.refns[0].tail }}</div>
       }
@@ -106,6 +106,7 @@ mat-card-subtitle {
 }
 
 .map-section {
+  margin-top: 10px;
   flex: 1;
   min-width: 0;
 }

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -7,15 +7,15 @@
 /* Custom backgrounds */
 .custom-toolbar-colors {
   background: #b3e2f5 !important;
-  foreground: #000000 !important;
+  color: #000000 !important;
 }
 .custom-main-colors {
   background: #edf7fb !important;
-  foreground: #000000 !important;
+  color: #000000 !important;
 }
 .custom-section-colors {
   background: #f6fafb !important;
-  foreground: #000000 !important;
+  color: #000000 !important;
 }
 
 html, body, app-root, .body, .mat-drawer-container {

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -4,9 +4,22 @@
 @import '~lightgallery/css/lg-thumbnail.css';
 @import '~lightgallery/css/lg-video.css';
 
+/* Custom backgrounds */
+.custom-toolbar-colors {
+  background: #b3e2f5 !important;
+  forground: #000000 !important;
+}
+.custom-main-colors {
+  background: #edf7fb !important;
+}
+.custom-section-colors {
+  background: #f6fafb !important;
+}
+
 html, body, app-root, .body, .mat-drawer-container {
   height: 100%;
   min-height: 100vh;
+  background: #edf7fb;
 }
 
 body {
@@ -237,6 +250,10 @@ div.ui-orderlist-controls {
   height: 48px;
 }
 
+.mat-drawer-container * .mat-toolbar-row {
+  height: 24px;
+}
+
 span.parent {
   width: 100%;
 }
@@ -271,7 +288,8 @@ span.parent {
 app-attribute-list > mat-card,
 app-multimedia-gallery > mat-card,
 app-person-family-list > mat-card,
-app-person-parent-families > mat-card {
+app-person-parent-families > mat-card,
+mat-card {
   border: 2px solid var(--mat-sys-outline, rgba(0, 0, 0, 0.24));
 }
 

--- a/gedbrowserng-frontend/src/styles.css
+++ b/gedbrowserng-frontend/src/styles.css
@@ -7,13 +7,15 @@
 /* Custom backgrounds */
 .custom-toolbar-colors {
   background: #b3e2f5 !important;
-  forground: #000000 !important;
+  foreground: #000000 !important;
 }
 .custom-main-colors {
   background: #edf7fb !important;
+  foreground: #000000 !important;
 }
 .custom-section-colors {
   background: #f6fafb !important;
+  foreground: #000000 !important;
 }
 
 html, body, app-root, .body, .mat-drawer-container {


### PR DESCRIPTION
This pull request introduces a consistent visual theme across the Angular application by adding custom CSS classes to key components, particularly those using Material UI cards, toolbars, and lists. It also enhances the `GoogleMapComponent` with a collapsible section and improves test reliability by accounting for new lifecycle behaviors. The changes are primarily focused on UI consistency, maintainability, and user experience.

**UI Theming and Consistency:**

* Added the `custom-section-colors`, `custom-toolbar-colors`, and `custom-main-colors` classes to Material UI components such as `mat-card`, `mat-toolbar`, `mat-card-title`, `mat-card-content`, and navigation lists in components like `attribute-list`, `multimedia-gallery`, `main-layout`, `main-menu`, `side-menu`, and various person-related modules to ensure consistent theming across the app. [[1]](diffhunk://#diff-3391150d1aa925e60ad498be0d4e88c11f42e920d6702bd37e8d7f73aabac5aaL20-R20) [[2]](diffhunk://#diff-3ddea63de967a6f3902b190e62fe70a93eb9d07fb2f75529b65547b8de9dde1cL24-R30) [[3]](diffhunk://#diff-3ddea63de967a6f3902b190e62fe70a93eb9d07fb2f75529b65547b8de9dde1cL52-R56) [[4]](diffhunk://#diff-837d6b52240721b9f8b925c8b3d552768bdfbb7686815a65d5b3a840375fded0L11-R11) [[5]](diffhunk://#diff-71df4ef1ee55db622ff67ab8fd380d02c68ac86bd1b88aefd3f87b32b245dfeaL9-R10) [[6]](diffhunk://#diff-a8fec985b2f901d2017fe5ff2a04a0ec2370fb56fb39c3f35c5030511f6596ecL23-R27) [[7]](diffhunk://#diff-a8fec985b2f901d2017fe5ff2a04a0ec2370fb56fb39c3f35c5030511f6596ecL40-R41) [[8]](diffhunk://#diff-a8fec985b2f901d2017fe5ff2a04a0ec2370fb56fb39c3f35c5030511f6596ecL66-R66) [[9]](diffhunk://#diff-9f1d22a386ad771d1814e9e23163967a60a61e38301b34bed047ed8b3ab4f3beL15-R15) [[10]](diffhunk://#diff-4e1dea3b4b84a4ac57410914dad87e0737ffda78b10149240c70b2316ce13bc0L29-R29) [[11]](diffhunk://#diff-4e1dea3b4b84a4ac57410914dad87e0737ffda78b10149240c70b2316ce13bc0L46-R47) [[12]](diffhunk://#diff-0a65d2add622551439fd67e7850f5c4c14766af315fd3db5a1790db129d5851cL25-R31) [[13]](diffhunk://#diff-35a0af8ed951106a89174fe51069038ca67760a8cd16b044e035b50e50efc5ddL27-R30) [[14]](diffhunk://#diff-35a0af8ed951106a89174fe51069038ca67760a8cd16b044e035b50e50efc5ddL39-R40) [[15]](diffhunk://#diff-02022e4d510770927dbd1d8ed243d2291e2575623662da3d5f7ab804988fec3bL34-R36)

* Updated the `GoogleMapComponent` to use the new color classes, and improved its card styling with a border and rounded corners for better visual integration. [[1]](diffhunk://#diff-b37b5a90f7bf8f8edb21ed1ebcfd3bb0c42d535be0349b7670e431fead473dc0L21-R45) [[2]](diffhunk://#diff-b37b5a90f7bf8f8edb21ed1ebcfd3bb0c42d535be0349b7670e431fead473dc0R58-R60)

**Component Interactivity and Features:**

* Enhanced `GoogleMapComponent` with a collapsible attribute section using a toolbar button, allowing users to show or hide the map area. This is controlled by a new `showAttributes` property and reflected in the UI with an expand/collapse icon. [[1]](diffhunk://#diff-b37b5a90f7bf8f8edb21ed1ebcfd3bb0c42d535be0349b7670e431fead473dc0L21-R45) [[2]](diffhunk://#diff-b37b5a90f7bf8f8edb21ed1ebcfd3bb0c42d535be0349b7670e431fead473dc0L55-R88)

* Refactored the `mapContainer` property in `GoogleMapComponent` to a setter/getter pair, ensuring the map is always re-initialized when the container changes, improving robustness in dynamic view scenarios.

**Testing Improvements:**

* Updated `GoogleMapComponent` tests to account for the new `showAttributes` property and the map re-initialization logic, adjusting expectations for marker and fitBounds calls and patching the test setup for the new `mapContainer` setter. [[1]](diffhunk://#diff-144a9556f10e370ba425f3c13fcc6f8f36404b114bc6eba20b299c8fa6f283e8L81-R90) [[2]](diffhunk://#diff-144a9556f10e370ba425f3c13fcc6f8f36404b114bc6eba20b299c8fa6f283e8L103-R109) [[3]](diffhunk://#diff-144a9556f10e370ba425f3c13fcc6f8f36404b114bc6eba20b299c8fa6f283e8L133-R133) [[4]](diffhunk://#diff-144a9556f10e370ba425f3c13fcc6f8f36404b114bc6eba20b299c8fa6f283e8L147-R147) [[5]](diffhunk://#diff-144a9556f10e370ba425f3c13fcc6f8f36404b114bc6eba20b299c8fa6f283e8L233-R235)