### PR TITLE
Move attribute deletion into editor dialog

### DIFF
--- a/gedbrowserng-frontend/src/app/components/attribute-dialog/new-attribute-dialog.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-dialog/new-attribute-dialog.component.spec.ts
@@ -1,11 +1,12 @@
 import { NO_ERRORS_SCHEMA } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { MatDialogRef, MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MatDialogModule, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ReactiveFormsModule, FormsModule } from '@angular/forms';
 import { MatFormFieldModule } from '@angular/material/form-field';
 import { MatInputModule } from '@angular/material/input';
 import { MatSelectModule } from '@angular/material/select';
 import { vi } from 'vitest';
+import { of } from 'rxjs';
 
 import { NewAttributeDialogComponent } from './new-attribute-dialog.component';
 
@@ -13,20 +14,26 @@ describe('NewAttributeDialogComponent', () => {
   let component: NewAttributeDialogComponent;
   let fixture: ComponentFixture<NewAttributeDialogComponent>;
   let mockDialogRef: any;
+  let mockDialog: any;
 
   beforeEach(() => {
     mockDialogRef = { close: vi.fn() };
+    mockDialog = {
+      open: vi.fn().mockReturnValue({ afterClosed: () => of(undefined) })
+    };
 
     TestBed.configureTestingModule({
     schemas: [NO_ERRORS_SCHEMA],
     imports: [MatDialogModule, ReactiveFormsModule, FormsModule, MatFormFieldModule, MatInputModule, MatSelectModule, NewAttributeDialogComponent],
     providers: [
       { provide: MatDialogRef, useValue: mockDialogRef },
+      { provide: MatDialog, useValue: mockDialog },
         {
             provide: MAT_DIALOG_DATA,
             useValue: {
                 options: [{ label: 'Test', value: 'test' }],
-                default: { type: 'test', text: '', date: '' }
+                default: { type: 'test', text: '', date: '' },
+                canDelete: false
             }
         }
     ]
@@ -47,5 +54,24 @@ describe('NewAttributeDialogComponent', () => {
   it('should close dialog on cancel', () => {
     component.onNoClick();
     expect(mockDialogRef.close).toHaveBeenCalled();
+  });
+
+  it('should open confirm dialog on delete click', () => {
+    component.onDeleteClick();
+    expect(mockDialog.open).toHaveBeenCalled();
+  });
+
+  it('should close editor dialog with deleted flag when deletion confirmed', () => {
+    mockDialog.open.mockReturnValue({ afterClosed: () => of(true) });
+    component.onDeleteClick();
+    expect(mockDialogRef.close).toHaveBeenCalledWith(
+      expect.objectContaining({ deleted: true })
+    );
+  });
+
+  it('should not close editor dialog when deletion cancelled', () => {
+    mockDialog.open.mockReturnValue({ afterClosed: () => of(false) });
+    component.onDeleteClick();
+    expect(mockDialogRef.close).not.toHaveBeenCalled();
   });
 });

--- a/gedbrowserng-frontend/src/app/components/attribute-dialog/new-attribute-dialog.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-dialog/new-attribute-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, Inject } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
+import { MatDialog, MatDialogRef, MAT_DIALOG_DATA, MatDialogTitle, MatDialogContent, MatDialogActions, MatDialogClose } from '@angular/material/dialog';
 
 import { NewAttributeDialogData } from '../../models';
 import { MatToolbar } from '@angular/material/toolbar';
@@ -10,6 +10,7 @@ import { MatSelect, MatOption } from '@angular/material/select';
 import { FormsModule } from '@angular/forms';
 import { MatInput } from '@angular/material/input';
 import { MatButton } from '@angular/material/button';
+import { ConfirmDialogComponent } from '../confirm-dialog/confirm-dialog.component';
 
 @Component({
     selector: 'app-new-attribute-dialog',
@@ -48,6 +49,9 @@ import { MatButton } from '@angular/material/button';
   </mat-form-field>
 </div>
 <div mat-dialog-actions>
+  @if (data.canDelete) {
+    <button mat-button color="warn" (click)="onDeleteClick()">Delete</button>
+  }
   <span class="example-fill-remaining-space"></span>
   <button mat-button [mat-dialog-close]="data.default" cdkFocusInitial>OK</button>
   <button mat-button (click)="onNoClick()" >Cancel</button>
@@ -57,10 +61,23 @@ import { MatButton } from '@angular/material/button';
 })
 export class NewAttributeDialogComponent {
   constructor(@Inject(MatDialogRef) public readonly dialogRef: MatDialogRef<NewAttributeDialogComponent>,
-    @Inject(MAT_DIALOG_DATA) public readonly data: NewAttributeDialogData) {
+    @Inject(MAT_DIALOG_DATA) public readonly data: NewAttributeDialogData,
+    @Inject(MatDialog) private readonly dialog: MatDialog) {
   }
 
   onNoClick(): void {
     this.dialogRef.close();
+  }
+
+  onDeleteClick(): void {
+    const confirmRef = this.dialog.open(ConfirmDialogComponent, {
+      data: { message: 'Are you sure you want to delete this attribute?' }
+    });
+    confirmRef.afterClosed().subscribe((confirmed: boolean) => {
+      if (confirmed) {
+        this.data.default.deleted = true;
+        this.dialogRef.close(this.data.default);
+      }
+    });
   }
 }

--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.spec.ts
@@ -133,6 +133,25 @@ describe('AttributeListItemComponent', () => {
     expect(mockMatDialog.open).toHaveBeenCalled();
   });
 
+  it('should delete attribute from list when edit dialog returns deleted flag', () => {
+    const attr1 = new ApiAttribute();
+    attr1.type = 'attr1';
+    const attr2 = new ApiAttribute();
+    attr2.type = 'attr2';
+
+    component.attributeList = [attr1, attr2];
+    component.attribute = attr1;
+
+    mockMatDialog.open.mockReturnValue({
+      afterClosed: () => of({ deleted: true, type: 'attr1', text: '', insert: false })
+    });
+    component.edit();
+
+    expect(component.attributeList.length).toBe(1);
+    expect(component.attributeList[0]).toBe(attr2);
+    expect(component.parent.save).toHaveBeenCalled();
+  });
+
   it('should delete attribute from list', () => {
     const attr1 = new ApiAttribute();
     attr1.type = 'attr1';

--- a/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/attribute-list-item.component.ts
@@ -41,8 +41,6 @@ import { SourceButtonComponent } from '../source-button/source-button.component'
                         [parent]="this" [dataset]="dataset" [attributes]="attributeList" [index]="index">
                 </app-multimedia-edit-button>
             }
-            <button mat-icon-button matTooltip="Delete" color="warn" (click)="delete()">
-                <mat-icon matListIcon>delete</mat-icon></button>
             @if (!href()) {
                 <app-source-button [parent]="this" [dataset]="dataset"></app-source-button>
             }
@@ -72,7 +70,13 @@ export class AttributeListItemComponent extends HasAttributeDialog {
     }
 
     edit() {
-        this.openAttributeDialog(result => { this.modifyAttribute(result); });
+        this.openAttributeDialog(result => {
+            if (result.deleted) {
+                this.deleteFromList();
+            } else {
+                this.modifyAttribute(result);
+            }
+        });
     }
 
     defaultData(): AttributeDialogData {
@@ -95,11 +99,19 @@ export class AttributeListItemComponent extends HasAttributeDialog {
         });
         dialogRef.afterClosed().subscribe((confirmed: boolean) => {
             if (confirmed) {
-                const index = this.attributeList.indexOf(this.attribute);
-                this.attributeList.splice(index, 1);
-                this.parent.save();
+                this.deleteFromList();
             }
         });
+    }
+
+    private deleteFromList(): void {
+        const index = (this.index >= 0 && this.index < this.attributeList.length && this.attributeList[this.index] === this.attribute)
+            ? this.index
+            : this.attributeList.indexOf(this.attribute);
+        if (index >= 0) {
+            this.attributeList.splice(index, 1);
+            this.parent.save();
+        }
     }
 
     href() {

--- a/gedbrowserng-frontend/src/app/components/attribute-list/has-attribute-dialog.ts
+++ b/gedbrowserng-frontend/src/app/components/attribute-list/has-attribute-dialog.ts
@@ -8,10 +8,11 @@ export abstract class HasAttributeDialog implements HasAttributeList {
   constructor(public readonly dialog: MatDialog) { }
 
   openAttributeDialog(callback: (result: AttributeDialogData) => void): void {
+    const defaultData = this.defaultData();
     const dialogRef = this.dialog.open(
       NewAttributeDialogComponent,
       {
-        data: { options: this.options(), default: this.defaultData() }
+        data: { options: this.options(), default: defaultData, canDelete: !defaultData.insert }
       });
 
     dialogRef.afterClosed().subscribe(result => {

--- a/gedbrowserng-frontend/src/app/models/attribute-dialog-data.ts
+++ b/gedbrowserng-frontend/src/app/models/attribute-dialog-data.ts
@@ -12,4 +12,6 @@ export interface AttributeDialogData {
   originalDate: string;
   originalPlace: string;
   originalNote: string;
+
+  deleted?: boolean;
 }

--- a/gedbrowserng-frontend/src/app/models/new-attribute-dialog-data.ts
+++ b/gedbrowserng-frontend/src/app/models/new-attribute-dialog-data.ts
@@ -4,4 +4,5 @@ import { AttributeDialogData } from './attribute-dialog-data';
 export class NewAttributeDialogData {
     options: SelectItem[];
     default: AttributeDialogData;
+    canDelete?: boolean;
 }

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
@@ -142,8 +142,10 @@ describe('PersonComponent', () => {
     component.person = mockPerson;
     component.dataset = 'ds';
     const spy = vi.spyOn(TestBed.inject(PersonService), 'put').mockReturnValue(of(mockPerson));
+    const getOneSpy = vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(of(mockPerson));
     component.save();
     expect(spy).toHaveBeenCalledWith('ds', mockPerson);
+    expect(getOneSpy).toHaveBeenCalledWith('ds', mockPerson.string);
   });
 
   it('options returns array of SelectItem', () => {

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
@@ -3,7 +3,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute, provideRouter } from '@angular/router';
 import { provideHttpClient } from '@angular/common/http';
 import { provideHttpClientTesting } from '@angular/common/http/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { vi } from 'vitest';
 
 import { PersonComponent } from './person.component';
@@ -156,13 +156,15 @@ describe('PersonComponent', () => {
   });
 
   it('save calls service.put', () => {
+    const fresh = { ...mockPerson, places: { placeName: 'Boston', location: { coordinates: [1, 2] } } } as unknown as ApiPerson;
     component.person = mockPerson;
     component.dataset = 'ds';
     const spy = vi.spyOn(TestBed.inject(PersonService), 'put').mockReturnValue(of(mockPerson));
-    const getOneSpy = vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(of(mockPerson));
+    const getOneSpy = vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(of(fresh));
     component.save();
     expect(spy).toHaveBeenCalledWith('ds', mockPerson);
     expect(getOneSpy).toHaveBeenCalledWith('ds', mockPerson.string);
+    expect(component.mapPlaces).toEqual([(fresh as any).places]);
   });
 
   it('save falls back to the put response when no person id is available', () => {
@@ -179,6 +181,35 @@ describe('PersonComponent', () => {
     expect(putSpy).toHaveBeenCalledWith('ds', personWithoutId);
     expect(getOneSpy).not.toHaveBeenCalled();
     expect(component.person).toBe(putResponse);
+  });
+
+  it('updates mapPlaces from the save response when no person id is available', () => {
+    const place = { placeName: 'Needham', location: { coordinates: [1, 2] } };
+    const personWithoutId = { attributes: [] } as ApiPerson;
+    const putResponse = { attributes: [], places: place } as unknown as ApiPerson;
+    component.person = personWithoutId;
+    component.dataset = 'ds';
+
+    vi.spyOn(TestBed.inject(PersonService), 'put').mockReturnValue(of(putResponse));
+    vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(of(mockPerson));
+
+    component.save();
+
+    expect(component.mapPlaces).toEqual([place]);
+  });
+
+  it('keeps the put response when reload fails', () => {
+    const putResponse = { ...mockPerson, places: { placeName: 'Needham', location: { coordinates: [1, 2] } } } as unknown as ApiPerson;
+    component.person = mockPerson;
+    component.dataset = 'ds';
+
+    vi.spyOn(TestBed.inject(PersonService), 'put').mockReturnValue(of(putResponse));
+    vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(throwError(() => new Error('refresh failed')));
+
+    component.save();
+
+    expect(component.person).toBe(putResponse);
+    expect(component.mapPlaces).toEqual([(putResponse as any).places]);
   });
 
   it('options returns array of SelectItem', () => {

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
@@ -148,6 +148,22 @@ describe('PersonComponent', () => {
     expect(getOneSpy).toHaveBeenCalledWith('ds', mockPerson.string);
   });
 
+  it('save falls back to the put response when no person id is available', () => {
+    const personWithoutId = { attributes: [] } as ApiPerson;
+    const putResponse = { attributes: [] } as ApiPerson;
+    component.person = personWithoutId;
+    component.dataset = 'ds';
+
+    const putSpy = vi.spyOn(TestBed.inject(PersonService), 'put').mockReturnValue(of(putResponse));
+    const getOneSpy = vi.spyOn(TestBed.inject(PersonService), 'getOne').mockReturnValue(of(mockPerson));
+
+    component.save();
+
+    expect(putSpy).toHaveBeenCalledWith('ds', personWithoutId);
+    expect(getOneSpy).not.toHaveBeenCalled();
+    expect(component.person).toBe(putResponse);
+  });
+
   it('options returns array of SelectItem', () => {
     const opts = component.options();
     expect(Array.isArray(opts)).toBe(true);
@@ -214,10 +230,63 @@ describe('PersonComponent', () => {
     expect(component.googleMapsApiKey).toBe('PLUGH');
   });
 
+  it('initializes an empty map key when the service returns no key', async () => {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: [
+        PersonComponent,
+        MockMainLayoutComponent,
+        MockAttributeListComponent,
+        MockMultimediaGalleryComponent,
+        MockPersonFamilyListComponent,
+        MockPersonParentFamiliesComponent
+      ],
+      providers: [
+        provideRouter([]),
+        provideHttpClient(),
+        provideHttpClientTesting(),
+        PersonService,
+        { provide: DatasetsService, useValue: { get: () => of(['test-db']) } },
+        { provide: SaveService, useValue: { getTextFile: (dataset: string) => of('GEDCOM content') } },
+        { provide: UploadService, useValue: { uploadGedFile: (file: File) => of({ success: true }) } },
+        { provide: UserService, useValue: { currentUser: null } },
+        { provide: AuthService, useValue: { isLoggedIn: () => false, login: () => {}, logout: () => {} } },
+        { provide: AuthApiService, useValue: { request: () => {} } },
+        { provide: ConfigService, useValue: { apiUrl: 'http://localhost' } },
+        { provide: MapKeyService, useValue: { getMapKey: () => of('') } },
+        {
+          provide: ActivatedRoute,
+          useValue: {
+            params: of({ dataset: 'testDataset' }),
+            data: of({ dataset: 'testDataset', person: mockPerson })
+          }
+        }
+      ]
+    }).compileComponents();
+
+    const fixture2 = TestBed.createComponent(PersonComponent);
+    const component2 = fixture2.componentInstance;
+    fixture2.detectChanges();
+
+    expect(component2.googleMapsApiKey).toBe('');
+  });
+
   it('normalizes a single place object into mapPlaces', () => {
     const singlePlace = { placeName: 'Needham', location: { coordinates: [-71.2377548, 42.2809285] } };
     const normalized = (component as any).normalizePlaces(singlePlace);
     expect(normalized).toEqual([singlePlace]);
+  });
+
+  it('returns the same array for an array place payload', () => {
+    const places = [
+      { placeName: 'A', location: { coordinates: [1, 2] } },
+      { placeName: 'B', southwest: [3, 4] }
+    ];
+
+    const normalized = (component as any).normalizePlaces(places);
+
+    expect(normalized).toBe(places);
   });
 
   it('normalizes object map payload and filters non-place values', () => {
@@ -232,6 +301,23 @@ describe('PersonComponent', () => {
     expect(normalized[1].placeName).toBe('B');
   });
 
+  it('returns an empty array for object payloads without place data', () => {
+    const payload = {
+      one: { nope: true },
+      two: { alsoNope: true }
+    };
+
+    const normalized = (component as any).normalizePlaces(payload);
+
+    expect(normalized).toEqual([]);
+  });
+
+  it('returns an empty array for primitive place payloads', () => {
+    const normalized = (component as any).normalizePlaces('not-a-place');
+
+    expect(normalized).toEqual([]);
+  });
+
   it('returns empty list for null place payload', () => {
     const normalized = (component as any).normalizePlaces(null);
     expect(normalized).toEqual([]);
@@ -242,5 +328,18 @@ describe('PersonComponent', () => {
     expect(component.hasMapPlaces()).toBe(false);
     component.mapPlaces = [{ placeName: 'Needham', location: [0, 0] }];
     expect(component.hasMapPlaces()).toBe(true);
+  });
+
+  it('canRenderMap requires both map places and a map key', () => {
+    component.mapPlaces = [];
+    component.googleMapsApiKey = 'PLUGH';
+    expect(component.canRenderMap()).toBe(false);
+
+    component.mapPlaces = [{ placeName: 'Needham', location: [0, 0] }];
+    component.googleMapsApiKey = '';
+    expect(component.canRenderMap()).toBe(false);
+
+    component.googleMapsApiKey = 'PLUGH';
+    expect(component.canRenderMap()).toBe(true);
   });
 });

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.spec.ts
@@ -86,40 +86,57 @@ describe('PersonComponent', () => {
     images: []
   } as ApiPerson;
 
-  beforeEach(() => {
-    TestBed.configureTestingModule({
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [
-        PersonComponent,
-        MockMainLayoutComponent,
-        MockAttributeListComponent,
-        MockMultimediaGalleryComponent,
-        MockPersonFamilyListComponent,
-        MockPersonParentFamiliesComponent
-    ],
-    providers: [
+  const mockImports = [
+    PersonComponent,
+    MockMainLayoutComponent,
+    MockAttributeListComponent,
+    MockMultimediaGalleryComponent,
+    MockPersonFamilyListComponent,
+    MockPersonParentFamiliesComponent
+  ];
+
+  function buildProviders(mapKey: string, person: any) {
+    return [
       provideRouter([]),
       provideHttpClient(),
       provideHttpClientTesting(),
       PersonService,
       { provide: DatasetsService, useValue: { get: () => of(['test-db']) } },
-      { provide: SaveService, useValue: { getTextFile: (dataset: string) => of('GEDCOM content') } },
-      { provide: UploadService, useValue: { uploadGedFile: (file: File) => of({ success: true }) } },
+      { provide: SaveService, useValue: { getTextFile: (_dataset: string) => of('GEDCOM content') } },
+      { provide: UploadService, useValue: { uploadGedFile: (_file: File) => of({ success: true }) } },
       { provide: UserService, useValue: { currentUser: null } },
       { provide: AuthService, useValue: { isLoggedIn: () => false, login: () => {}, logout: () => {} } },
       { provide: AuthApiService, useValue: { request: () => {} } },
       { provide: ConfigService, useValue: { apiUrl: 'http://localhost' } },
-      { provide: MapKeyService, useValue: { getMapKey: () => of('PLUGH') } },
+      { provide: MapKeyService, useValue: { getMapKey: () => of(mapKey) } },
       {
         provide: ActivatedRoute,
         useValue: {
           params: of({ dataset: 'testDataset' }),
-          data: of({ dataset: 'testDataset', person: mockPerson })
+          data: of({ dataset: 'testDataset', person })
         }
       }
-    ]
-})
-    .compileComponents();
+    ];
+  }
+
+  async function createFixture(mapKey: string, person: any): Promise<ComponentFixture<PersonComponent>> {
+    TestBed.resetTestingModule();
+    await TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: mockImports,
+      providers: buildProviders(mapKey, person)
+    }).compileComponents();
+    const f = TestBed.createComponent(PersonComponent);
+    f.detectChanges();
+    return f;
+  }
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      schemas: [NO_ERRORS_SCHEMA],
+      imports: mockImports,
+      providers: buildProviders('PLUGH', mockPerson)
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -177,53 +194,17 @@ describe('PersonComponent', () => {
   });
 
   it('ngOnInit falls back to empty attributes when none provided', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-    schemas: [NO_ERRORS_SCHEMA],
-    imports: [PersonComponent,
-      MockMainLayoutComponent,
-      MockAttributeListComponent,
-      MockMultimediaGalleryComponent,
-      MockPersonFamilyListComponent,
-      MockPersonParentFamiliesComponent],
-    providers: [
-      provideRouter([]),
-      provideHttpClient(),
-      provideHttpClientTesting(),
-      PersonService,
-      { provide: DatasetsService, useValue: { get: () => of(['test-db']) } },
-      { provide: SaveService, useValue: { getTextFile: (dataset: string) => of('GEDCOM content') } },
-      { provide: UploadService, useValue: { uploadGedFile: (file: File) => of({ success: true }) } },
-      { provide: UserService, useValue: { currentUser: null } },
-      { provide: AuthService, useValue: { isLoggedIn: () => false, login: () => {}, logout: () => {} } },
-      { provide: AuthApiService, useValue: { request: () => {} } },
-      { provide: ConfigService, useValue: { apiUrl: 'http://localhost' } },
-      { provide: MapKeyService, useValue: { getMapKey: () => of('PLUGH') } },
-      {
-        provide: ActivatedRoute,
-        useValue: {
-          params: of({ dataset: 'testDataset' }),
-          data: of({
-            dataset: 'testDataset',
-            person: {
-              attributes: undefined,
-              lifespan: {},
-                        refns: [{ string: '', tail: '' }],
-                        changes: [{ string: '', attributes: [{ string: '' }] }],
-                        famss: [],
-                        famcs: [],
-                        images: []
-                    }
-                })
-            }
-        }
-    ]
-}).compileComponents();
-
-    const fixture2 = TestBed.createComponent(PersonComponent);
-    const component2 = fixture2.componentInstance;
-    fixture2.detectChanges();
-    expect(component2.attributes).toEqual([]);
+    const personWithNoAttributes = {
+      attributes: undefined,
+      lifespan: {},
+      refns: [{ string: '', tail: '' }],
+      changes: [{ string: '', attributes: [{ string: '' }] }],
+      famss: [],
+      famcs: [],
+      images: []
+    };
+    const fixture2 = await createFixture('PLUGH', personWithNoAttributes);
+    expect(fixture2.componentInstance.attributes).toEqual([]);
   });
 
   it('reads map key on init', () => {
@@ -231,45 +212,8 @@ describe('PersonComponent', () => {
   });
 
   it('initializes an empty map key when the service returns no key', async () => {
-    TestBed.resetTestingModule();
-    await TestBed.configureTestingModule({
-      schemas: [NO_ERRORS_SCHEMA],
-      imports: [
-        PersonComponent,
-        MockMainLayoutComponent,
-        MockAttributeListComponent,
-        MockMultimediaGalleryComponent,
-        MockPersonFamilyListComponent,
-        MockPersonParentFamiliesComponent
-      ],
-      providers: [
-        provideRouter([]),
-        provideHttpClient(),
-        provideHttpClientTesting(),
-        PersonService,
-        { provide: DatasetsService, useValue: { get: () => of(['test-db']) } },
-        { provide: SaveService, useValue: { getTextFile: (dataset: string) => of('GEDCOM content') } },
-        { provide: UploadService, useValue: { uploadGedFile: (file: File) => of({ success: true }) } },
-        { provide: UserService, useValue: { currentUser: null } },
-        { provide: AuthService, useValue: { isLoggedIn: () => false, login: () => {}, logout: () => {} } },
-        { provide: AuthApiService, useValue: { request: () => {} } },
-        { provide: ConfigService, useValue: { apiUrl: 'http://localhost' } },
-        { provide: MapKeyService, useValue: { getMapKey: () => of('') } },
-        {
-          provide: ActivatedRoute,
-          useValue: {
-            params: of({ dataset: 'testDataset' }),
-            data: of({ dataset: 'testDataset', person: mockPerson })
-          }
-        }
-      ]
-    }).compileComponents();
-
-    const fixture2 = TestBed.createComponent(PersonComponent);
-    const component2 = fixture2.componentInstance;
-    fixture2.detectChanges();
-
-    expect(component2.googleMapsApiKey).toBe('');
+    const fixture2 = await createFixture('', mockPerson);
+    expect(fixture2.componentInstance.googleMapsApiKey).toBe('');
   });
 
   it('normalizes a single place object into mapPlaces', () => {

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.ts
@@ -264,25 +264,17 @@ export class PersonComponent implements OnInit, HasAttributeList, HasPerson, Sav
   save() {
     this.service.put(this.dataset, this.person).subscribe(
       (data: ApiPerson) => {
+        this.applyPersonState(data);
+
         const personId = data?.string || this.person?.string;
         if (!personId) {
-          this.zone.run(() => {
-            this.person = data;
-            this.person.attributes = this.person?.attributes || [];
-            this.attributes = this.person.attributes;
-            this.cdr.markForCheck();
-          });
           return;
         }
 
-        this.service.getOne(this.dataset, personId).subscribe((fresh: ApiPerson) => {
-          this.zone.run(() => {
-            this.person = fresh;
-            this.person.attributes = this.person?.attributes || [];
-            this.attributes = this.person.attributes;
-            this.cdr.markForCheck();
-          });
-        });
+        this.service.getOne(this.dataset, personId).subscribe(
+          (fresh: ApiPerson) => this.applyPersonState(fresh),
+          () => this.applyPersonState(data)
+        );
       }
     );
   }
@@ -334,5 +326,21 @@ export class PersonComponent implements OnInit, HasAttributeList, HasPerson, Sav
       || Array.isArray(place.coordinates)
       || Array.isArray(place.southwest)
       || Array.isArray(place.northeast);
+  }
+
+  private applyPersonState(person: ApiPerson): void {
+    this.zone.run(() => {
+      if (!person) {
+        this.attributes = [];
+        this.mapPlaces = [];
+        this.cdr.markForCheck();
+        return;
+      }
+      this.person = person;
+      this.person.attributes = this.person?.attributes || [];
+      this.attributes = this.person.attributes;
+      this.mapPlaces = this.normalizePlaces((this.person as any)?.places);
+      this.cdr.markForCheck();
+    });
   }
 }

--- a/gedbrowserng-frontend/src/app/modules/person/person.component.ts
+++ b/gedbrowserng-frontend/src/app/modules/person/person.component.ts
@@ -264,7 +264,25 @@ export class PersonComponent implements OnInit, HasAttributeList, HasPerson, Sav
   save() {
     this.service.put(this.dataset, this.person).subscribe(
       (data: ApiPerson) => {
-        this.person = data;
+        const personId = data?.string || this.person?.string;
+        if (!personId) {
+          this.zone.run(() => {
+            this.person = data;
+            this.person.attributes = this.person?.attributes || [];
+            this.attributes = this.person.attributes;
+            this.cdr.markForCheck();
+          });
+          return;
+        }
+
+        this.service.getOne(this.dataset, personId).subscribe((fresh: ApiPerson) => {
+          this.zone.run(() => {
+            this.person = fresh;
+            this.person.attributes = this.person?.attributes || [];
+            this.attributes = this.person.attributes;
+            this.cdr.markForCheck();
+          });
+        });
       }
     );
   }


### PR DESCRIPTION
## Summary
- move attribute delete action from attribute row into the attribute editor dialog
- keep delete confirmation dialog behavior
- close both confirmation and editor dialogs on successful delete
- ensure person page state refreshes after save by reloading the person record
- remove deleted attribute from the rendered list immediately

## Additional Changes
- merged latest `development` into this branch

## Validation
- `npx vitest run src/app/components/attribute-list/attribute-list-item.component.spec.ts src/app/components/attribute-dialog/new-attribute-dialog.component.spec.ts src/app/modules/person/person.component.spec.ts`
- all targeted tests pass